### PR TITLE
feat: add Lean.MVarId.assertHypotheses' 

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -40,6 +40,7 @@ import Std.Data.Rat.Lemmas
 import Std.Lean.AttributeExtra
 import Std.Lean.Command
 import Std.Lean.Delaborator
+import Std.Lean.Meta.AssertHypotheses
 import Std.Lean.Meta.Basic
 import Std.Lean.Meta.InstantiateMVars
 import Std.Lean.Meta.SavedState

--- a/Std/Lean/Meta/AssertHypotheses.lean
+++ b/Std/Lean/Meta/AssertHypotheses.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Std.Lean.Meta.Basic
+
+open Lean Lean.Meta
+
+namespace Lean.Meta
+
+/--
+Description of a hypothesis for `Lean.MVarId.assertHypotheses'`.
+-/
+structure Hypothesis' extends Hypothesis where
+  /-- The hypothesis' `BinderInfo` -/
+  binderInfo : BinderInfo
+  /-- The hypothesis' `LocalDeclKind` -/
+  kind : LocalDeclKind
+
+/--
+Add the given hypotheses to the local context. This is a generalisation of
+`Lean.MVarId.assertHypotheses` which lets you specify
+-/
+def _root_.Lean.MVarId.assertHypotheses' (mvarId : MVarId)
+    (hs : Array Hypothesis') : MetaM (Array FVarId × MVarId) := do
+  let (fvarIds, mvarId) ← mvarId.assertHypotheses $ hs.map (·.toHypothesis)
+  mvarId.modifyLCtx λ lctx => Id.run do
+    let mut lctx := lctx
+    for h : i in [:hs.size] do
+      let h := hs[i]'h.2
+      if h.kind != .default then
+        lctx := lctx.setKind fvarIds[i]! h.kind
+      if h.binderInfo != .default then
+        lctx := lctx.setBinderInfo fvarIds[i]! h.binderInfo
+    pure lctx
+  return (fvarIds, mvarId)
+
+end Lean.Meta


### PR DESCRIPTION
This is a variant of core's `assertHypotheses` which allows us to specify the `BinderInfo` and `LocalDeclKind` of the asserted hypotheses.

Depends on #42 