### PR TITLE
feat: add Lean.Meta.getUnusedNames

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -12,6 +12,7 @@ import Std.Data.Array.Init.Lemmas
 import Std.Data.Array.Lemmas
 import Std.Data.AssocList
 import Std.Data.BinomialHeap
+import Std.Data.Char
 import Std.Data.DList
 import Std.Data.Fin.Lemmas
 import Std.Data.HashMap

--- a/Std.lean
+++ b/Std.lean
@@ -37,12 +37,14 @@ import Std.Data.RBMap.WF
 import Std.Data.Rat
 import Std.Data.Rat.Basic
 import Std.Data.Rat.Lemmas
+import Std.Data.String
 import Std.Lean.AttributeExtra
 import Std.Lean.Command
 import Std.Lean.Delaborator
 import Std.Lean.Meta.Basic
 import Std.Lean.Meta.InstantiateMVars
 import Std.Lean.Meta.SavedState
+import Std.Lean.Meta.UnusedNames
 import Std.Lean.MonadBacktrack
 import Std.Lean.NameMapAttribute
 import Std.Lean.Parser

--- a/Std/Data/Char.lean
+++ b/Std/Data/Char.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Std.Tactic.RCases
+
+namespace Char
+
+private theorem csize_eq (c) :
+    String.csize c = 1 ∨ String.csize c = 2 ∨ String.csize c = 3 ∨
+    String.csize c = 4 := by
+  simp only [String.csize, utf8Size]
+  repeat (first | split | (solve | simp))
+
+theorem csize_pos (c) : 0 < String.csize c := by
+  rcases csize_eq c with _|_|_|_ <;> simp_all
+
+theorem csize_le_4 (c) : String.csize c ≤ 4 := by
+  rcases csize_eq c with _|_|_|_ <;> simp_all

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -444,6 +444,15 @@ theorem le_sub_iff_add_le {x y k : Nat} (h : k ≤ y) : x ≤ y - k ↔ x + k �
 theorem le_pred_of_lt {m n : Nat} (h : m < n) : m ≤ n - 1 :=
   Nat.sub_le_sub_right h 1
 
+protected theorem sub_add_lt_sub {n m k : Nat} (h₁ : m + k ≤ n) (h₂ : 0 < k) :
+    n - (m + k) < n - m :=
+  match k with
+  | zero => Nat.lt_irrefl _ h₂ |>.elim
+  | succ _ =>
+    Nat.lt_of_lt_of_le
+      (pred_lt (Nat.ne_of_lt $ Nat.sub_pos_of_lt $ lt_of_succ_le h₁).symm)
+      (Nat.sub_le_sub_left _ $ Nat.le_add_right _ _)
+
 /- mod -/
 
 theorem le_of_mod_lt {a b : Nat} (h : a % b < a) : b ≤ a :=

--- a/Std/Data/String.lean
+++ b/Std/Data/String.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+namespace String
+
+/--
+If `pre` is a prefix of `s`, i.e. `s = pre ++ t`, return the remainder `t`.
+-/
+def dropPrefix? (s : String) (pre : String) : Option Substring :=
+  let s := s.toSubstring
+  if s.take pre.length == pre.toSubstring then
+    s.drop pre.length
+  else
+    none
+
+end String

--- a/Std/Data/String.lean
+++ b/Std/Data/String.lean
@@ -4,16 +4,42 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
+import Std.Data.Char
+import Std.Data.Nat.Lemmas
+
+namespace Substring
+
+/--
+If `pre` is a prefix of `s`, i.e. `s = pre ++ t`, return the remainder `t`.
+-/
+def dropPrefix? (s : Substring) (pre : Substring) : Option Substring :=
+  go 0 (pre.stopPos - pre.startPos)
+where
+  /-- Auxiliary definition for `dropPrefix?`. -/
+  go (start : String.Pos) (stop : String.Pos) : Option Substring :=
+    if h : start ≥ stop then
+      some { s with startPos := s.startPos + start }
+    else
+      let cs := s.get start
+      let cp := pre.get start
+      if cs == cp then
+        have : start.byteIdx + String.csize cs ≤ stop.byteIdx + 4 :=
+          Nat.add_le_add (Nat.le_of_lt $ Nat.not_le.mp h) (Char.csize_le_4 _)
+        have : stop.byteIdx + 4 - (start.byteIdx + String.csize cs) <
+                stop.byteIdx + 4 - start.byteIdx :=
+          Nat.sub_add_lt_sub this (Char.csize_pos _)
+        go (start + cs) stop
+      else
+        none
+termination_by go start stop => stop.byteIdx + 4 - start.byteIdx
+
+end Substring
+
+
 namespace String
 
 /--
 If `pre` is a prefix of `s`, i.e. `s = pre ++ t`, return the remainder `t`.
 -/
 def dropPrefix? (s : String) (pre : String) : Option Substring :=
-  let s := s.toSubstring
-  if s.take pre.length == pre.toSubstring then
-    s.drop pre.length
-  else
-    none
-
-end String
+  s.toSubstring.dropPrefix? pre.toSubstring

