### PR TITLE
Add NonemptyList

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -20,6 +20,7 @@ import Std.Data.Int.Lemmas
 import Std.Data.List.Basic
 import Std.Data.List.Init.Lemmas
 import Std.Data.List.Lemmas
+import Std.Data.List.NonemptyList
 import Std.Data.Nat.Basic
 import Std.Data.Nat.Gcd
 import Std.Data.Nat.Lemmas

--- a/Std/Data/List/NonemptyList.lean
+++ b/Std/Data/List/NonemptyList.lean
@@ -20,8 +20,8 @@ structure NonemptyList (α : Type u) where
 namespace NonemptyList
 
 /-- Convert from a standard `List α`. Requires a proof that the list is nonempty,
-which we attempt to close by `trivial`. -/
-def ofList (L : List α) (h : L ≠ [] := by trivial) : NonemptyList α :=
+which we attempt to close by `simp`. -/
+def ofList (L : List α) (h : L ≠ [] := by simp) : NonemptyList α :=
   match L, h with
   | [],     _ => by contradiction
   | x::xs,  _ => ⟨x,xs⟩

--- a/Std/Data/List/NonemptyList.lean
+++ b/Std/Data/List/NonemptyList.lean
@@ -41,15 +41,20 @@ instance [ToString α] : ToString (NonemptyList α) := ⟨(toString ·.toList)�
 
 end NonemptyList
 
+/-- Convert list to a nonempty list, or none if empty -/
 def List.nonempty? : List α → Option (NonemptyList α)
 | [] => none
 | hd::tl => some ⟨hd,tl⟩
 
+/-- Convert list to a nonempty list, or panic if empty -/
 def List.nonempty! [Inhabited α] : List α → NonemptyList α
 | [] => panic! "nonempty! called on empty list D:"
 | hd::tl => ⟨hd,tl⟩
 
 namespace NonemptyList
 
+/-- Monomorphic reduce on nonempty list.
+Elements are combined in left-to-right order (with accumulator as first argument to `f`).
+-/
 def reduce (f : α → α → α) : NonemptyList α → α
 | ⟨hd,tl⟩ => tl.foldl f hd

--- a/Std/Data/List/NonemptyList.lean
+++ b/Std/Data/List/NonemptyList.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2019 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: James Gallicchio
+-/
+import Std.Data.List.Basic
+
+namespace Std
+
+/--
+`NonemptyList α` is isomorphic to a list with at least one element.
+-/
+structure NonemptyList (α : Type u) where
+  /-- The head of the (non-empty) list. -/
+  hd : α
+  /-- The tail of the (non-empty) list. -/
+  tl : List α
+  deriving Inhabited
+
+namespace NonemptyList
+
+/-- Convert from a standard `List α`. Requires a proof that the list is nonempty,
+which we attempt to close by `trivial`. -/
+def ofList (L : List α) (h : L ≠ [] := by trivial) : NonemptyList α :=
+  match L, h with
+  | [],     _ => by contradiction
+  | x::xs,  _ => ⟨x,xs⟩
+
+-- TODO: is there a way to apply `ofList` as a coercion?
+
+/-- Convert to a standard `List α`. -/
+def toList : NonemptyList α → List α
+| ⟨hd,tl⟩ => hd::tl
+
+instance : CoeHead (NonemptyList α) (List α) where
+  coe ne := ne.toList
+
+instance [Repr α] : Repr (NonemptyList α) := ⟨(reprPrec ·.toList)⟩
+
+instance [ToString α] : ToString (NonemptyList α) := ⟨(toString ·.toList)⟩

--- a/Std/Data/List/NonemptyList.lean
+++ b/Std/Data/List/NonemptyList.lean
@@ -38,3 +38,18 @@ instance : CoeHead (NonemptyList α) (List α) where
 instance [Repr α] : Repr (NonemptyList α) := ⟨(reprPrec ·.toList)⟩
 
 instance [ToString α] : ToString (NonemptyList α) := ⟨(toString ·.toList)⟩
+
+end NonemptyList
+
+def List.nonempty? : List α → Option (NonemptyList α)
+| [] => none
+| hd::tl => some ⟨hd,tl⟩
+
+def List.nonempty! [Inhabited α] : List α → NonemptyList α
+| [] => panic! "nonempty! called on empty list D:"
+| hd::tl => ⟨hd,tl⟩
+
+namespace NonemptyList
+
+def reduce (f : α → α → α) : NonemptyList α → α
+| ⟨hd,tl⟩ => tl.foldl f hd


### PR DESCRIPTION
Sort of a stub at the moment, but a useful type to have rather than inlining the head/tail at use site.

I suspect we'd want to replicate many (most?) functions on `List` to have equivalents here, but my current use case just pattern matches the head/tail out so I don't know yet what functions will be useful.