### PR TITLE
chore: ext should fail if no progress

### DIFF
--- a/Std/Tactic/Ext.lean
+++ b/Std/Tactic/Ext.lean
@@ -165,7 +165,7 @@ elab_rules : tactic
   | `(tactic| ext $pats* $[: $n]?) => do
     let pats := RCases.expandRIntroPats pats
     let depth := n.map (·.getNat) |>.getD 1000000
-    let gs ← extCore (← getMainGoal) pats.toList depth !pats.isEmpty
+    let gs ← extCore (← getMainGoal) pats.toList depth
     replaceMainGoal <| gs.map (·.1) |>.toList
 
 /--

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -6,6 +6,11 @@ set_option linter.missingDocs false
 structure A (n : Nat) where
   a : Nat
 
+example (a b : A n) : a = b ∨ True := by
+  fail_if_success
+    apply Or.inl; ext
+  exact Or.inr trivial
+
 structure B (n) extends A n where
   b : Nat
   h : b > 0


### PR DESCRIPTION
This matches Lean 3 behaviour, and seems both more helpful to end users and to tactics that use `ext`.