### PR TITLE
Prove correctness of `HashMap.findEntry?/insert/erase`

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -19,6 +19,7 @@ import Std.Data.DList
 import Std.Data.Fin.Lemmas
 import Std.Data.HashMap
 import Std.Data.HashMap.Basic
+import Std.Data.HashMap.Lemmas
 import Std.Data.HashMap.WF
 import Std.Data.Int.Basic
 import Std.Data.Int.DivMod

--- a/Std.lean
+++ b/Std.lean
@@ -26,6 +26,7 @@ import Std.Data.Int.Lemmas
 import Std.Data.List.Basic
 import Std.Data.List.Init.Lemmas
 import Std.Data.List.Lemmas
+import Std.Data.List.Perm
 import Std.Data.Nat.Basic
 import Std.Data.Nat.Gcd
 import Std.Data.Nat.Lemmas

--- a/Std/Classes/BEq.lean
+++ b/Std/Classes/BEq.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Std.Logic
 
 /-! ## Boolean equality -/
 
@@ -16,6 +17,10 @@ class PartialEquivBEq (α) [BEq α] : Prop where
   symm : (a : α) == b → b == a
   /-- Transitivity for `BEq`. If `a == b` and `b == c` then `a == c`. -/
   trans : (a : α) == b → b == c → a == c
