### PR TITLE
feat: Option.eq_some_of_isSome

### DIFF
--- a/Std/Data/Option/Basic.lean
+++ b/Std/Data/Option/Basic.lean
@@ -45,6 +45,10 @@ instance {p : α → Prop} [DecidablePred p] : ∀ o : Option α, Decidable (∃
 def get {α : Type u} : (o : Option α) → isSome o → α
   | some x, _ => x
 
+theorem eq_some_of_isSome {α : Type u} :
+    ∀ {o : Option α} (h : Option.isSome o), o = some (Option.get _ h)
+  | some _, _ => rfl
+
 /-- `guard p a` returns `some a` if `p a` holds, otherwise `none`. -/
 def guard (p : α → Prop) [DecidablePred p] (a : α) : Option α := if p a then some a else none
 


### PR DESCRIPTION
This is used in mathlib3, and if we don't put it in std it will be orphaned in its own file in mathlib4, since if came from `init/data/option/instances.lean`