### PR TITLE
feat: add Array.{equalSet,qsortOrd,min,max}

### DIFF
--- a/Std/Data/Array/Basic.lean
+++ b/Std/Data/Array/Basic.lean
@@ -44,7 +44,7 @@ set_option linter.unusedVariables.funArgs false in
 /--
 Sort an array using `compare` to compare elements.
 -/
-def qsortOrd [Inhabited α] [ord : Ord α] (xs : Array α) : Array α :=
+def qsortOrd [ord : Ord α] (xs : Array α) : Array α :=
   xs.qsort λ x y => compare x y |>.isLT
 
 set_option linter.unusedVariables.funArgs false in

--- a/Std/Data/Array/Basic.lean
+++ b/Std/Data/Array/Basic.lean
@@ -40,82 +40,82 @@ arrays, remove duplicates and then compare them elementwise.
 def equalSet [BEq α] (xs ys : Array α) : Bool :=
   xs.all (ys.contains ·) && ys.all (xs.contains ·)
 
-set_option linter.unusedVariables false in
+set_option linter.unusedVariables.funArgs false in
 /--
 Sort an array using `compare` to compare elements.
 -/
 def qsortOrd [Inhabited α] [ord : Ord α] (xs : Array α) : Array α :=
   xs.qsort λ x y => compare x y |>.isLT
 
-set_option linter.unusedVariables false in
+set_option linter.unusedVariables.funArgs false in
 /--
 Find the first minimal element of an array. If the array is empty, `d` is
 returned. If `start` and `stop` are given, only the subarray `xs[start:stop]` is
 considered.
 -/
 @[inline]
-protected def minD [ord : Ord α] (d : α) (xs : Array α) (start := 0)
-    (stop := xs.size) : α :=
+protected def minD [ord : Ord α]
+    (xs : Array α) (d : α) (start := 0) (stop := xs.size) : α :=
   xs.foldl (init := d) (start := start) (stop := stop) λ min x =>
     if compare x min |>.isLT then x else min
 
-set_option linter.unusedVariables false in
+set_option linter.unusedVariables.funArgs false in
 /--
 Find the first minimal element of an array. If the array is empty, `none` is
 returned. If `start` and `stop` are given, only the subarray `xs[start:stop]` is
 considered.
 -/
 @[inline]
-protected def min? [ord : Ord α] (xs : Array α) (start := 0)
-    (stop := xs.size) : Option α :=
+protected def min? [ord : Ord α]
+    (xs : Array α) (start := 0) (stop := xs.size) : Option α :=
   if h : start < xs.size then
     some $ xs.minD (xs.get ⟨start, h⟩) start stop
   else
     none
 
-set_option linter.unusedVariables false in
+set_option linter.unusedVariables.funArgs false in
 /--
 Find the first minimal element of an array. If the array is empty, `default` is
 returned. If `start` and `stop` are given, only the subarray `xs[start:stop]` is
 considered.
 -/
 @[inline]
-protected def min [ord : Ord α] [Inhabited α] (xs : Array α) (start := 0)
-    (stop := xs.size) : α :=
+protected def minI [ord : Ord α] [Inhabited α]
+    (xs : Array α) (start := 0) (stop := xs.size) : α :=
   xs.minD default start stop
 
-set_option linter.unusedVariables false in
+set_option linter.unusedVariables.funArgs false in
 /--
 Find the first maximal element of an array. If the array is empty, `d` is
 returned. If `start` and `stop` are given, only the subarray `xs[start:stop]` is
 considered.
 -/
 @[inline]
-protected def maxD [ord : Ord α] (d : α) (xs : Array α) (start := 0)
-    (stop := xs.size) : α :=
+protected def maxD [ord : Ord α]
+    (xs : Array α) (d : α) (start := 0) (stop := xs.size) : α :=
   xs.minD (ord := ord.opposite) d start stop
 
-set_option linter.unusedVariables false in
+set_option linter.unusedVariables.funArgs false in
 /--
 Find the first maximal element of an array. If the array is empty, `none` is
 returned. If `start` and `stop` are given, only the subarray `xs[start:stop]` is
 considered.
 -/
 @[inline]
-protected def max? [ord : Ord α] (xs : Array α) (start := 0)
-    (stop := xs.size) : Option α :=
+protected def max? [ord : Ord α]
+    (xs : Array α) (start := 0) (stop := xs.size) : Option α :=
   xs.min? (ord := ord.opposite) start stop
 
-set_option linter.unusedVariables false in
+set_option linter.unusedVariables.funArgs false in
 /--
 Find the first maximal element of an array. If the array is empty, `default` is
 returned. If `start` and `stop` are given, only the subarray `xs[start:stop]` is
 considered.
 -/
 @[inline]
-protected def max [ord : Ord α] [Inhabited α] (xs : Array α) (start := 0)
-    (stop := xs.size) : α :=
-  xs.min (ord := ord.opposite) start stop
+protected def maxI [ord : Ord α] [Inhabited α]
+    (xs : Array α) (start := 0) (stop := xs.size) : α :=
+  xs.minI (ord := ord.opposite) start stop
 
 end Array
 


### PR DESCRIPTION
---
Depends on #48 

The `max`/`min` variants use a convention which I've established in my own code: `Ord` instances (and `BEq`, `LT` etc.) are always named. This makes it easy to give a non-standard order, but it makes the unused arguments linter unhappy.