--- a/Std/Lean/Meta/UnusedNames.lean
+++ b/Std/Lean/Meta/UnusedNames.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Lean.Meta
+import Std.Data.String
+
+open Lean Lean.Meta
+
+namespace Lean.Name
+
+private def parseIndexSuffix (s : Substring) : Option Nat :=
+  if s.isEmpty then
+    none
+  else if s.front == '_' then
+    s.drop 1 |>.toNat?
+  else
+    none
+
+/--
+Result type of `Lean.Name.matchUpToIndexSuffix`. See there for details.
+-/
+inductive MatchUpToIndexSuffix
+  /-- Exact match. -/
+  |  exactMatch
+  /-- No match. -/
+  | noMatch
+  /-- Match up to suffix. -/
+  | suffixMatch (i : Nat)
+
+/--
+Succeeds if `n` is equal to `query`, except `n` may have an additional `_i`
+suffix for some natural number `i`. More specifically:
+
+- If `n = query`, the result is `exactMatch`.
+- If `n = query ++ "_i"` for some natural number `i`, the result is
+  `suffixMatch i`.
+- Otherwise the result is `noMatch`.
+-/
+def matchUpToIndexSuffix (n : Name) (query : Name) :
+    MatchUpToIndexSuffix :=
+  match n, query with
+  | .str pre₁ s₁, .str pre₂ s₂ =>
+    if pre₁ != pre₂ then
+      .noMatch
+    else
+      if let some suffix := s₁.dropPrefix? s₂ then
+        if suffix.isEmpty then
+          .exactMatch
+        else
+          if let some i := parseIndexSuffix suffix then
+            .suffixMatch i
+          else
+            .noMatch
+      else
+        .noMatch
+  | n, query => if n == query then .exactMatch else .noMatch
+
+end Name
+
+
+namespace LocalContext
+
+/--
+Obtain the least natural number `i` such that `suggestion ++ "_i"` is an unused
+name in the given local context. If `suggestion` itself is unused, the result
+is `none`.
+-/
+def getUnusedUserNameIndex (lctx : LocalContext) (suggestion : Name) :
+    Option Nat := Id.run do
+  let mut minSuffix := none
+  for ldecl in lctx do
+    let hypName := ldecl.userName
+    if hypName.hasMacroScopes then
+      continue
+    match ldecl.userName.matchUpToIndexSuffix suggestion with
+    | .exactMatch => minSuffix := updateMinSuffix minSuffix 1
+    | .noMatch => continue
+    | .suffixMatch i => minSuffix := updateMinSuffix minSuffix (i + 1)
+  minSuffix
+where
+  /-- Auxiliary definition for `getUnusedUserNameIndex`. -/
+  @[inline]
+  updateMinSuffix : Option Nat → Nat → Option Nat
+    | none, j => some j
+    | some i, j => some $ i.max j
+
+/--
+Obtain a name `n` such that `n` is unused in the given local context and
+`suggestion` is a prefix of `n`. This is similar to `getUnusedName` but uses
+a different algorithm which may or may not be faster.
+-/
+def getUnusedUserName (lctx : LocalContext) (suggestion : Name) : Name :=
+  let suggestion := suggestion.eraseMacroScopes
+  match lctx.getUnusedUserNameIndex suggestion with
+  | none => suggestion
+  | some i => suggestion.appendIndexAfter i
+
+/--
+Obtain `n` distinct names such that each name is unused in the given local
+context and `suggestion` is a prefix of each name.
+-/
+def getUnusedUserNames (lctx : LocalContext) (n : Nat) (suggestion : Name) :
+    Array Name :=
+  if n == 0 then
+    #[]
+  else
+    let suggestion := suggestion.eraseMacroScopes
+    let acc := Array.mkEmpty n
+    match lctx.getUnusedUserNameIndex suggestion with
+    | none => loop (acc.push suggestion) (n - 1) 1
+    | some i => loop acc n i
+where
+  /-- Auxiliary definition for `getUnusedUserNames`. -/
+  loop (acc : Array Name) (n i : Nat) : Array Name :=
+    match n with
+    | 0 => acc
+    | n + 1 => loop (acc.push $ suggestion.appendIndexAfter i) n (i + 1)
+
+end Lean.LocalContext
+
+
+namespace Lean.Meta
+
+/--
+Obtain a name `n` such that `n` is unused in the current local context and
+`suggestion` is a prefix of `n`.
+-/
+def getUnusedUserName [Monad m] [MonadLCtx m] (suggestion : Name) : m Name :=
+  return (← getLCtx).getUnusedUserName suggestion
+
+/--
+Obtain `n` distinct names such that each name is unused in the current local
+context and `suggestion` is a prefix of each name.
+-/
+def getUnusedUserNames [Monad m] [MonadLCtx m] (n : Nat) (suggestion : Name) :
+    m (Array Name) :=
+  return (← getLCtx).getUnusedUserNames n suggestion


### PR DESCRIPTION
This is a variant of `LocalContext.getUnusedName` which (a) may or may not be more efficient and (b) allows us to get multiple unused names in one go.