### PR TITLE
chore: bump to nightly-2022-11-17

### DIFF
--- a/Std/Data/Array/Init/Lemmas.lean
+++ b/Std/Data/Array/Init/Lemmas.lean
@@ -23,6 +23,8 @@ attribute [simp] data_toArray uset
 
 @[simp] theorem size_toArray (as : List α) : as.toArray.size = as.length := by simp [size]
 
+@[simp] theorem size_mk (as : List α) : (Array.mk as).size = as.length := by simp [size]
+
 theorem getElem_eq_data_get (a : Array α) (h : i < a.size) : a[i] = a.data.get ⟨i, h⟩ := by
   by_cases i < a.size <;> simp [*] <;> rfl
 

--- a/Std/Data/BinomialHeap.lean
+++ b/Std/Data/BinomialHeap.lean
@@ -243,7 +243,8 @@ theorem Heap.realSize_deleteMin {s : Heap α} (eq : s.deleteMin le = some (a, s'
   | { before, val, node, next } =>
     intro ⟨m, ih₁, ih₂⟩
     rw [realSize, Nat.add_right_comm, ih₂]
-    simp only [realSize_merge, HeapNode.realSize_toHeap, ih₁, Nat.add_assoc, Nat.add_left_comm]
+    simp at ih₁
+    simp [realSize_merge, HeapNode.realSize_toHeap, ih₁, Nat.add_assoc, Nat.add_left_comm]
 
 theorem Heap.realSize_tail? {s : Heap α} : s.tail? le = some s' →
     s.realSize = s'.realSize + 1 := by

--- a/Std/Data/BinomialHeap.lean
+++ b/Std/Data/BinomialHeap.lean
@@ -241,10 +241,9 @@ theorem Heap.realSize_deleteMin {s : Heap α} (eq : s.deleteMin le = some (a, s'
   revert this
   match s.findMin le (cons r a c) ⟨id, a, c, s⟩ with
   | { before, val, node, next } =>
-    intro ⟨m, ih₁, ih₂⟩
+    intro ⟨m, ih₁, ih₂⟩; dsimp only at ih₁ ih₂
     rw [realSize, Nat.add_right_comm, ih₂]
-    simp at ih₁
-    simp [realSize_merge, HeapNode.realSize_toHeap, ih₁, Nat.add_assoc, Nat.add_left_comm]
+    simp only [realSize_merge, HeapNode.realSize_toHeap, ih₁, Nat.add_assoc, Nat.add_left_comm]
 
 theorem Heap.realSize_tail? {s : Heap α} : s.tail? le = some s' →
     s.realSize = s'.realSize + 1 := by

--- a/Std/Tactic/Ext/Attr.lean
+++ b/Std/Tactic/Ext/Attr.lean
@@ -13,7 +13,8 @@ open Lean Meta
 syntax "declare_ext_theorems_for" ident : command
 
 /-- The environment extension to track `@[ext]` lemmas. -/
-initialize extExtension : SimpleScopedEnvExtension (Name × Array DiscrTree.Key) (DiscrTree Name) ←
+initialize extExtension :
+    SimpleScopedEnvExtension (Name × Array (DiscrTree.Key true)) (DiscrTree Name true) ←
   registerSimpleScopedEnvExtension {
     addEntry := fun dt (n, ks) => dt.insertCore ks n
     initial := {}

--- a/Std/Tactic/Lint/Simp.lean
+++ b/Std/Tactic/Lint/Simp.lean
@@ -76,7 +76,7 @@ def isSimpTheorem (declName : Name) : MetaM Bool := do
 
 open Lean.Meta.DiscrTree in
 /-- Returns the list of elements in the discrimination tree. -/
-partial def _root_.Lean.Meta.DiscrTree.elements (d : DiscrTree α) : Array α :=
+partial def _root_.Lean.Meta.DiscrTree.elements (d : DiscrTree α s) : Array α :=
   d.root.foldl (init := #[]) fun arr _ => trieElements arr
 where
   /-- Returns the list of elements in the trie. -/

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-11-14
+leanprover/lean4:nightly-2022-11-17


### PR DESCRIPTION
I'd like to get up to nightly-2022-11-17, as it has some fixes we need in mathlib4.

There's a broken proof here in HashMap/WF.lean, at `WF.filterMap`.