### PR TITLE
chore: add doc-gen4 facet to lakefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ will be located at `build/doc/Std.html`.
 Note that documentation for the latest nightly of `std4` is available as part of [the Mathlib 4
 documentation][mathlib4 docs].
 
-[std4 docs]: https://leanprover-community.github.io/mathlib4_docs/Std.html
+[mathlib4 docs]: https://leanprover-community.github.io/mathlib4_docs/Std.html

--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ Work in progress standard library for Lean 4. This is a collection of data struc
   find Std -name "*.lean" | env LC_ALL=C sort | sed 's/\.lean//;s,/,.,g;s/^/import /' > Std.lean
   ```
   (or use `scripts/updateStd.sh` which contains this command).
+
+# Documentation
+
+You can generate `std4`'s documentation with `lake -Kdoc=on build Std:docs`. The top-level HTML file
+will be located at `build/doc/Std.html`.
+
+Note that documentation for the latest nightly of `std4` is available as part of [the Mathlib 4
+documentation][mathlib4 docs].
+
+[std4 docs]: https://leanprover-community.github.io/mathlib4_docs/Std.html

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -13,3 +13,6 @@ lean_lib Std
 lean_exe runLinter where
   root := `scripts.runLinter
   supportInterpreter := true
+
+meta if get_config? doc = some "on" then
+require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"


### PR DESCRIPTION
Generate documentation with `lake -Kdoc=on build Std:docs`.

- [x] add explanation in the readme

See also the [relevant zulip thread][zulip].

[zulip]: https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/local.20documentation.3F