+
+theorem bne_symm [BEq α] [PartialEquivBEq α] (a b : α) : a != b → b != a :=
+  fun h => Bool.not_eq_true_iff_ne_true.mpr fun h' =>
+    Bool.not_bne_of_beq (PartialEquivBEq.symm h') h
 
 @[simp] theorem beq_eq_false_iff_ne [BEq α] [LawfulBEq α]
     (a b : α) : (a == b) = false ↔ a ≠ b := by

--- a/Std/Classes/BEq.lean
+++ b/Std/Classes/BEq.lean
@@ -18,9 +18,9 @@ class PartialEquivBEq (α) [BEq α] : Prop where
   /-- Transitivity for `BEq`. If `a == b` and `b == c` then `a == c`. -/
   trans : (a : α) == b → b == c → a == c
 
-theorem bne_symm [BEq α] [PartialEquivBEq α] (a b : α) : a != b → b != a :=
+theorem bne_symm [BEq α] [PartialEquivBEq α] {a b : α} : a != b → b != a :=
   fun h => Bool.not_eq_true_iff_ne_true.mpr fun h' =>
-    Bool.not_bne_of_beq (PartialEquivBEq.symm h') h
+    Bool.bne_iff_not_beq.mp h (PartialEquivBEq.symm h')
 
 @[simp] theorem beq_eq_false_iff_ne [BEq α] [LawfulBEq α]
     (a b : α) : (a == b) = false ↔ a ≠ b := by

--- a/Std/Data/Array/Lemmas.lean
+++ b/Std/Data/Array/Lemmas.lean
@@ -53,6 +53,9 @@ theorem get?_len_le (a : Array α) (i : Nat) (h : a.size ≤ i) : a[i]? = none :
 theorem getElem_mem_data (a : Array α) (h : i < a.size) : a[i] ∈ a.data := by
   simp [getElem_eq_data_get, List.get_mem]
 
+theorem get_of_mem_data {as : Array α} {a : α} : a ∈ as.data → ∃ (i : Fin as.size), as[i] = a :=
+  List.get_of_mem
+
 theorem getElem?_eq_data_get? (a : Array α) (i : Nat) : a[i]? = a.data.get? i := by
   by_cases i < a.size <;> simp_all [getElem?_pos, getElem?_neg, List.get?_eq_get, eq_comm]; rfl
 

--- a/Std/Data/HashMap/Basic.lean
+++ b/Std/Data/HashMap/Basic.lean
@@ -86,10 +86,7 @@ def empty (capacity := 8) : Imp α β :=
   empty' nBuckets (Nat.isPowerOfTwo_nextPowerOfTwo _)
 
 /-- Calculates the bucket index from a `hash` value. -/
-/- Remark: we use a C implementation because this function is performance critical. -/
-@[extern c inline "(size_t)(#2) & (lean_unbox(#1) - 1)"]
 def mkIdx {sz : Nat} (hash : UInt64) (h : sz.isPowerOfTwo) : {u : USize // u.toNat < sz} :=
-  -- TODO(WN): Use the (provably equivalent) bitwise `&&&` in the spec as well like libLean does
   ⟨hash.toUSize % sz, USize.modn_lt _ (Nat.pos_of_isPowerOfTwo h)⟩
 
 /--

--- a/Std/Data/HashMap/Basic.lean
+++ b/Std/Data/HashMap/Basic.lean
@@ -88,9 +88,9 @@ def empty (capacity := 0) : Imp α β :=
     else ⟨nbuckets, Nat.zero_lt_of_ne_zero h⟩
   empty' n n.2
 
-/-- Calculates the bucket index from a hash value `u`. -/
-def mkIdx {n : Nat} (h : 0 < n) (u : USize) : {u : USize // u.toNat < n} :=
-  ⟨u % n, USize.modn_lt _ h⟩
+/-- Calculates the bucket index for the key `a`. -/
+def mkIdx [Hashable α] {n : Nat} (h : 0 < n) (a : α) : {u : USize // u.toNat < n} :=
+  ⟨(hash a |>.toUSize) % n, USize.modn_lt _ h⟩
 
 /--
 Inserts a key-value pair into the bucket array. This function assumes that the data is not
@@ -98,7 +98,7 @@ already in the array, which is appropriate when reinserting elements into the ar
 -/
 @[inline] def reinsertAux [Hashable α]
     (data : Bucket α β) (a : α) (b : β) : Bucket α β :=
-  let ⟨i, h⟩ := mkIdx data.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx data.2 a
   data.update i (.cons a b data.1[i]) h
 
 /-- Folds a monadic function over the elements in the map (in arbitrary order). -/
@@ -116,19 +116,19 @@ already in the array, which is appropriate when reinserting elements into the ar
 /-- Given a key `a`, returns a key-value pair in the map whose key compares equal to `a`. -/
 def findEntry? [BEq α] [Hashable α] (m : Imp α β) (a : α) : Option (α × β) :=
   let ⟨_, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx buckets.2 a
   buckets.1[i].findEntry? a
 
 /-- Looks up an element in the map with key `a`. -/
 def find? [BEq α] [Hashable α] (m : Imp α β) (a : α) : Option β :=
   let ⟨_, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx buckets.2 a
   buckets.1[i].find? a
 
 /-- Returns true if the element `a` is in the map. -/
 def contains [BEq α] [Hashable α] (m : Imp α β) (a : α) : Bool :=
   let ⟨_, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx buckets.2 a
   buckets.1[i].contains a
 
 /-- Copies all the entries from `buckets` into a new hash map with a larger capacity. -/
@@ -156,7 +156,7 @@ If an element equal to `a` is already in the map, it is replaced by `b`.
 -/
 @[inline] def insert [BEq α] [Hashable α] (m : Imp α β) (a : α) (b : β) : Imp α β :=
   let ⟨size, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx buckets.2 a
   let bkt := buckets.1[i]
   bif bkt.contains a then
     ⟨size, buckets.update i (bkt.replace a b) h⟩
@@ -173,7 +173,7 @@ Removes key `a` from the map. If it does not exist in the map, the map is return
 -/
 def erase [BEq α] [Hashable α] (m : Imp α β) (a : α) : Imp α β :=
   let ⟨size, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx buckets.2 a
   let bkt := buckets.1[i]
   bif bkt.contains a then ⟨size - 1, buckets.update i (bkt.erase a) h⟩ else m
 

--- a/Std/Data/HashMap/Basic.lean
+++ b/Std/Data/HashMap/Basic.lean
@@ -106,8 +106,8 @@ already in the array, which is appropriate when reinserting elements into the ar
   map.buckets.1.foldlM (init := d) fun d b => b.foldlM f d
 
 /-- Folds a function over the elements in the map (in arbitrary order). -/
-@[inline] def fold (f : δ → α → β → δ) (d : δ) (m : Imp α β) : δ :=
-  Id.run $ foldM f d m
+@[inline] def fold (f : δ → α → β → δ) (d : δ) (map : Imp α β) : δ :=
+  map.buckets.1.foldl (init := d) fun d b => b.foldl f d
 
 /-- Runs a monadic function over the elements in the map (in arbitrary order). -/
 @[inline] def forM [Monad m] (f : α → β → m PUnit) (h : Imp α β) : m PUnit :=

--- a/Std/Data/HashMap/Basic.lean
+++ b/Std/Data/HashMap/Basic.lean
@@ -148,7 +148,7 @@ where
       let target := es.foldl reinsertAux target
       go (i+1) source target
     else target
-  termination_by go i source _ => source.size - i
+termination_by go i source _ => source.size - i
 
 /--
 Inserts key-value pair `a, b` into the map.

--- a/Std/Data/HashMap/Basic.lean
+++ b/Std/Data/HashMap/Basic.lean
@@ -148,7 +148,7 @@ where
       let target := es.foldl reinsertAux target
       go (i+1) source target
     else target
-termination_by _ i source _ => source.size - i
+  termination_by go i source _ => source.size - i
 
 /--
 Inserts key-value pair `a, b` into the map.

--- a/Std/Data/HashMap/Lemmas.lean
+++ b/Std/Data/HashMap/Lemmas.lean
@@ -1,0 +1,85 @@
+import Std.Data.HashMap.Basic
+import Std.Data.HashMap.WF
+import Std.Data.List.Lemmas
+import Std.Data.List.Perm
+import Std.Data.Array.Lemmas
+
+namespace Std.HashMap
+
+variable [BEq α] [Hashable α]
+
+theorem toList_insert (m : HashMap α β) (a b)
+    : (m.insert a b).toList ~ (a, b) :: m.toList.eraseP (·.1 == a) :=
+  sorry
+
+theorem toList_erase (m : HashMap α β) (a)
+    : (m.erase a).toList ~ m.toList.eraseP (·.1 == a) :=
+  sorry
+
+theorem find?_of_toList_contains (m : HashMap α β) (a : α) (b : β)
+    : (∃ a', a == a' ∧ (a', b) ∈ m.toList) ↔ m.find? a = some b :=
+  sorry
+
+theorem find?_of_toList_not_contains (m : HashMap α β) (a : α)
+    : (∀ a' (b : β), a == a' → (a', b) ∉ m.toList) ↔ m.find? a = none := by
+  apply Iff.intro
+  . intro h
+
+  . intro h
+    sorry
+
+theorem find?_insert (m : HashMap α β) (a a' b)
+    : a' == a → (m.insert a b).find? a' = some b := by
+  intro hEq
+  apply (find?_of_toList_contains _ _ _).mp
+  refine ⟨a, hEq, ?_⟩
+  rw [List.Perm.mem_iff (toList_insert m a b)]
+  apply List.mem_cons_self
+
+theorem find?_insert_of_ne [PartialEquivBEq α] (m : HashMap α β) (a a' b)
+    : a != a' → (m.insert a b).find? a' = m.find? a' := by
+  intro hNe
+  suffices ∀ b', (m.insert a b).find? a' = some b' ↔ m.find? a' = some b' by
+    cases h : (m.insert a b).find? a' with
+    | none =>
+      apply Eq.symm
+      apply Option.not_isSome_iff_eq_none.mp
+      intro hSome
+      let ⟨b₂, hB₂⟩ := Option.isSome_iff_exists.mp hSome
+      rw [← this] at hB₂
+      cases h.symm.trans hB₂
+    | some b' => exact (this b').mp h |>.symm
+  intro b'
+  rw [← find?_of_toList_contains, ← find?_of_toList_contains]
+  simp only [List.Perm.mem_iff (toList_insert m a b), List.mem_cons]
+  apply Iff.intro
+  . intro ⟨a₂, hA₂Eq, hA₂⟩
+    refine ⟨a₂, hA₂Eq, ?_⟩
+    cases hA₂ with
+    | inl h =>
+      cases h
+      have := Bool.not_bne_of_beq (PartialEquivBEq.symm hA₂Eq)
+      contradiction
+    | inr h => exact List.mem_of_mem_eraseP h
+  . intro ⟨a₂, hA₂Eq, hA₂⟩
+    refine ⟨a₂, hA₂Eq, ?_⟩
+    apply Or.inr
+    refine (List.mem_eraseP_of_neg ?_).mpr hA₂
+    dsimp
+    intro h
+    apply Bool.not_bne_of_beq (PartialEquivBEq.trans hA₂Eq h |> PartialEquivBEq.symm) hNe
+
+theorem find?_erase [PartialEquivBEq α] (m : HashMap α β) (a a')
+    : a == a' → (m.erase a).find? a' = none := by
+  intro hEq
+  apply (find?_of_toList_not_contains _ _).mp
+  intro a₂ b hA₂ hMem
+  rw [List.Perm.mem_iff (toList_erase m a)] at hMem
+  sorry
+  -- TODO: this is false; do we need to rely on elements in the map never repeating?
+  --  theorem not_of_mem_eraseP {l : List α} : a ∈ l.eraseP p → ¬p a := sorry
+  -- apply not_of_mem_eraseP hMem
+  -- have : a₂ == a := PartialEquivBEq.symm (PartialEquivBEq.trans hEq hA₂)
+  -- exact this
+
+end Std.HashMap

--- a/Std/Data/HashMap/Lemmas.lean
+++ b/Std/Data/HashMap/Lemmas.lean
@@ -20,13 +20,108 @@ theorem List.eraseP_eq_filter_of_unique (l : List α) (p : α → Bool)
       simp [eraseP, filter, hP, filter_eq_self.mpr this]
     | false => simp [eraseP_cons, filter, hP, ih]
 
-namespace Std.HashMap
-
-variable [BEq α] [Hashable α] [PartialEquivBEq α]
-
-/-- The map does not store duplicate keys. -/
-theorem Pairwise_bne_toList (m : HashMap α β) : m.toList.Pairwise (·.1 != ·.1) :=
+@[simp]
+theorem Array.foldl_zero {as : Array α} {init : β} {f : β → α → β}
+    : as.foldl f init (stop := 0) = init := by
   sorry
+
+@[simp]
+theorem Array.foldl_succ {as : Array α} {init : β} {f : β → α → β} (i : Fin as.size)
+    : as.foldl f init (stop := i + 1) = f (as.foldl f init (stop := i)) as[i] := by
+  sorry
+
+theorem Array.foldlM_zero [Monad m] [LawfulMonad m]
+    {as : Array α} {init : β} {f : β → α → m β} {start : Nat}
+    : as.foldlM f init start 0 = pure init := by
+  unfold foldlM foldlM.loop
+  simp [Nat.not_lt_zero]
+
+theorem Array.foldlM_succ [Monad m] [LawfulMonad m]
+    {as : Array α} {init : β} {f : β → α → m β} {start : Nat} (i : Fin as.size) : start ≤ i.val
+    → (as.foldlM f init start (i.val + 1)) = as.foldlM f init start i >>= (f · as[i]) := by
+  intro hStartLe
+  have hISuccLe : i.val + 1 ≤ as.size := Nat.succ_le_of_lt i.isLt
+  have hILe : i.val ≤ as.size := Nat.le_of_lt i.isLt
+  simp only [foldlM, hISuccLe, hILe, dite_true]
+  conv => lhs; unfold foldlM.loop
+  simp only [Nat.lt_succ_of_le hStartLe, dite_true]
+  split
+  case h_1 h =>
+    exfalso
+    exact Nat.le_trans (Nat.sub_eq_zero_iff_le.mp h) hStartLe
+      |> Nat.lt_of_succ_le
+      |> Nat.not_lt_of_le (Nat.le_refl _)
+  case h_2 h =>
+    -- This is kinda tricky, since foldlM recurses on start rather than stop. Rethink..
+    sorry
+
+namespace Std.HashMap
+open List
+
+variable [BEq α] [Hashable α] [LawfulHashable α] [PartialEquivBEq α]
+
+/-- It is a bit easier to reason about `fold (append)` than `fold (fold)`,
+so we transfer most proofs about `toList` from this auxiliary function. -/
+def toList' (m : HashMap α β) : List (α × β) :=
+  m.val.buckets.val.foldl (init := []) (fun acc bkt => acc ++ bkt.toList)
+
+-- TODO: naming
+theorem foldl_induction₂ {as : Array α} (motive : Nat → β → β → Prop) {init₁ init₂ : β}
+    (h0 : motive 0 init₁ init₂) {f g : β → α → β}
+    (hf : ∀ i : Fin as.size, ∀ acc₁ acc₂,
+      motive i.1 acc₁ acc₂ → motive (i.1 + 1) (f acc₁ as[i]) (g acc₂ as[i]))
+    : motive as.size (as.foldl f init₁) (as.foldl g init₂) := by
+  apply Array.foldl_induction
+    (motive := fun i (acc : β) => motive i acc (as.foldl g init₂ (stop := i)))
+    (h0 := Array.foldl_zero ▸ h0)
+    (hf := fun _ _ hPrev => by rw [Array.foldl_succ]; exact hf _ _ _ hPrev)
+
+theorem toList_perm_toList' (m : HashMap α β) : m.toList' ~ m.toList := by
+  unfold toList toList' HashMap.fold HashMap.Imp.fold
+  apply foldl_induction₂ (fun _ l₁ l₂ => l₁ ~ l₂) (h0 := List.Perm.nil)
+  intro acc₁ acc₂ l hAcc
+  sorry
+
+/-- The map does not store duplicate (`beq`) keys. -/
+theorem Pairwise_bne_toList (m : HashMap α β) : m.toList.Pairwise (·.1 != ·.1) := by
+  apply List.Perm.pairwise_iff (bne_symm _ _) (toList_perm_toList' m) |>.mp
+  unfold toList'
+  refine Array.foldl_induction
+    (motive := fun i (acc : List (α × β)) =>
+      -- The acc has the desired property
+      acc.Pairwise (·.1 != ·.1)
+      -- All not-yet-accumulated buckets are pairwise disjoint with the acc
+      ∧ ∀ j, i ≤ j → (_ : j < m.val.buckets.val.size) →
+        ∀ p ∈ acc, ∀ r ∈ m.val.buckets.val[j].toList, p.1 != r.1)
+    ?h0 ?hf |>.left
+  case h0 => exact ⟨List.Pairwise.nil, fun.⟩
+  case hf =>
+    have hWF := Imp.WF_iff.mp m.property |>.right
+    intro i acc h
+    refine ⟨List.pairwise_append.mpr ⟨h.left, ?bkt, ?accbkt⟩, ?accbkts⟩
+    case bkt =>
+      -- Main proof 1: the contents of any given bucket are pairwise bne
+      have := hWF.distinct m.val.buckets.val[i] (Array.getElem_mem_data _ _)
+      exact List.Pairwise.imp Bool.not_eq_true_iff_ne_true.mpr this
+    case accbkt =>
+      intro a hA b hB
+      exact h.right i.val (Nat.le_refl _) i.isLt a hA b hB
+    case accbkts =>
+      intro j hGe hLt p hP r hR
+      cases List.mem_append.mp hP
+      case inl hP => exact h.right j (Nat.le_of_succ_le hGe) hLt p hP r hR
+      case inr hP =>
+        -- Main proof 2: distinct buckets store bne keys
+        refine Bool.not_eq_true_iff_ne_true.mpr fun h => ?_
+        have hHashEq := LawfulHashable.hash_eq h
+        have hGt := Nat.lt_of_succ_le hGe
+        have hHashP := hWF.hash_self i (Nat.lt_trans hGt hLt) _ hP
+        have hHashR := hWF.hash_self j hLt _ hR
+        dsimp at hHashP hHashR
+        have : i.val = j := by
+          rw [hHashEq] at hHashP
+          exact .trans hHashP.symm hHashR
+        exact Nat.ne_of_lt hGt this
 
 theorem toList_eraseP_eq_toList_filter (m : HashMap α β)
     : m.toList.eraseP (·.1 == a) = m.toList.filter (·.1 != a) := by

--- a/Std/Data/HashMap/Lemmas.lean
+++ b/Std/Data/HashMap/Lemmas.lean
@@ -4,17 +4,54 @@ import Std.Data.List.Lemmas
 import Std.Data.List.Perm
 import Std.Data.Array.Lemmas
 
+/-- If there is at most one element with the property `p`, erasing one such element
+is the same as filtering out all of them. -/
+theorem List.eraseP_eq_filter_of_unique (l : List α) (p : α → Bool)
+    : l.Pairwise (p · → !p ·) → l.eraseP p = l.filter (!p ·) := by
+  intro h
+  induction l with
+  | nil => rfl
+  | cons x xs ih =>
+    specialize ih (Pairwise.sublist (sublist_cons x xs) h)
+    cases hP : p x with
+    | true =>
+      rw [Pairwise_cons] at h
+      have : ∀ a ∈ xs, !p a := fun a hA => h.left a hA hP
+      simp [eraseP, filter, hP, filter_eq_self.mpr this]
+    | false => simp [eraseP_cons, filter, hP, ih]
+
 namespace Std.HashMap
 
-variable [BEq α] [Hashable α]
+variable [BEq α] [Hashable α] [PartialEquivBEq α]
 
-theorem toList_insert (m : HashMap α β) (a b)
+/-- The map does not store duplicate keys. -/
+theorem Pairwise_bne_toList (m : HashMap α β) : m.toList.Pairwise (·.1 != ·.1) :=
+  sorry
+
+theorem toList_eraseP_eq_toList_filter (m : HashMap α β)
+    : m.toList.eraseP (·.1 == a) = m.toList.filter (·.1 != a) := by
+  apply List.eraseP_eq_filter_of_unique
+  apply List.Pairwise.imp ?_ (Pairwise_bne_toList _)
+  intro (a₁, _) (a₂, _) hA₁Bne hA₁Beq
+  rw [Bool.not_eq_true_iff_ne_true]
+  intro hA₂Beq
+  exact Bool.not_bne_of_beq (PartialEquivBEq.trans hA₁Beq (PartialEquivBEq.symm hA₂Beq)) hA₁Bne
+
+theorem toList_insert_perm_cons_eraseP (m : HashMap α β) (a : α) (b : β)
     : (m.insert a b).toList ~ (a, b) :: m.toList.eraseP (·.1 == a) :=
   sorry
 
-theorem toList_erase (m : HashMap α β) (a)
+theorem toList_insert (m : HashMap α β) (a : α) (b : β)
+    : (m.insert a b).toList ~ (a, b) :: m.toList.filter (·.1 != a) :=
+  toList_eraseP_eq_toList_filter m ▸ toList_insert_perm_cons_eraseP m a b
+
+theorem toList_erase_perm_eraseP (m : HashMap α β) (a : α)
     : (m.erase a).toList ~ m.toList.eraseP (·.1 == a) :=
   sorry
+
+theorem toList_erase (m : HashMap α β) (a : α)
+    : (m.erase a).toList ~ m.toList.filter (·.1 != a) :=
+  toList_eraseP_eq_toList_filter m ▸ toList_erase_perm_eraseP m a
 
 theorem find?_of_toList_contains (m : HashMap α β) (a : α) (b : β)
     : (∃ a', a == a' ∧ (a', b) ∈ m.toList) ↔ m.find? a = some b :=
@@ -23,10 +60,14 @@ theorem find?_of_toList_contains (m : HashMap α β) (a : α) (b : β)
 theorem find?_of_toList_not_contains (m : HashMap α β) (a : α)
     : (∀ a' (b : β), a == a' → (a', b) ∉ m.toList) ↔ m.find? a = none := by
   apply Iff.intro
-  . intro h
-
-  . intro h
-    sorry
+  . rw [← Option.not_isSome_iff_eq_none]
+    intro h hSome
+    let ⟨b, hB⟩ := Option.isSome_iff_exists.mp hSome
+    let ⟨a', hA, hMem⟩ := find?_of_toList_contains m a b |>.mpr hB
+    exact h a' b hA hMem
+  . intro h a' b hA hMem
+    refine Option.ne_none_iff_exists.mpr ?_ h
+    exact ⟨b, find?_of_toList_contains m a b |>.mp ⟨a', hA, hMem⟩ |>.symm⟩
 
 theorem find?_insert (m : HashMap α β) (a a' b)
     : a' == a → (m.insert a b).find? a' = some b := by
@@ -36,50 +77,35 @@ theorem find?_insert (m : HashMap α β) (a a' b)
   rw [List.Perm.mem_iff (toList_insert m a b)]
   apply List.mem_cons_self
 
-theorem find?_insert_of_ne [PartialEquivBEq α] (m : HashMap α β) (a a' b)
+theorem find?_insert_of_ne (m : HashMap α β) (a a' : α) (b : β)
     : a != a' → (m.insert a b).find? a' = m.find? a' := by
   intro hNe
-  suffices ∀ b', (m.insert a b).find? a' = some b' ↔ m.find? a' = some b' by
-    cases h : (m.insert a b).find? a' with
-    | none =>
-      apply Eq.symm
-      apply Option.not_isSome_iff_eq_none.mp
-      intro hSome
-      let ⟨b₂, hB₂⟩ := Option.isSome_iff_exists.mp hSome
-      rw [← this] at hB₂
-      cases h.symm.trans hB₂
-    | some b' => exact (this b').mp h |>.symm
+  apply Option.ext
   intro b'
-  rw [← find?_of_toList_contains, ← find?_of_toList_contains]
-  simp only [List.Perm.mem_iff (toList_insert m a b), List.mem_cons]
+  show find? (insert m a b) a' = some b' ↔ find? m a' = some b'
+  simp only [← find?_of_toList_contains, List.Perm.mem_iff (toList_insert m a b), List.mem_cons,
+    List.mem_filter, Prod.mk.injEq]
   apply Iff.intro
-  . intro ⟨a₂, hA₂Eq, hA₂⟩
-    refine ⟨a₂, hA₂Eq, ?_⟩
-    cases hA₂ with
-    | inl h =>
-      cases h
-      have := Bool.not_bne_of_beq (PartialEquivBEq.symm hA₂Eq)
-      contradiction
-    | inr h => exact List.mem_of_mem_eraseP h
-  . intro ⟨a₂, hA₂Eq, hA₂⟩
-    refine ⟨a₂, hA₂Eq, ?_⟩
-    apply Or.inr
-    refine (List.mem_eraseP_of_neg ?_).mpr hA₂
-    dsimp
-    intro h
-    apply Bool.not_bne_of_beq (PartialEquivBEq.trans hA₂Eq h |> PartialEquivBEq.symm) hNe
+  . intro ⟨a'', hA', h⟩
+    cases h with
+    | inl hEq =>
+      cases hEq.left
+      exfalso
+      exact Bool.not_bne_of_beq (PartialEquivBEq.symm hA') hNe
+    | inr hMem => exact ⟨a'', hA', hMem.left⟩
+  . intro ⟨a'', hA', hMem⟩
+    refine ⟨a'', hA', .inr ?_⟩
+    refine ⟨hMem, Bool.not_eq_true_iff_ne_true.mpr ?_⟩
+    intro hA''
+    exact Bool.not_bne_of_beq (PartialEquivBEq.symm (PartialEquivBEq.trans hA' hA'')) hNe
 
-theorem find?_erase [PartialEquivBEq α] (m : HashMap α β) (a a')
+theorem find?_erase (m : HashMap α β) (a a')
     : a == a' → (m.erase a).find? a' = none := by
   intro hEq
   apply (find?_of_toList_not_contains _ _).mp
   intro a₂ b hA₂ hMem
   rw [List.Perm.mem_iff (toList_erase m a)] at hMem
-  sorry
-  -- TODO: this is false; do we need to rely on elements in the map never repeating?
-  --  theorem not_of_mem_eraseP {l : List α} : a ∈ l.eraseP p → ¬p a := sorry
-  -- apply not_of_mem_eraseP hMem
-  -- have : a₂ == a := PartialEquivBEq.symm (PartialEquivBEq.trans hEq hA₂)
-  -- exact this
+  refine Bool.not_bne_of_beq (PartialEquivBEq.symm <| PartialEquivBEq.trans hEq hA₂) ?_
+  exact List.mem_filter.mp hMem |>.right
 
 end Std.HashMap

--- a/Std/Data/HashMap/Lemmas.lean
+++ b/Std/Data/HashMap/Lemmas.lean
@@ -156,13 +156,19 @@ theorem toListModel_foldl_reinsertAux (bkt : List (α × β)) (tgt : Buckets α 
     refine Perm.trans (Perm.symm perm_middle) ?_
     apply Perm.append_left _ (Perm.refl _)
 
+theorem toListModel_expand (size : Nat) (bkts : Buckets α β)
+    : (expand size bkts).buckets.toListModel ~ bkts.toListModel := by
+  refine (go _ _ _).trans ?_
+  rw [toListModel_mk, toListModel_eq]
+  simp [Perm.refl]
 
-private theorem toListModel_expand_aux (i : Nat) (src : Array (AssocList α β)) (target : Buckets α β) :
+where
+go (i : Nat) (src : Array (AssocList α β)) (target : Buckets α β) :
     (expand.go i src target).toListModel
     ~ (src.data.drop i).foldl (init := target.toListModel) (fun a b => a ++ b.toList) := by
   unfold expand.go; split
   case inl hI =>
-    refine (toListModel_expand_aux (i +1) _ _).trans ?_
+    refine (go (i +1) _ _).trans ?_
     have h₀ : (src.data.set i AssocList.nil).drop (i + 1) = src.data.drop (i + 1) := by
       apply drop_ext
       intro j hJ
@@ -180,12 +186,6 @@ private theorem toListModel_expand_aux (i : Nat) (src : Array (AssocList α β))
     have : src.data.length ≤ i := by simp [Nat.le_of_not_lt, hI]
     simp [Perm.refl, drop_eq_nil_of_le this]
   termination_by _ i src _ => src.size - i
-
-theorem toListModel_expand (size : Nat) (bkts : Buckets α β)
-    : (expand size bkts).buckets.toListModel ~ bkts.toListModel := by
-  refine (toListModel_expand_aux _ _ _).trans ?_
-  rw [toListModel_mk, toListModel_eq]
-  simp [Perm.refl]
 
 theorem exists_of_toListModel_update_WF (bkts : Buckets α β) (H : bkts.WF) (i d h) :
     ∃ l₁ l₂, bkts.toListModel = l₁ ++ bkts.1[i.toNat].toList ++ l₂

--- a/Std/Data/HashMap/Lemmas.lean
+++ b/Std/Data/HashMap/Lemmas.lean
@@ -21,71 +21,37 @@ theorem List.eraseP_eq_filter_of_unique (l : List α) (p : α → Bool)
     | false => simp [eraseP_cons, filter, hP, ih]
 
 @[simp]
-theorem Array.foldl_zero {as : Array α} {init : β} {f : β → α → β}
-    : as.foldl f init (stop := 0) = init := by
-  sorry
-
-@[simp]
-theorem Array.foldl_succ {as : Array α} {init : β} {f : β → α → β} (i : Fin as.size)
-    : as.foldl f init (stop := i + 1) = f (as.foldl f init (stop := i)) as[i] := by
-  sorry
-
-theorem Array.foldlM_zero [Monad m] [LawfulMonad m]
-    {as : Array α} {init : β} {f : β → α → m β} {start : Nat}
-    : as.foldlM f init start 0 = pure init := by
-  unfold foldlM foldlM.loop
-  simp [Nat.not_lt_zero]
-
-theorem Array.foldlM_succ [Monad m] [LawfulMonad m]
-    {as : Array α} {init : β} {f : β → α → m β} {start : Nat} (i : Fin as.size) : start ≤ i.val
-    → (as.foldlM f init start (i.val + 1)) = as.foldlM f init start i >>= (f · as[i]) := by
-  intro hStartLe
-  have hISuccLe : i.val + 1 ≤ as.size := Nat.succ_le_of_lt i.isLt
-  have hILe : i.val ≤ as.size := Nat.le_of_lt i.isLt
-  simp only [foldlM, hISuccLe, hILe, dite_true]
-  conv => lhs; unfold foldlM.loop
-  simp only [Nat.lt_succ_of_le hStartLe, dite_true]
-  split
-  case h_1 h =>
-    exfalso
-    exact Nat.le_trans (Nat.sub_eq_zero_iff_le.mp h) hStartLe
-      |> Nat.lt_of_succ_le
-      |> Nat.not_lt_of_le (Nat.le_refl _)
-  case h_2 h =>
-    -- This is kinda tricky, since foldlM recurses on start rather than stop. Rethink..
-    sorry
+theorem List.foldl_cons_fn (l₁ l₂ : List α) :
+    l₁.foldl (init := l₂) (fun acc x => x :: acc) = l₁.reverse ++ l₂ := by
+  induction l₁ generalizing l₂ <;> simp [*]
 
 namespace Std.HashMap
 open List
 
 variable [BEq α] [Hashable α] [LawfulHashable α] [PartialEquivBEq α]
 
-/-- It is a bit easier to reason about `fold (append)` than `fold (fold)`,
-so we transfer most proofs about `toList` from this auxiliary function. -/
-def toList' (m : HashMap α β) : List (α × β) :=
+/-- It is a bit easier to reason about `foldl (append)` than `foldl (foldl)`, so we use this
+(less efficient) variant of `toList` as the mathematical model. -/
+def toListModel (m : HashMap α β) : List (α × β) :=
   m.val.buckets.val.foldl (init := []) (fun acc bkt => acc ++ bkt.toList)
 
--- TODO: naming
-theorem foldl_induction₂ {as : Array α} (motive : Nat → β → β → Prop) {init₁ init₂ : β}
-    (h0 : motive 0 init₁ init₂) {f g : β → α → β}
-    (hf : ∀ i : Fin as.size, ∀ acc₁ acc₂,
-      motive i.1 acc₁ acc₂ → motive (i.1 + 1) (f acc₁ as[i]) (g acc₂ as[i]))
-    : motive as.size (as.foldl f init₁) (as.foldl g init₂) := by
-  apply Array.foldl_induction
-    (motive := fun i (acc : β) => motive i acc (as.foldl g init₂ (stop := i)))
-    (h0 := Array.foldl_zero ▸ h0)
-    (hf := fun _ _ hPrev => by rw [Array.foldl_succ]; exact hf _ _ _ hPrev)
-
-theorem toList_perm_toList' (m : HashMap α β) : m.toList' ~ m.toList := by
-  unfold toList toList' HashMap.fold HashMap.Imp.fold
-  apply foldl_induction₂ (fun _ l₁ l₂ => l₁ ~ l₂) (h0 := List.Perm.nil)
-  intro acc₁ acc₂ l hAcc
-  sorry
+theorem toList_eq_reverse_toListModel (m : HashMap α β) : m.toList = m.toListModel.reverse := by
+  simp only [toList, toListModel, fold, Imp.fold, Array.foldl_eq_foldl_data, AssocList.foldl_eq,
+    List.foldl_cons_fn]
+  suffices ∀ (l₁ : List (AssocList α β)) (l₂ : List (α × β)),
+      l₁.foldl (init := l₂.reverse) (fun d b => b.toList.reverse ++ d) =
+      (l₁.foldl (init := l₂) fun acc bkt => acc ++ bkt.toList).reverse by
+    apply this (l₂ := [])
+  intro l₁
+  induction l₁ with
+  | nil => intro; rfl
+  | cons a as ih =>
+    intro l₂
+    simp only [List.foldl, ← List.reverse_append, ih]
 
 /-- The map does not store duplicate (`beq`) keys. -/
-theorem Pairwise_bne_toList (m : HashMap α β) : m.toList.Pairwise (·.1 != ·.1) := by
-  apply List.Perm.pairwise_iff (bne_symm _ _) (toList_perm_toList' m) |>.mp
-  unfold toList'
+theorem Pairwise_bne_toListModel (m : HashMap α β) : m.toListModel.Pairwise (·.1 != ·.1) := by
+  unfold toListModel
   refine Array.foldl_induction
     (motive := fun i (acc : List (α × β)) =>
       -- The acc has the desired property
@@ -123,53 +89,62 @@ theorem Pairwise_bne_toList (m : HashMap α β) : m.toList.Pairwise (·.1 != ·.
           exact .trans hHashP.symm hHashR
         exact Nat.ne_of_lt hGt this
 
-theorem toList_eraseP_eq_toList_filter (m : HashMap α β)
-    : m.toList.eraseP (·.1 == a) = m.toList.filter (·.1 != a) := by
+theorem toListModel_eraseP_eq_toListModel_filter (m : HashMap α β)
+    : m.toListModel.eraseP (·.1 == a) = m.toListModel.filter (·.1 != a) := by
   apply List.eraseP_eq_filter_of_unique
-  apply List.Pairwise.imp ?_ (Pairwise_bne_toList _)
+  apply List.Pairwise.imp ?_ (Pairwise_bne_toListModel _)
   intro (a₁, _) (a₂, _) hA₁Bne hA₁Beq
   rw [Bool.not_eq_true_iff_ne_true]
   intro hA₂Beq
   exact Bool.not_bne_of_beq (PartialEquivBEq.trans hA₁Beq (PartialEquivBEq.symm hA₂Beq)) hA₁Bne
 
-theorem toList_insert_perm_cons_eraseP (m : HashMap α β) (a : α) (b : β)
-    : (m.insert a b).toList ~ (a, b) :: m.toList.eraseP (·.1 == a) :=
+theorem toListModel_insert_perm_cons_eraseP (m : HashMap α β) (a : α) (b : β)
+    : (m.insert a b).toListModel ~ (a, b) :: m.toListModel.eraseP (·.1 == a) :=
   sorry
 
-theorem toList_insert (m : HashMap α β) (a : α) (b : β)
-    : (m.insert a b).toList ~ (a, b) :: m.toList.filter (·.1 != a) :=
-  toList_eraseP_eq_toList_filter m ▸ toList_insert_perm_cons_eraseP m a b
+theorem toListModel_insert (m : HashMap α β) (a : α) (b : β)
+    : (m.insert a b).toListModel ~ (a, b) :: m.toListModel.filter (·.1 != a) :=
+  toListModel_eraseP_eq_toListModel_filter m ▸ toListModel_insert_perm_cons_eraseP m a b
 
-theorem toList_erase_perm_eraseP (m : HashMap α β) (a : α)
-    : (m.erase a).toList ~ m.toList.eraseP (·.1 == a) :=
+theorem toListModel_erase_perm_eraseP (m : HashMap α β) (a : α)
+    : (m.erase a).toListModel ~ m.toListModel.eraseP (·.1 == a) :=
   sorry
 
-theorem toList_erase (m : HashMap α β) (a : α)
-    : (m.erase a).toList ~ m.toList.filter (·.1 != a) :=
-  toList_eraseP_eq_toList_filter m ▸ toList_erase_perm_eraseP m a
+theorem toListModel_erase (m : HashMap α β) (a : α)
+    : (m.erase a).toListModel ~ m.toListModel.filter (·.1 != a) :=
+  toListModel_eraseP_eq_toListModel_filter m ▸ toListModel_erase_perm_eraseP m a
 
-theorem find?_of_toList_contains (m : HashMap α β) (a : α) (b : β)
-    : (∃ a', a == a' ∧ (a', b) ∈ m.toList) ↔ m.find? a = some b :=
+theorem findEntry?_eq (m : HashMap α β) (a : α)
+    : m.findEntry? a = m.toListModel.find? (·.1 == a) := by
+  unfold findEntry? Imp.findEntry?
+  conv => simp_match; simp_match
   sorry
 
-theorem find?_of_toList_not_contains (m : HashMap α β) (a : α)
-    : (∀ a' (b : β), a == a' → (a', b) ∉ m.toList) ↔ m.find? a = none := by
+theorem find?_of_toListModel_contains (m : HashMap α β) (a : α) (b : β)
+    : (∃ a', a == a' ∧ (a', b) ∈ m.toListModel) ↔ m.find? a = some b := by
+  unfold HashMap.toListModel HashMap.find? Imp.find?
+  -- have H : (∃ a', a == a' ∧ (a', b) ∈ m.toListModel)
+  --     ↔ (∃ a', ∃ bkt, (i : Fin m.val.buckets.val.size) → bkt = m.val.buckets.val[i] → (a',b) ∈ bkt) := sorry
+  sorry
+
+theorem find?_of_toListModel_not_contains (m : HashMap α β) (a : α)
+    : (∀ a' (b : β), a == a' → (a', b) ∉ m.toListModel) ↔ m.find? a = none := by
   apply Iff.intro
   . rw [← Option.not_isSome_iff_eq_none]
     intro h hSome
     let ⟨b, hB⟩ := Option.isSome_iff_exists.mp hSome
-    let ⟨a', hA, hMem⟩ := find?_of_toList_contains m a b |>.mpr hB
+    let ⟨a', hA, hMem⟩ := find?_of_toListModel_contains m a b |>.mpr hB
     exact h a' b hA hMem
   . intro h a' b hA hMem
     refine Option.ne_none_iff_exists.mpr ?_ h
-    exact ⟨b, find?_of_toList_contains m a b |>.mp ⟨a', hA, hMem⟩ |>.symm⟩
+    exact ⟨b, find?_of_toListModel_contains m a b |>.mp ⟨a', hA, hMem⟩ |>.symm⟩
 
 theorem find?_insert (m : HashMap α β) (a a' b)
     : a' == a → (m.insert a b).find? a' = some b := by
   intro hEq
-  apply (find?_of_toList_contains _ _ _).mp
+  apply (find?_of_toListModel_contains _ _ _).mp
   refine ⟨a, hEq, ?_⟩
-  rw [List.Perm.mem_iff (toList_insert m a b)]
+  rw [List.Perm.mem_iff (toListModel_insert m a b)]
   apply List.mem_cons_self
 
 theorem find?_insert_of_ne (m : HashMap α β) (a a' : α) (b : β)
@@ -178,7 +153,7 @@ theorem find?_insert_of_ne (m : HashMap α β) (a a' : α) (b : β)
   apply Option.ext
   intro b'
   show find? (insert m a b) a' = some b' ↔ find? m a' = some b'
-  simp only [← find?_of_toList_contains, List.Perm.mem_iff (toList_insert m a b), List.mem_cons,
+  simp only [← find?_of_toListModel_contains, List.Perm.mem_iff (toListModel_insert m a b), List.mem_cons,
     List.mem_filter, Prod.mk.injEq]
   apply Iff.intro
   . intro ⟨a'', hA', h⟩
@@ -197,9 +172,9 @@ theorem find?_insert_of_ne (m : HashMap α β) (a a' : α) (b : β)
 theorem find?_erase (m : HashMap α β) (a a')
     : a == a' → (m.erase a).find? a' = none := by
   intro hEq
-  apply (find?_of_toList_not_contains _ _).mp
+  apply (find?_of_toListModel_not_contains _ _).mp
   intro a₂ b hA₂ hMem
-  rw [List.Perm.mem_iff (toList_erase m a)] at hMem
+  rw [List.Perm.mem_iff (toListModel_erase m a)] at hMem
   refine Bool.not_bne_of_beq (PartialEquivBEq.symm <| PartialEquivBEq.trans hEq hA₂) ?_
   exact List.mem_filter.mp hMem |>.right
 

--- a/Std/Data/HashMap/WF.lean
+++ b/Std/Data/HashMap/WF.lean
@@ -68,7 +68,7 @@ theorem reinsertAux_size [Hashable α] (data : Buckets α β) (a : α) (b : β) 
 
 theorem reinsertAux_WF [BEq α] [Hashable α] {data : Buckets α β} {a : α} {b : β} (H : data.WF)
     (h₁ : ∀ [PartialEquivBEq α] [LawfulHashable α],
-      haveI := mkIdx data.2 a
+      haveI := mkIdx (hash a) data.2
       (data.val[this.1]'this.2).All fun x _ => ¬(a == x)) :
     (reinsertAux data a b).WF :=
   H.update (.cons h₁) fun
@@ -309,7 +309,7 @@ theorem WF.filterMap {α β γ} {f : α → β → Option γ} [BEq α] [Hashable
       simp; exact match f a.1 a.2 with
       | none => .cons _ ih
       | some b => .cons₂ _ ih
-  suffices ∀ bk sz (h : 0 < bk.length),
+  suffices ∀ bk sz (h : bk.length.isPowerOfTwo),
     m.buckets.val.mapM (m := M) (filterMap.go f .nil) ⟨0⟩ = (⟨bk⟩, ⟨sz⟩) →
     WF ⟨sz, ⟨bk⟩, h⟩ from this _ _ _ rfl
   simp [Array.mapM_eq_mapM_data, bind, StateT.bind, H2]

--- a/Std/Data/HashMap/WF.lean
+++ b/Std/Data/HashMap/WF.lean
@@ -12,36 +12,36 @@ namespace Imp
 
 attribute [-simp] Bool.not_eq_true
 
-namespace Bucket
+namespace Buckets
 
-@[ext] protected theorem ext : ∀ {b₁ b₂ : Bucket α β}, b₁.1.data = b₂.1.data → b₁ = b₂
+@[ext] protected theorem ext : ∀ {b₁ b₂ : Buckets α β}, b₁.1.data = b₂.1.data → b₁ = b₂
   | ⟨⟨_⟩, _⟩, ⟨⟨_⟩, _⟩, rfl => rfl
 
-theorem update_data (self : Bucket α β) (i d h) :
+theorem update_data (self : Buckets α β) (i d h) :
     (self.update i d h).1.data = self.1.data.set i.toNat d := rfl
 
-@[simp] theorem update_size (self : Bucket α β) (i d h) :
+@[simp] theorem update_size (self : Buckets α β) (i d h) :
     (self.update i d h).1.size = self.1.size := Array.size_uset ..
 
-theorem exists_of_update (self : Bucket α β) (i d h) :
+theorem exists_of_update (self : Buckets α β) (i d h) :
     ∃ l₁ l₂, self.1.data = l₁ ++ self.1[i] :: l₂ ∧ List.length l₁ = i.toNat ∧
       (self.update i d h).1.data = l₁ ++ d :: l₂ := by
   simp [Array.getElem_eq_data_get]; exact List.exists_of_set' h
 
-theorem size_eq (data : Bucket α β) :
+theorem size_eq (data : Buckets α β) :
   size data = .sum (data.1.data.map (·.toList.length)) := rfl
 
-theorem mk_size (h) : (mk n h : Bucket α β).size = 0 := by
-  simp [Bucket.size_eq, Bucket.mk, mkArray]; clear h
+theorem mk_size (h) : (mk n h : Buckets α β).size = 0 := by
+  simp [Buckets.size_eq, Buckets.mk, mkArray]; clear h
   induction n <;> simp [*]
 
-theorem WF.mk' [BEq α] [Hashable α] (h) : (Bucket.mk n h : Bucket α β).WF := by
+theorem WF.mk' [BEq α] [Hashable α] (h) : (Buckets.mk n h : Buckets α β).WF := by
   refine ⟨fun _ h => ?_, fun i h => ?_⟩
-  · simp [Bucket.mk, empty', mkArray, List.mem_replicate] at h
+  · simp [Buckets.mk, empty', mkArray, List.mem_replicate] at h
     simp [h, List.Pairwise.nil]
-  · simp [Bucket.mk, empty', mkArray, Array.getElem_eq_data_get, AssocList.All]
+  · simp [Buckets.mk, empty', mkArray, Array.getElem_eq_data_get, AssocList.All]
 
-theorem WF.update [BEq α] [Hashable α] {buckets : Bucket α β} {i d h} (H : buckets.WF)
+theorem WF.update [BEq α] [Hashable α] {buckets : Buckets α β} {i d h} (H : buckets.WF)
     (h₁ : ∀ [PartialEquivBEq α] [LawfulHashable α],
       (buckets.1[i].toList.Pairwise fun a b => ¬(a.1 == b.1)) →
       d.toList.Pairwise fun a b => ¬(a.1 == b.1))
@@ -57,15 +57,15 @@ theorem WF.update [BEq α] [Hashable α] {buckets : Bucket α β} {i d h} (H : b
     · next eq => exact eq ▸ h₂ (H.2 _ _) _ hp
     · simp at hi; exact H.2 i hi _ hp
 
-end Bucket
+end Buckets
 
-theorem reinsertAux_size [Hashable α] (data : Bucket α β) (a : α) (b : β) :
+theorem reinsertAux_size [Hashable α] (data : Buckets α β) (a : α) (b : β) :
     (reinsertAux data a b).size = data.size.succ := by
-  simp [Bucket.size_eq, reinsertAux]
-  refine have ⟨l₁, l₂, h₁, _, eq⟩ := Bucket.exists_of_update ..; eq ▸ ?_
+  simp [Buckets.size_eq, reinsertAux]
+  refine have ⟨l₁, l₂, h₁, _, eq⟩ := Buckets.exists_of_update ..; eq ▸ ?_
   simp [h₁, Nat.succ_add]; rfl
 
-theorem reinsertAux_WF [BEq α] [Hashable α] {data : Bucket α β} {a : α} {b : β} (H : data.WF)
+theorem reinsertAux_WF [BEq α] [Hashable α] {data : Buckets α β} {a : α} {b : β} (H : data.WF)
     (h₁ : ∀ [PartialEquivBEq α] [LawfulHashable α],
       haveI := mkIdx data.2 a
       (data.val[this.1]'this.2).All fun x _ => ¬(a == x)) :
@@ -74,13 +74,13 @@ theorem reinsertAux_WF [BEq α] [Hashable α] {data : Bucket α β} {a : α} {b 
     | _, _, .head .. => rfl
     | H, _, .tail _ h => H _ h
 
-theorem expand_size [Hashable α] {buckets : Bucket α β} :
+theorem expand_size [Hashable α] {buckets : Buckets α β} :
     (expand sz buckets).buckets.size = buckets.size := by
   rw [expand, go]
-  · rw [Bucket.mk_size]; simp [Bucket.size]
+  · rw [Buckets.mk_size]; simp [Buckets.size]
   · intro.
 where
-  go (i source) (target : Bucket α β) (hs : ∀ j < i, source.data.getD j .nil = .nil) :
+  go (i source) (target : Buckets α β) (hs : ∀ j < i, source.data.getD j .nil = .nil) :
       (expand.go i source target).size =
         .sum (source.data.map (·.toList.length)) + target.size := by
     unfold expand.go; split
@@ -92,11 +92,11 @@ where
         · next H => exact hs _ (Nat.lt_of_le_of_ne (Nat.le_of_lt_succ hj) (Ne.symm H))
       · case b =>
         refine have ⟨l₁, l₂, h₁, _, eq⟩ := List.exists_of_set' H; eq ▸ ?_
-        simp [h₁, Bucket.size_eq]
+        simp [h₁, Buckets.size_eq]
         rw [Nat.add_assoc, Nat.add_assoc, Nat.add_assoc]; congr 1
         (conv => rhs; rw [Nat.add_left_comm]); congr 1
         rw [← Array.getElem_eq_data_get]
-        have := @reinsertAux_size α β _; simp [Bucket.size] at this
+        have := @reinsertAux_size α β _; simp [Buckets.size] at this
         induction source[i].toList generalizing target <;> simp [*, Nat.succ_add]; rfl
     · next H =>
       rw [(_ : Nat.sum _ = 0), Nat.zero_add]
@@ -111,7 +111,7 @@ termination_by go i source _ _ => source.size - i
 theorem expand_WF.foldl [BEq α] [Hashable α] (rank : α → Nat) {l : List (α × β)} {i : Nat}
     (hl₁ : ∀ [PartialEquivBEq α] [LawfulHashable α], l.Pairwise fun a b => ¬(a.1 == b.1))
     (hl₂ : ∀ x ∈ l, rank x.1 = i)
-    {target : Bucket α β} (ht₁ : target.WF)
+    {target : Buckets α β} (ht₁ : target.WF)
     (ht₂ : ∀ bucket ∈ target.1.data,
       bucket.All fun k _ => rank k ≤ i ∧
         ∀ [PartialEquivBEq α] [LawfulHashable α], ∀ x ∈ l, ¬(x.1 == k)) :
@@ -125,7 +125,7 @@ theorem expand_WF.foldl [BEq α] [Hashable α] (rank : α → Nat) {l : List (α
     refine ih hl₁.2 hl₂.2
       (reinsertAux_WF ht₁ fun _ h => (ht₂ _ (Array.getElem_mem_data ..) _ h).2.1)
       (fun _ h => ?_)
-    simp [reinsertAux, Bucket.update] at h
+    simp [reinsertAux, Buckets.update] at h
     match List.mem_or_eq_of_mem_set h with
     | .inl h =>
       intro _ hf
@@ -138,16 +138,16 @@ theorem expand_WF.foldl [BEq α] [Hashable α] (rank : α → Nat) {l : List (α
         have ⟨h₁, h₂⟩ := ht₂ _ (Array.getElem_mem_data ..) _ h
         exact ⟨h₁, h₂.2⟩
 
-theorem expand_WF [BEq α] [Hashable α] {buckets : Bucket α β} (H : buckets.WF) :
+theorem expand_WF [BEq α] [Hashable α] {buckets : Buckets α β} (H : buckets.WF) :
     (expand sz buckets).buckets.WF :=
-  go _ H.1 H.2 ⟨.mk' _, fun _ _ _ _ => by simp_all [Bucket.mk, List.mem_replicate]⟩
+  go _ H.1 H.2 ⟨.mk' _, fun _ _ _ _ => by simp_all [Buckets.mk, List.mem_replicate]⟩
 where
   go (i) {source : Array (AssocList α β)}
       (hs₁ : ∀ [LawfulHashable α] [PartialEquivBEq α], ∀ bucket ∈ source.data,
         bucket.toList.Pairwise fun a b => ¬(a.1 == b.1))
       (hs₂ : ∀ (j : Nat) (h : j < source.size),
         source[j].All fun k _ => ((hash k).toUSize % source.size).toNat = j)
-      {target : Bucket α β} (ht : target.WF ∧ ∀ bucket ∈ target.1.data,
+      {target : Buckets α β} (ht : target.WF ∧ ∀ bucket ∈ target.1.data,
         bucket.All fun k _ => ((hash k).toUSize % source.size).toNat < i) :
       (expand.go i source target).WF := by
     unfold expand.go; split
@@ -173,16 +173,16 @@ theorem insert_size [BEq α] [Hashable α] {m : Imp α β} {k v}
     (h : m.size = m.buckets.size) :
     (insert m k v).size = (insert m k v).buckets.size := by
   dsimp [insert, cond]; split
-  · unfold Bucket.size
-    refine have ⟨_, _, h₁, _, eq⟩ := Bucket.exists_of_update ..; eq ▸ ?_
-    simp [h, h₁, Bucket.size_eq]
+  · unfold Buckets.size
+    refine have ⟨_, _, h₁, _, eq⟩ := Buckets.exists_of_update ..; eq ▸ ?_
+    simp [h, h₁, Buckets.size_eq]
   split
-  · unfold Bucket.size
-    refine have ⟨_, _, h₁, _, eq⟩ := Bucket.exists_of_update ..; eq ▸ ?_
-    simp [h, h₁, Bucket.size_eq, Nat.succ_add]; rfl
-  · rw [expand_size]; simp [h, expand, Bucket.size]
-    refine have ⟨_, _, h₁, _, eq⟩ := Bucket.exists_of_update ..; eq ▸ ?_
-    simp [h₁, Bucket.size_eq, Nat.succ_add]; rfl
+  · unfold Buckets.size
+    refine have ⟨_, _, h₁, _, eq⟩ := Buckets.exists_of_update ..; eq ▸ ?_
+    simp [h, h₁, Buckets.size_eq, Nat.succ_add]; rfl
+  · rw [expand_size]; simp [h, expand, Buckets.size]
+    refine have ⟨_, _, h₁, _, eq⟩ := Buckets.exists_of_update ..; eq ▸ ?_
+    simp [h₁, Buckets.size_eq, Nat.succ_add]; rfl
 
 private theorem mem_replaceF {l : List (α × β)} {x : α × β} {p : α × β → Bool} :
     x ∈ (l.replaceF fun a => bif p a then some (k, v) else none) → x.1 = k ∨ x ∈ l := by
@@ -241,9 +241,9 @@ theorem erase_size [BEq α] [Hashable α] {m : Imp α β} {k}
     (erase m k).size = (erase m k).buckets.size := by
   dsimp [erase, cond]; split
   · next H =>
-    simp [h, Bucket.size]
-    refine have ⟨_, _, h₁, _, eq⟩ := Bucket.exists_of_update ..; eq ▸ ?_
-    simp [h, h₁, Bucket.size_eq]
+    simp [h, Buckets.size]
+    refine have ⟨_, _, h₁, _, eq⟩ := Buckets.exists_of_update ..; eq ▸ ?_
+    simp [h, h₁, Buckets.size_eq]
     rw [(_ : List.length _ = _ + 1), Nat.add_right_comm]; {rfl}
     clear h₁ eq
     simp [AssocList.contains_eq] at H
@@ -264,7 +264,7 @@ theorem WF.out [BEq α] [Hashable α] {m : Imp α β} (h : m.WF) :
     m.size = m.buckets.size ∧ m.buckets.WF := by
   induction h with
   | mk h₁ h₂ => exact ⟨h₁, h₂⟩
-  | @empty' _ h => exact ⟨(Bucket.mk_size h).symm, .mk' h⟩
+  | @empty' _ h => exact ⟨(Buckets.mk_size h).symm, .mk' h⟩
   | insert _ ih => exact ⟨insert_size ih.1, insert_WF ih.2⟩
   | erase _ ih => exact ⟨erase_size ih.1, erase_WF ih.2⟩
 
@@ -275,8 +275,8 @@ theorem WF_iff [BEq α] [Hashable α] {m : Imp α β} :
 theorem WF.mapVal {α β γ} {f : α → β → γ} [BEq α] [Hashable α]
     {m : Imp α β} (H : WF m) : WF (mapVal f m) := by
   have ⟨h₁, h₂⟩ := H.out
-  simp [Imp.mapVal, Bucket.mapVal, WF_iff, h₁]; refine ⟨?_, ?_, fun i h => ?_⟩
-  · simp [Bucket.size]; congr; funext l; simp
+  simp [Imp.mapVal, Buckets.mapVal, WF_iff, h₁]; refine ⟨?_, ?_, fun i h => ?_⟩
+  · simp [Buckets.size]; congr; funext l; simp
   · simp [List.forall_mem_map_iff, List.pairwise_map]
     exact fun _ => h₂.1 _
   · simp [AssocList.All, List.forall_mem_map_iff] at h ⊢
@@ -313,7 +313,7 @@ theorem WF.filterMap {α β γ} {f : α → β → Option γ} [BEq α] [Hashable
     WF ⟨sz, ⟨bk⟩, h⟩ from this _ _ _ rfl
   simp [Array.mapM_eq_mapM_data, bind, StateT.bind, H2]
   intro bk sz h e'; cases e'
-  refine .mk (by simp [Bucket.size]) ⟨?_, fun i h => ?_⟩
+  refine .mk (by simp [Buckets.size]) ⟨?_, fun i h => ?_⟩
   · simp [List.forall_mem_map_iff]
     refine fun l h => (List.pairwise_reverse.2 ?_).imp (mt PartialEquivBEq.symm)
     have := H.out.2.1 _ h

--- a/Std/Data/HashMap/WF.lean
+++ b/Std/Data/HashMap/WF.lean
@@ -25,7 +25,7 @@ theorem update_data (self : Buckets α β) (i d h) :
 
 /-- This theorem, small it may seem, can solve many problems. Apply whenever possible. -/
 theorem exists_of_update (self : Buckets α β) (i d h) :
-    ∃ l₁ l₂, self.1.data = l₁ ++ self.1[i] :: l₂ ∧ List.length l₁ = i.toNat ∧
+    ∃ l₁ l₂, self.1.data = l₁ ++ self.1[i.toNat] :: l₂ ∧ List.length l₁ = i.toNat ∧
       (self.update i d h).1.data = l₁ ++ d :: l₂ := by
   simp [Array.getElem_eq_data_get]; exact List.exists_of_set' h
 

--- a/Std/Data/HashMap/WF.lean
+++ b/Std/Data/HashMap/WF.lean
@@ -23,6 +23,7 @@ theorem update_data (self : Buckets α β) (i d h) :
 @[simp] theorem update_size (self : Buckets α β) (i d h) :
     (self.update i d h).1.size = self.1.size := Array.size_uset ..
 
+/-- This theorem, small it may seem, can solve many problems. Apply whenever possible. -/
 theorem exists_of_update (self : Buckets α β) (i d h) :
     ∃ l₁ l₂, self.1.data = l₁ ++ self.1[i] :: l₂ ∧ List.length l₁ = i.toNat ∧
       (self.update i d h).1.data = l₁ ++ d :: l₂ := by

--- a/Std/Data/HashMap/WF.lean
+++ b/Std/Data/HashMap/WF.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro
 import Std.Data.HashMap.Basic
 import Std.Data.List.Lemmas
 import Std.Data.Array.Lemmas
-import Std.Tactic.ShowTerm
 
 namespace Std.HashMap
 namespace Imp

--- a/Std/Data/HashMap/WF.lean
+++ b/Std/Data/HashMap/WF.lean
@@ -67,7 +67,7 @@ theorem reinsertAux_size [Hashable α] (data : Bucket α β) (a : α) (b : β) :
 
 theorem reinsertAux_WF [BEq α] [Hashable α] {data : Bucket α β} {a : α} {b : β} (H : data.WF)
     (h₁ : ∀ [PartialEquivBEq α] [LawfulHashable α],
-      haveI := mkIdx data.2 (hash a).toUSize
+      haveI := mkIdx data.2 a
       (data.val[this.1]'this.2).All fun x _ => ¬(a == x)) :
     (reinsertAux data a b).WF :=
   H.update (.cons h₁) fun

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -747,11 +747,11 @@ substring of `l₂`, that is, `l₂` has the form `s ++ l₁ ++ t` for some `s, 
 -/
 def isInfix (l₁ : List α) (l₂ : List α) : Prop := ∃ s t, s ++ l₁ ++ t = l₂
 
-@[inherit_doc] infixl:50 " <+: " => isPrefix
+@[inherit_doc] scoped infixl:50 " <+: " => isPrefix
 
-@[inherit_doc] infixl:50 " <:+ " => isSuffix
+@[inherit_doc] scoped infixl:50 " <:+ " => isSuffix
 
-@[inherit_doc] infixl:50 " <:+: " => isInfix
+@[inherit_doc] scoped infixl:50 " <:+: " => isInfix
 
 /--
 `inits l` is the list of initial segments of `l`.

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1294,6 +1294,14 @@ theorem foldr_hom (f : β₁ → β₂) (g₁ : α → β₁ → β₁) (g₂ : 
     (H : ∀ x y, g₂ x (f y) = f (g₁ x y)) : l.foldr g₂ (f init) = f (l.foldr g₁ init) := by
   induction l <;> simp [*, H]
 
+theorem foldl_cons_fn (l₁ l₂ : List α) :
+    l₁.foldl (init := l₂) (fun acc x => x :: acc) = l₁.reverse ++ l₂ := by
+  induction l₁ generalizing l₂ <;> simp [*]
+
+theorem foldl_append_fn (l₁ : List α) (l₂ : List β) (f : α → List β) :
+    l₁.foldl (init := l₂) (fun acc x => acc ++ f x) = l₂ ++ l₁.bind f := by
+  induction l₁ generalizing l₂ <;> simp [*]
+
 /-! ### union -/
 
 section union

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -526,7 +526,7 @@ theorem get_of_eq {l l' : List α} (h : l = l') (i : Fin l.length) :
 theorem get_zero : ∀ {l : List α} (h : 0 < l.length), l.get ⟨0, h⟩ = l.head?
   | _::_, _ => rfl
 
-theorem get_append : ∀ {l₁ l₂ : List α} (n : Nat) (h : n < l₁.length),
+theorem get_append : ∀ {l₁ : List α} (l₂ : List α) (n : Nat) (h : n < l₁.length),
     (l₁ ++ l₂).get ⟨n, length_append .. ▸ Nat.lt_add_right _ _ _ h⟩ = l₁.get ⟨n, h⟩
 | a :: l, _, 0, h => rfl
 | a :: l, _, n+1, h => by simp only [get, cons_append]; apply get_append

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1068,6 +1068,20 @@ theorem Pairwise.imp {α R S} (H : ∀ {a b}, R a b → S a b) :
   | _, .nil => .nil
   | _, .cons h₁ h₂ => .cons (H ∘ h₁ ·) (h₂.imp H)
 
+theorem pairwise_append_comm_of_symm {α R} (s : ∀ {a b}, R a b → R b a) {l₁ l₂ : List α} :
+    Pairwise R (l₁ ++ l₂) ↔ Pairwise R (l₂ ++ l₁) := by
+  have : ∀ l₁ l₂ : List α, (∀ x : α, x ∈ l₁ → ∀ y : α, y ∈ l₂ → R x y) →
+    ∀ x : α, x ∈ l₂ → ∀ y : α, y ∈ l₁ → R x y := fun l₁ l₂ a x xm y ym => s (a y ym x xm)
+  simp only [pairwise_append, and_left_comm] <;> rw [Iff.intro (this l₁ l₂) (this l₂ l₁)]
+
+theorem pairwise_middle_of_symm {α R} (s : ∀ {a b}, R a b → R b a) {a : α} {l₁ l₂ : List α} :
+    Pairwise R (l₁ ++ a :: l₂) ↔ Pairwise R (a :: (l₁ ++ l₂)) :=
+  show Pairwise R (l₁ ++ ([a] ++ l₂)) ↔ Pairwise R ([a] ++ l₁ ++ l₂) by
+    rw [← append_assoc, pairwise_append, @pairwise_append _ _ ([a] ++ l₁),
+      pairwise_append_comm_of_symm s]
+    simp only [mem_append, or_comm]
+    rfl
+
 /-! ### replaceF -/
 
 @[simp] theorem length_replaceF : length (replaceF f l) = length l := by

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1029,6 +1029,26 @@ end erase
 
 /-! ### filter and partition -/
 
+section filter
+
+@[simp] theorem filter_nil (p : α → Bool) : filter p [] = [] := rfl
+
+@[simp] theorem filter_cons_of_pos (l : List α) : p a → filter p (a::l) = a :: filter p l :=
+  fun h => by simp [filter, h]
+
+@[simp] theorem filter_cons_of_neg (l : List α) : ¬ p a → filter p (a::l) = filter p l :=
+  fun h => by simp [filter, h]
+
+@[simp] theorem filter_append : ∀ (l₁ l₂ : List α), filter p (l₁++l₂) = filter p l₁ ++ filter p l₂
+  | [],      _  => rfl
+  | (a::l₁), l₂ => by cases hP : p a <;> simp [hP, filter_append]
+
+theorem filter_sublist : ∀ (l : List α), filter p l <+ l
+  | []     => Sublist.slnil
+  | (a::l) => if pa : p a
+    then by simp [pa, Sublist.cons₂, filter_sublist l]
+    else by simp [pa, Sublist.cons, filter_sublist l]
+
 theorem mem_filter : x ∈ filter p as ↔ x ∈ as ∧ p x := by
   induction as with
   | nil => simp [filter]
@@ -1037,12 +1057,29 @@ theorem mem_filter : x ∈ filter p as ↔ x ∈ as ∧ p x := by
     · exact or_congr_left (and_iff_left_of_imp fun | rfl => ‹_›).symm
     · exact (or_iff_right fun ⟨rfl, h⟩ => (Bool.not_eq_true _).mpr ‹_› h).symm
 
+theorem filter_eq_self : filter p as = as ↔ ∀ a ∈ as, p a := by
+  induction as with
+  | nil => exact iff_of_true rfl (fun _ h => nomatch h)
+  | cons a as ih =>
+    rw [forall_mem_cons]
+    cases hP : p a with
+    | true =>
+      rw [filter_cons_of_pos _ hP, cons_inj, ih, and_iff_right rfl]
+    | false =>
+      refine iff_of_false ?_ (nomatch ·)
+      intro hL
+      refine Bool.eq_false_iff.mp hP ?_
+      refine mem_filter (as := a :: as) |>.mp ?_ |>.right
+      simp [mem_cons_self, hL]
+
 @[simp] theorem partition_eq_filter_filter (p : α → Bool) (l : List α) :
     partition p l = (filter p l, filter (not ∘ p) l) := by simp [partition, aux] where
   aux : ∀ l {as bs}, partition.loop p l (as, bs) =
     (as.reverse ++ filter p l, bs.reverse ++ filter (not ∘ p) l)
   | [] => by simp [partition.loop, filter]
   | a :: l => by cases pa : p a <;> simp [partition.loop, pa, aux, filter, append_assoc]
+
+end filter
 
 /-! ### pairwise -/
 

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1165,7 +1165,6 @@ theorem pairwise_middle_of_symm {α R} (s : ∀ {a b}, R a b → R b a) {a : α}
     rw [← append_assoc, pairwise_append, @pairwise_append _ _ ([a] ++ l₁),
       pairwise_append_comm_of_symm s]
     simp only [mem_append, or_comm]
-    rfl
 
 /-- If there is at most one element with the property `p`, erasing one such element is the same
 as filtering out all of them. -/

--- a/Std/Data/List/Perm.lean
+++ b/Std/Data/List/Perm.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
+-/
+
+import Std.Data.List.Basic
+import Std.Data.List.Lemmas
+
+/-!
+# List Permutations
+
+This file introduces the `List.Perm` relation, which is true if two lists are permutations of one
+another.
+
+## Notation
+
+The notation `~` is used for permutation equivalence.
+-/
+
+namespace List
+
+/-- `Perm l₁ l₂` or `l₁ ~ l₂` asserts that `l₁` and `l₂` are Permutations
+  of each other. This is defined by induction using pairwise swaps. -/
+inductive Perm {α} : List α → List α → Prop
+  /-- The empty list is a permutation of itself. -/
+  | nil   : Perm [] []
+  /-- Consing preserves the `Perm` relation. -/
+  | cons  : ∀ (x : α) {l₁ l₂ : List α}, Perm l₁ l₂ → Perm (x::l₁) (x::l₂)
+  /-- Lists with the first two elements swapped are permutations of each other. -/
+  | swap  : ∀ (x y : α) (l : List α), Perm (y::x::l) (x::y::l)
+  /-- The `Perm` relation is transitive. -/
+  | trans : ∀ {l₁ l₂ l₃ : List α}, Perm l₁ l₂ → Perm l₂ l₃ → Perm l₁ l₃
+
+open Perm
+
+@[inherit_doc] scoped infixl:50 " ~ " => Perm
+
+protected theorem Perm.refl : ∀ (l : List α), l ~ l
+  | []      => Perm.nil
+  | (x::xs) => (Perm.refl xs).cons x
+
+protected theorem Perm.symm {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₂ ~ l₁ := by
+  induction p with
+  | nil => exact Perm.nil
+  | cons x _ ih => exact Perm.cons x ih
+  | swap x y l => exact Perm.swap y x l
+  | trans _ _ ih₁ ih₂ => exact Perm.trans ih₂ ih₁
+
+theorem Perm_comm {l₁ l₂ : List α} : l₁ ~ l₂ ↔ l₂ ~ l₁ := ⟨Perm.symm, Perm.symm⟩
+
+theorem Perm.swap' (x y : α) {l₁ l₂ : List α} (p : l₁ ~ l₂) : y::x::l₁ ~ x::y::l₂ :=
+  have h1 : y :: l₁ ~ y :: l₂ := Perm.cons y p
+  have h2 : x :: y :: l₁ ~ x :: y :: l₂ := Perm.cons x h1
+  have h3 : y :: x :: l₁ ~ x :: y :: l₁ := Perm.swap x y l₁
+  Perm.trans h3 h2
+
+theorem Perm.Equivalence : Equivalence (@Perm α) := ⟨Perm.refl, Perm.symm, Perm.trans⟩
+
+instance (α : Type u) : Setoid (List α) := ⟨Perm, Perm.Equivalence⟩
+
+theorem Perm.subset {α : Type u} {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₁ ⊆ l₂ := by
+  induction p with
+  | nil => exact nil_subset _
+  | cons _ _ ih => exact cons_subset_cons _ ih
+  | swap x y l =>
+    intro a
+    rw [mem_cons]
+    exact fun
+    | Or.inl rfl => Mem.tail _ (Mem.head ..)
+    | Or.inr (Mem.head ..) => Mem.head ..
+    | Or.inr (Mem.tail _ a_mem_l) => Mem.tail _ (Mem.tail _ a_mem_l)
+  | trans _ _ ih₁ ih₂ => exact Subset.trans ih₁ ih₂
+
+theorem perm_middle {a : α} : ∀ {l₁ l₂ : List α}, l₁++a::l₂ ~ a::(l₁++l₂)
+| [], _ => Perm.refl _
+| b::l₁, l₂ =>
+  let h2 := @perm_middle α a l₁ l₂
+  (h2.cons _).trans (swap a b _)
+
+theorem perm_insertNth {x : α} : ∀ {l : List α} {n : Nat}, n ≤ l.length → insertNth n x l ~ x :: l
+  | [], 0, _ => Perm.refl _
+  | [], _+1, h => False.elim (Nat.not_succ_le_zero _ h)
+  | _::_, 0, _ => Perm.refl _
+  | _::_, _+1, h =>
+    Perm.trans
+      (Perm.cons _ (perm_insertNth (Nat.le_of_succ_le_succ h)))
+      (Perm.swap _ _ _)
+
+theorem Perm.mem_iff {a : α} {l₁ l₂ : List α} (h : l₁ ~ l₂) : a ∈ l₁ ↔ a ∈ l₂ :=
+  Iff.intro (fun m => h.subset m) fun m => h.symm.subset m
+
+/-- The way Lean 4 computes the motive with `elabAsElim` has changed
+relative to the behaviour of `elab_as_eliminator` in Lean 3.
+See
+https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Potential.20elaboration.20bug.20with.20.60elabAsElim.60/near/299573172
+for an explanation of the change made here relative to mathlib3.
+-/
+@[elab_as_elim]
+theorem perm_induction_on
+    {P : (l₁ : List α) → (l₂ : List α) → l₁ ~ l₂ → Prop} {l₁ l₂ : List α} (p : l₁ ~ l₂)
+    (nil : P [] [] .nil)
+    (cons : ∀ x l₁ l₂, (h : l₁ ~ l₂) → P l₁ l₂ h → P (x :: l₁) (x :: l₂) (.cons x h))
+    (swap : ∀ x y l₁ l₂, (h : l₁ ~ l₂) → P l₁ l₂ h →
+      P (y :: x :: l₁) (x :: y :: l₂) (.trans (.swap x y _) (.cons _ (.cons _ h))))
+    (trans : ∀ l₁ l₂ l₃, (h₁ : l₁ ~ l₂) → (h₂ : l₂ ~ l₃) → P l₁ l₂ h₁ → P l₂ l₃ h₂ →
+      P l₁ l₃ (.trans h₁ h₂)) : P l₁ l₂ p :=
+  have P_refl l : P l l (.refl l) :=
+    List.recOn l nil fun x xs ih => cons x xs xs (Perm.refl xs) ih
+  Perm.recOn p nil cons (fun x y l => swap x y l l (Perm.refl l) (P_refl l)) @trans
+
+theorem perm_inv_core {a : α} {l₁ l₂ r₁ r₂ : List α} :
+    l₁ ++ a :: r₁ ~ l₂ ++ a :: r₂ → l₁ ++ r₁ ~ l₂ ++ r₂ := by
+  generalize e₁ : l₁ ++ a :: r₁ = s₁; generalize e₂ : l₂ ++ a :: r₂ = s₂
+  intro p; induction p using perm_induction_on generalizing l₁ l₂ r₁ r₂ with
+  | nil => apply (not_mem_nil a).elim; rw [← e₁]; simp
+  | cons x t₁ t₂ p w =>
+    rcases l₁ with _ | ⟨y, l₁⟩ <;> rcases l₂ with _ | ⟨z, l₂⟩ <;> injections <;> subst_vars
+    · exact p
+    · exact p.trans perm_middle
+    · exact perm_middle.symm.trans p
+    · exact (w rfl rfl).cons z
+  | swap x y t₁ t₂ p w =>
+    rcases l₁ with _ | ⟨y, _ | ⟨z, l₁⟩⟩ <;> rcases l₂ with _ | ⟨u, _ | ⟨v, l₂⟩⟩ <;>
+      injections <;> subst_vars
+    · exact p.cons y
+    · exact p.cons u
+    · exact (p.trans perm_middle).cons u
+    · exact p.cons y
+    · exact p.cons u
+    · exact ((p.trans perm_middle).cons v).trans (swap _ _ _)
+    · exact (perm_middle.symm.trans p).cons y
+    · exact (swap _ _ _).trans ((perm_middle.symm.trans p).cons u)
+    · exact (w rfl rfl).swap' _ _
+  | trans t₁ t₂ t₃ p₁ p₂ w₁ w₂ =>
+    subst t₁ t₃
+    let ⟨l₂, r₂, e₂⟩ := mem_constructor (p₁.subset (by simp) : a ∈ t₂)
+    subst t₂; exact (w₁ rfl rfl).trans (w₂ rfl rfl)
+
+theorem Perm.cons_inv {a : α} {l₁ l₂ : List α} : a :: l₁ ~ a :: l₂ → l₁ ~ l₂ :=
+  @perm_inv_core _ _ [] [] _ _
+
+theorem Perm.length_eq {l₁ l₂ : List α} (p : l₁ ~ l₂) : length l₁ = length l₂ := by
+  induction p with
+  | nil => simp
+  | cons _ _ ih => simp [ih]
+  | swap _ _ l => simp
+  | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂
+
+theorem Perm.eq_nil {l : List α} (p : l ~ []) : l = [] := eq_nil_of_length_eq_zero p.length_eq
+
+theorem Perm.nil_eq {l : List α} (p : [] ~ l) : [] = l := p.symm.eq_nil.symm
+
+theorem Perm.pairwise_iff {R : α → α → Prop} (S : ∀ {a b}, R a b → R b a) :
+    ∀ {l₁ l₂ : List α}, l₁ ~ l₂ → (Pairwise R l₁ ↔ Pairwise R l₂) := by
+  suffices ∀ {l₁ l₂}, l₁ ~ l₂ → Pairwise R l₁ → Pairwise R l₂ from
+    fun l₁ l₂ p => ⟨this p, this p.symm⟩
+  intros l₁ l₂ p d
+  induction d generalizing l₂ with
+  | nil => rw [← p.nil_eq]; constructor
+  | @cons a h d _ ih =>
+    obtain ⟨s₂, t₂, rfl⟩ := mem_constructor (p.subset (.head ..) : a ∈ l₂)
+    have p' := (p.trans perm_middle).cons_inv
+    exact (pairwise_middle_of_symm S).2 (Pairwise_cons.2 ⟨fun b m => d _ (p'.symm.subset m), ih p'⟩)
+
+theorem Perm.nodup_iff {l₁ l₂ : List α} : l₁ ~ l₂ → (Nodup l₁ ↔ Nodup l₂) :=
+  Perm.pairwise_iff <| @Ne.symm α
+
+end List

--- a/Std/Data/List/Perm.lean
+++ b/Std/Data/List/Perm.lean
@@ -90,6 +90,20 @@ theorem perm_insertNth {x : α} : ∀ {l : List α} {n : Nat}, n ≤ l.length �
 theorem Perm.mem_iff {a : α} {l₁ l₂ : List α} (h : l₁ ~ l₂) : a ∈ l₁ ↔ a ∈ l₂ :=
   Iff.intro (fun m => h.subset m) fun m => h.symm.subset m
 
+theorem Perm.append_right {l₁ l₂ : List α} (t : List α) (p : l₁ ~ l₂) : l₁++t ~ l₂++t :=
+  p.recOn
+    (Perm.refl ([] ++ t))
+    (fun x _ _ _ q => q.cons x)
+    (fun x y l => swap x y (l ++ t))
+    (fun _ _ q r => trans q r)
+
+theorem Perm.append_left {t₁ t₂ : List α} : ∀ (l : List α), t₁ ~ t₂ → l++t₁ ~ l++t₂
+  | [],    p => p
+  | x::xs, p => (append_left xs p).cons x
+
+theorem Perm.append {l₁ l₂ t₁ t₂ : List α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁++t₁ ~ l₂++t₂ :=
+  (p₁.append_right t₁).trans (p₂.append_left l₂)
+
 /-- The way Lean 4 computes the motive with `elabAsElim` has changed
 relative to the behaviour of `elab_as_eliminator` in Lean 3.
 See

--- a/Std/Logic.lean
+++ b/Std/Logic.lean
@@ -704,8 +704,8 @@ theorem Bool.eq_false_iff {b : Bool} : b = false ↔ b ≠ true :=
 theorem Bool.not_eq_true_iff_ne_true {b : Bool} : (!b) = true ↔ ¬(b = true) := by
   cases b <;> decide
 
-theorem Bool.not_bne_of_beq [BEq α] {a a' : α} : a == a' → a != a' → False :=
-  fun hEq hNe => Bool.not_eq_true_iff_ne_true.mp hNe hEq
+theorem Bool.bne_iff_not_beq [BEq α] {a a' : α} : a != a' ↔ ¬(a == a')  :=
+  Bool.not_eq_true_iff_ne_true
 
 /-! ## miscellaneous -/
 

--- a/Std/Logic.lean
+++ b/Std/Logic.lean
@@ -690,6 +690,23 @@ theorem apply_ite (f : α → β) (P : Prop) [Decidable P] (x y : α) :
 @[simp] theorem ite_not (P : Prop) [Decidable P] (x y : α) : ite (¬P) x y = ite P y x :=
   dite_not P (fun _ => x) (fun _ => y)
 
+/-! ## Booleans -/
+
+theorem false_ne_true : False ≠ True := fun h => h.symm ▸ trivial
+
+theorem Bool.eq_false_or_eq_true : (b : Bool) → b = true ∨ b = false
+  | true => .inl rfl
+  | false => .inr rfl
+
+theorem Bool.eq_false_iff {b : Bool} : b = false ↔ b ≠ true :=
+  ⟨ne_true_of_eq_false, eq_false_of_ne_true⟩
+
+theorem Bool.not_eq_true_iff_ne_true {b : Bool} : (!b) = true ↔ ¬(b = true) := by
+  cases b <;> decide
+
+theorem Bool.not_bne_of_beq [BEq α] {a a' : α} : a == a' → a != a' → False :=
+  fun hEq hNe => Bool.not_eq_true_iff_ne_true.mp hNe hEq
+
 /-! ## miscellaneous -/
 
 attribute [simp] inline
@@ -740,14 +757,5 @@ theorem subsingleton_iff_forall_eq (x : α) : Subsingleton α ↔ ∀ y, y = x :
 
 example [Subsingleton α] (p : α → Prop) : Subsingleton (Subtype p) :=
   ⟨fun ⟨x, _⟩ ⟨y, _⟩ => by congr; exact Subsingleton.elim x y⟩
-
-theorem false_ne_true : False ≠ True := fun h => h.symm ▸ trivial
-
-theorem Bool.eq_false_or_eq_true : (b : Bool) → b = true ∨ b = false
-  | true => .inl rfl
-  | false => .inr rfl
-
-theorem Bool.eq_false_iff {b : Bool} : b = false ↔ b ≠ true :=
-  ⟨ne_true_of_eq_false, eq_false_of_ne_true⟩
 
 theorem ne_comm {α} {a b : α} : a ≠ b ↔ b ≠ a := ⟨Ne.symm, Ne.symm⟩


### PR DESCRIPTION
- The PR includes a partial port of `List.Perm`. I was initially hoping to do a more principled port to mathport to begin with, but its dependency tree turned out to be a bit deep, so that might have to wait.