### PR TITLE
feat: add Lean.MVarId.tryClearMany'

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -43,6 +43,7 @@ import Std.Lean.AttributeExtra
 import Std.Lean.Command
 import Std.Lean.Delaborator
 import Std.Lean.Meta.Basic
+import Std.Lean.Meta.Clear
 import Std.Lean.Meta.Inaccessible
 import Std.Lean.Meta.InstantiateMVars
 import Std.Lean.Meta.SavedState

--- a/Std/Lean/Meta/Clear.lean
+++ b/Std/Lean/Meta/Clear.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Std.Lean.Meta.Basic
+
+open Lean Lean.Meta
+
+/--
+Try to clear the given fvars from the local context. Returns the new goal and
+the hypotheses that were cleared. Unlike `Lean.MVarId.tryClearMany`, this
+function does not require the `hyps` to be given in the order in which they
+appear in the local context.
+-/
+def Lean.MVarId.tryClearMany' (goal : MVarId) (hyps : Array FVarId) :
+    MetaM (MVarId × Array FVarId) :=
+  goal.withContext do
+    let hyps ← sortFVarsByContextOrder hyps
+    hyps.foldrM (init := (goal, Array.mkEmpty hyps.size))
+      λ h (goal, cleared) => do
+        let goal' ← goal.tryClear h
+        let cleared := if goal == goal' then cleared else cleared.push h
+        return (goal', cleared)


### PR DESCRIPTION
This is a variant of core's `tryClearMany` which sorts the given `FVarId`s by context order before trying to clear them. This makes sure we clear everything we can.

Depends on #42 