### PR TITLE
feat: more API for Lean.{Persistent,}Hash{Map,Set}

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -44,6 +44,8 @@ import Std.Lean.AttributeExtra
 import Std.Lean.Command
 import Std.Lean.Delaborator
 import Std.Lean.Expr
+import Std.Lean.HashMap
+import Std.Lean.HashSet
 import Std.Lean.Meta.AssertHypotheses
 import Std.Lean.Meta.Basic
 import Std.Lean.Meta.Clear
@@ -55,6 +57,8 @@ import Std.Lean.Meta.UnusedNames
 import Std.Lean.MonadBacktrack
 import Std.Lean.NameMapAttribute
 import Std.Lean.Parser
+import Std.Lean.PersistentHashMap
+import Std.Lean.PersistentHashSet
 import Std.Lean.Tactic
 import Std.Lean.TagAttribute
 import Std.Linter

--- a/Std/Data/HashMap/Basic.lean
+++ b/Std/Data/HashMap/Basic.lean
@@ -316,7 +316,12 @@ instance : GetElem (HashMap α β) α (Option β) fun _ _ => True where
 
 /-- Combines two hashmaps using function `f` to combine two values at a key. -/
 @[inline] def mergeWith (f : α → β → β → β) (self other : HashMap α β) : HashMap α β :=
-  Id.run (mergeWithM f self other)
+  -- Implementing this function directly, rather than via `mergeWithM`, gives
+  -- us less constrained universes.
+  other.fold (init := self) λ map k v₂ =>
+    match map.find? k with
+    | none => map.insert k v₂
+    | some v₁ => map.insert k $ f k v₁ v₂
 
 /-- Runs a monadic function over the elements in the map (in arbitrary order). -/
 @[inline] def forM [Monad m] (f : α → β → m PUnit) (self : HashMap α β) : m PUnit := self.1.forM f

--- a/Std/Lean/HashMap.lean
+++ b/Std/Lean/HashMap.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Lean.Data.HashMap
+
+namespace Lean.HashMap
+
+variable [BEq α] [Hashable α]
+
+instance : ForIn m (HashMap α β) (α × β) where
+  forIn m init f := do
+    let mut acc := init
+    for buckets in m.val.buckets.val do
+      for d in buckets do
+        match ← f d acc with
+        | .done b => return b
+        | .yield b => acc := b
+    return acc
+
+/--
+Merge two `HashMap`s. The values of keys which appear in both maps are combined
+using the monadic function `f`.
+-/
+@[specialize]
+def mergeWithM {m α β} [BEq α] [Hashable α] [Monad m] (f : α → β → β → m β)
+    (self other : HashMap α β) : m (HashMap α β) :=
+  other.foldM (init := self) λ map k v₂ =>
+    match map.find? k with
+    | none => return map.insert k v₂
+    | some v₁ => return map.insert k (← f k v₁ v₂)
+
+/--
+Merge two `HashMap`s. The values of keys which appear in both maps are combined
+using `f`.
+-/
+@[inline]
+def mergeWith (f : α → β → β → β) (self other : HashMap α β) : HashMap α β :=
+  -- Implementing this function directly, rather than via `mergeWithM`, gives
+  -- us less constrained universes.
+  other.fold (init := self) λ map k v₂ =>
+    match map.find? k with
+    | none => map.insert k v₂
+    | some v₁ => map.insert k $ f k v₁ v₂

--- a/Std/Lean/HashMap.lean
+++ b/Std/Lean/HashMap.lean
@@ -21,26 +21,26 @@ instance : ForIn m (HashMap α β) (α × β) where
     return acc
 
 /--
-Merge two `HashMap`s. The values of keys which appear in both maps are combined
-using the monadic function `f`.
+`O(|other|)` amortized. Merge two `HashMap`s.
+The values of keys which appear in both maps are combined using the monadic function `f`.
 -/
 @[specialize]
 def mergeWithM {m α β} [BEq α] [Hashable α] [Monad m] (f : α → β → β → m β)
     (self other : HashMap α β) : m (HashMap α β) :=
-  other.foldM (init := self) λ map k v₂ =>
+  other.foldM (init := self) fun map k v₂ =>
     match map.find? k with
     | none => return map.insert k v₂
     | some v₁ => return map.insert k (← f k v₁ v₂)
 
 /--
-Merge two `HashMap`s. The values of keys which appear in both maps are combined
-using `f`.
+`O(|other|)` amortized. Merge two `HashMap`s.
+The values of keys which appear in both maps are combined using `f`.
 -/
 @[inline]
 def mergeWith (f : α → β → β → β) (self other : HashMap α β) : HashMap α β :=
   -- Implementing this function directly, rather than via `mergeWithM`, gives
   -- us less constrained universes.
-  other.fold (init := self) λ map k v₂ =>
+  other.fold (init := self) fun map k v₂ =>
     match map.find? k with
     | none => map.insert k v₂
-    | some v₁ => map.insert k $ f k v₁ v₂
+    | some v₁ => map.insert k <| f k v₁ v₂

--- a/Std/Lean/HashSet.lean
+++ b/Std/Lean/HashSet.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Lean.Data.HashSet
+
+namespace Lean.HashSet
+
+variable [BEq α] [Hashable α]
+
+/--
+Returns `true` if `f` returns `true` for any element of the set.
+-/
+@[specialize]
+def anyM [Monad m] (s : HashSet α) (f : α → m Bool) : m Bool := do
+  for a in s do
+    if ← f a then
+      return true
+  return false
+
+/--
+Returns `true` if `f` returns `true` for any element of the set.
+-/
+@[inline]
+def any (s : HashSet α) (f : α → Bool) : Bool :=
+  Id.run $ s.anyM f
+
+/--
+Returns `true` if `f` returns `true` for all elements of the set.
+-/
+@[specialize]
+def allM [Monad m] (s : HashSet α) (f : α → m Bool) : m Bool := do
+  for a in s do
+    if ! (← f a) then
+      return false
+  return true
+
+/--
+Returns `true` if `f` returns `true` for all elements of the set.
+-/
+@[inline]
+def all (s : HashSet α) (f : α → Bool) : Bool :=
+  Id.run $ s.allM f
+
+instance : BEq (HashSet α) where
+  beq s t := s.all (t.contains ·) && t.all (s.contains ·)
+
+/--
+Similar to `insert`, but also returns a Boolean flad indicating whether an
+existing entry has been replaced with `a ↦ b`.
+-/
+@[inline]
+def insert' (s : HashSet α) (a : α) : HashSet α × Bool :=
+  let oldSize := s.size
+  let s := s.insert a
+  (s, s.size == oldSize)
+
+/--
+Obtain a `HashSet` from an array.
+-/
+@[inline]
+protected def ofArray [BEq α] [Hashable α] (as : Array α) : HashSet α :=
+  HashSet.empty.insertMany as
+
+/--
+Obtain a `HashSet` from a list.
+-/
+@[inline]
+protected def ofList [BEq α] [Hashable α] (as : Array α) : HashSet α :=
+  HashSet.empty.insertMany as
+
+/--
+Merge two `HashSet`s.
+-/
+@[inline]
+def merge {α : Type u} [BEq α] [Hashable α] (s t : HashSet α) : HashSet α :=
+  t.fold (init := s) λ s a => s.insert a
+  -- We don't use `insertMany` here because it gives weird universes.

--- a/Std/Lean/HashSet.lean
+++ b/Std/Lean/HashSet.lean
@@ -11,7 +11,7 @@ namespace Lean.HashSet
 variable [BEq α] [Hashable α]
 
 /--
-Returns `true` if `f` returns `true` for any element of the set.
+`O(n)`. Returns `true` if `f` returns `true` for any element of the set.
 -/
 @[specialize]
 def anyM [Monad m] (s : HashSet α) (f : α → m Bool) : m Bool := do
@@ -21,34 +21,34 @@ def anyM [Monad m] (s : HashSet α) (f : α → m Bool) : m Bool := do
   return false
 
 /--
-Returns `true` if `f` returns `true` for any element of the set.
+`O(n)`. Returns `true` if `f` returns `true` for any element of the set.
 -/
 @[inline]
 def any (s : HashSet α) (f : α → Bool) : Bool :=
-  Id.run $ s.anyM f
+  Id.run <| s.anyM f
 
 /--
-Returns `true` if `f` returns `true` for all elements of the set.
+`O(n)`. Returns `true` if `f` returns `true` for all elements of the set.
 -/
 @[specialize]
 def allM [Monad m] (s : HashSet α) (f : α → m Bool) : m Bool := do
   for a in s do
-    if ! (← f a) then
+    if !(← f a) then
       return false
   return true
 
 /--
-Returns `true` if `f` returns `true` for all elements of the set.
+`O(n)`. Returns `true` if `f` returns `true` for all elements of the set.
 -/
 @[inline]
 def all (s : HashSet α) (f : α → Bool) : Bool :=
-  Id.run $ s.allM f
+  Id.run <| s.allM f
 
 instance : BEq (HashSet α) where
   beq s t := s.all (t.contains ·) && t.all (s.contains ·)
 
 /--
-Similar to `insert`, but also returns a Boolean flad indicating whether an
+`O(1)` amortized. Similar to `insert`, but also returns a Boolean flag indicating whether an
 existing entry has been replaced with `a ↦ b`.
 -/
 @[inline]
@@ -58,23 +58,23 @@ def insert' (s : HashSet α) (a : α) : HashSet α × Bool :=
   (s, s.size == oldSize)
 
 /--
-Obtain a `HashSet` from an array.
+`O(n)`. Obtain a `HashSet` from an array.
 -/
 @[inline]
 protected def ofArray [BEq α] [Hashable α] (as : Array α) : HashSet α :=
   HashSet.empty.insertMany as
 
 /--
-Obtain a `HashSet` from a list.
+`O(n)`. Obtain a `HashSet` from a list.
 -/
 @[inline]
 protected def ofList [BEq α] [Hashable α] (as : Array α) : HashSet α :=
   HashSet.empty.insertMany as
 
 /--
-Merge two `HashSet`s.
+`O(|t|)` amortized. Merge two `HashSet`s.
 -/
 @[inline]
 def merge {α : Type u} [BEq α] [Hashable α] (s t : HashSet α) : HashSet α :=
-  t.fold (init := s) λ s a => s.insert a
+  t.fold (init := s) fun s a => s.insert a
   -- We don't use `insertMany` here because it gives weird universes.

--- a/Std/Lean/PersistentHashMap.lean
+++ b/Std/Lean/PersistentHashMap.lean
@@ -11,11 +11,10 @@ namespace Lean.PersistentHashMap
 variable [BEq α] [Hashable α]
 
 /--
-Similar to `insert`, but also returns a Boolean flad indicating whether an
+Similar to `insert`, but also returns a Boolean flag indicating whether an
 existing entry has been replaced with `a ↦ b`.
 -/
-def insert' (m : PersistentHashMap α β) (a : α) (b : β) :
-    PersistentHashMap α β × Bool :=
+def insert' (m : PersistentHashMap α β) (a : α) (b : β) : PersistentHashMap α β × Bool :=
   let oldSize := m.size
   let m := m.insert a b
   (m, m.size == oldSize)
@@ -24,14 +23,14 @@ def insert' (m : PersistentHashMap α β) (a : α) (b : β) :
 Turns a `PersistentHashMap` into an array of key-value pairs.
 -/
 def toArray (m : PersistentHashMap α β) : Array (α × β) :=
-  m.foldl (init := Array.mkEmpty m.size) λ xs k v => xs.push (k, v)
+  m.foldl (init := Array.mkEmpty m.size) fun xs k v => xs.push (k, v)
 
 /--
 Builds a `PersistentHashMap` from a list of key-value pairs. Values of
 duplicated keys are replaced by their respective last occurrences.
 -/
 def ofList (xs : List (α × β)) : PersistentHashMap α β :=
-  xs.foldl (init := {}) λ m (k, v) => m.insert k v
+  xs.foldl (init := {}) fun m (k, v) => m.insert k v
 
 /--
 Variant of `ofList` which accepts a function that combines values of duplicated
@@ -39,17 +38,17 @@ keys.
 -/
 def ofListWith (xs : List (α × β)) (f : α → β → β → β) :
     PersistentHashMap α β :=
-  xs.foldl (init := {}) λ m (k, v) =>
+  xs.foldl (init := {}) fun m (k, v) =>
     match m.find? k with
     | none    => m.insert k v
-    | some v' => m.insert k $ f k v v'
+    | some v' => m.insert k <| f k v v'
 
 /--
 Builds a `PersistentHashMap` from an array of key-value pairs. Values of
 duplicated keys are replaced by their respective last occurrences.
 -/
 def ofArray (xs : Array (α × β)) : PersistentHashMap α β :=
-  xs.foldl (init := {}) λ m (k, v) => m.insert k v
+  xs.foldl (init := {}) fun m (k, v) => m.insert k v
 
 /--
 Variant of `ofArray` which accepts a function that combines values of duplicated
@@ -57,10 +56,10 @@ keys.
 -/
 def ofArrayWith (xs : Array (α × β)) (f : α → β → β → β) :
     PersistentHashMap α β :=
-  xs.foldl (init := {}) λ m (k, v) =>
+  xs.foldl (init := {}) fun m (k, v) =>
     match m.find? k with
     | none    => m.insert k v
-    | some v' => m.insert k $ f k v v'
+    | some v' => m.insert k <| f k v v'
 
 /--
 Merge two `PersistentHashMap`s. The values of keys which appear in both maps are
@@ -69,7 +68,7 @@ combined using the monadic function `f`.
 @[specialize]
 def mergeWithM [Monad m] (self other : PersistentHashMap α β)
     (f : α → β → β → m β) : m (PersistentHashMap α β) :=
-  other.foldlM (init := self) λ map k v₂ =>
+  other.foldlM (init := self) fun map k v₂ =>
     match map.find? k with
     | none => return map.insert k v₂
     | some v₁ => return map.insert k (← f k v₁ v₂)
@@ -83,7 +82,7 @@ def mergeWith (self other : PersistentHashMap α β) (f : α → β → β → �
     PersistentHashMap α β :=
   -- Implementing this function directly, rather than via `mergeWithM`, gives
   -- us less constrained universes.
-  other.foldl (init := self) λ map k v₂ =>
+  other.foldl (init := self) fun map k v₂ =>
     match map.find? k with
     | none => map.insert k v₂
-    | some v₁ => map.insert k $ f k v₁ v₂
+    | some v₁ => map.insert k <| f k v₁ v₂

--- a/Std/Lean/PersistentHashMap.lean
+++ b/Std/Lean/PersistentHashMap.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Lean.Data.PersistentHashMap
+
+namespace Lean.PersistentHashMap
+
+variable [BEq α] [Hashable α]
+
+/--
+Similar to `insert`, but also returns a Boolean flad indicating whether an
+existing entry has been replaced with `a ↦ b`.
+-/
+def insert' (m : PersistentHashMap α β) (a : α) (b : β) :
+    PersistentHashMap α β × Bool :=
+  let oldSize := m.size
+  let m := m.insert a b
+  (m, m.size == oldSize)
+
+/--
+Turns a `PersistentHashMap` into an array of key-value pairs.
+-/
+def toArray (m : PersistentHashMap α β) : Array (α × β) :=
+  m.foldl (init := Array.mkEmpty m.size) λ xs k v => xs.push (k, v)
+
+/--
+Builds a `PersistentHashMap` from a list of key-value pairs. Values of
+duplicated keys are replaced by their respective last occurrences.
+-/
+def ofList (xs : List (α × β)) : PersistentHashMap α β :=
+  xs.foldl (init := {}) λ m (k, v) => m.insert k v
+
+/--
+Variant of `ofList` which accepts a function that combines values of duplicated
+keys.
+-/
+def ofListWith (xs : List (α × β)) (f : α → β → β → β) :
+    PersistentHashMap α β :=
+  xs.foldl (init := {}) λ m (k, v) =>
+    match m.find? k with
+    | none    => m.insert k v
+    | some v' => m.insert k $ f k v v'
+
+/--
+Builds a `PersistentHashMap` from an array of key-value pairs. Values of
+duplicated keys are replaced by their respective last occurrences.
+-/
+def ofArray (xs : Array (α × β)) : PersistentHashMap α β :=
+  xs.foldl (init := {}) λ m (k, v) => m.insert k v
+
+/--
+Variant of `ofArray` which accepts a function that combines values of duplicated
+keys.
+-/
+def ofArrayWith (xs : Array (α × β)) (f : α → β → β → β) :
+    PersistentHashMap α β :=
+  xs.foldl (init := {}) λ m (k, v) =>
+    match m.find? k with
+    | none    => m.insert k v
+    | some v' => m.insert k $ f k v v'
+
+/--
+Merge two `PersistentHashMap`s. The values of keys which appear in both maps are
+combined using the monadic function `f`.
+-/
+@[specialize]
+def mergeWithM [Monad m] (self other : PersistentHashMap α β)
+    (f : α → β → β → m β) : m (PersistentHashMap α β) :=
+  other.foldlM (init := self) λ map k v₂ =>
+    match map.find? k with
+    | none => return map.insert k v₂
+    | some v₁ => return map.insert k (← f k v₁ v₂)
+
+/--
+Merge two `PersistentHashMap`s. The values of keys which appear in both maps are
+combined using `f`.
+-/
+@[inline]
+def mergeWith (self other : PersistentHashMap α β) (f : α → β → β → β) :
+    PersistentHashMap α β :=
+  -- Implementing this function directly, rather than via `mergeWithM`, gives
+  -- us less constrained universes.
+  other.foldl (init := self) λ map k v₂ =>
+    match map.find? k with
+    | none => map.insert k v₂
+    | some v₁ => map.insert k $ f k v₁ v₂

--- a/Std/Lean/PersistentHashSet.lean
+++ b/Std/Lean/PersistentHashSet.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2022 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Lean.Data.PersistentHashSet
+
+namespace Lean.PersistentHashSet
+
+variable [BEq α] [Hashable α]
+
+instance : ForIn m (PersistentHashSet α) α where
+  forIn s init step := do
+    let mut state := init
+    for (k, _) in s.set do
+      match ← step k state with
+      | .done state' => return state'
+      | .yield state' => state := state'
+    return state
+
+/--
+Returns `true` if `f` returns `true` for any element of the set.
+-/
+@[specialize]
+def anyM [Monad m] (s : PersistentHashSet α) (f : α → m Bool) : m Bool := do
+  for a in s do
+    if ← f a then
+      return true
+  return false
+
+/--
+Returns `true` if `f` returns `true` for any element of the set.
+-/
+@[inline]
+def any (s : PersistentHashSet α) (f : α → Bool) : Bool :=
+  Id.run $ s.anyM f
+
+/--
+Returns `true` if `f` returns `true` for all elements of the set.
+-/
+@[specialize]
+def allM [Monad m] (s : PersistentHashSet α) (f : α → m Bool) : m Bool := do
+  for a in s do
+    if ! (← f a) then
+      return false
+  return true
+
+/--
+Returns `true` if `f` returns `true` for all elements of the set.
+-/
+@[inline]
+def all (s : PersistentHashSet α) (f : α → Bool) : Bool :=
+  Id.run $ s.allM f
+
+instance : BEq (PersistentHashSet α) where
+  beq s t := s.all (t.contains ·) && t.all (s.contains ·)
+
+/--
+Similar to `insert`, but also returns a Boolean flad indicating whether an
+existing entry has been replaced with `a ↦ b`.
+-/
+@[inline]
+def insert' (s : PersistentHashSet α) (a : α) : PersistentHashSet α × Bool :=
+  let oldSize := s.size
+  let s := s.insert a
+  (s, s.size == oldSize)
+
+/--
+Insert all elements from a collection into a `PersistentHashSet`.
+-/
+def insertMany [ForIn Id ρ α] (s : PersistentHashSet α) (as : ρ) :
+    PersistentHashSet α := Id.run do
+  let mut s := s
+  for a in as do
+    s := s.insert a
+  return s
+
+/--
+Obtain a `PersistentHashSet` from an array.
+-/
+@[inline]
+protected def ofArray [BEq α] [Hashable α] (as : Array α) :
+    PersistentHashSet α :=
+  PersistentHashSet.empty.insertMany as
+
+/--
+Obtain a `PersistentHashSet` from a list.
+-/
+@[inline]
+protected def ofList [BEq α] [Hashable α] (as : Array α) :
+    PersistentHashSet α :=
+  PersistentHashSet.empty.insertMany as
+
+/--
+Merge two `PersistentHashSet`s.
+-/
+@[inline]
+def merge (s t : PersistentHashSet α) : PersistentHashSet α :=
+  s.insertMany t

--- a/Std/Lean/PersistentHashSet.lean
+++ b/Std/Lean/PersistentHashSet.lean
@@ -34,7 +34,7 @@ Returns `true` if `f` returns `true` for any element of the set.
 -/
 @[inline]
 def any (s : PersistentHashSet α) (f : α → Bool) : Bool :=
-  Id.run $ s.anyM f
+  Id.run <| s.anyM f
 
 /--
 Returns `true` if `f` returns `true` for all elements of the set.
@@ -51,13 +51,13 @@ Returns `true` if `f` returns `true` for all elements of the set.
 -/
 @[inline]
 def all (s : PersistentHashSet α) (f : α → Bool) : Bool :=
-  Id.run $ s.allM f
+  Id.run <| s.allM f
 
 instance : BEq (PersistentHashSet α) where
   beq s t := s.all (t.contains ·) && t.all (s.contains ·)
 
 /--
-Similar to `insert`, but also returns a Boolean flad indicating whether an
+Similar to `insert`, but also returns a Boolean flag indicating whether an
 existing entry has been replaced with `a ↦ b`.
 -/
 @[inline]
@@ -80,16 +80,14 @@ def insertMany [ForIn Id ρ α] (s : PersistentHashSet α) (as : ρ) :
 Obtain a `PersistentHashSet` from an array.
 -/
 @[inline]
-protected def ofArray [BEq α] [Hashable α] (as : Array α) :
-    PersistentHashSet α :=
+protected def ofArray [BEq α] [Hashable α] (as : Array α) : PersistentHashSet α :=
   PersistentHashSet.empty.insertMany as
 
 /--
 Obtain a `PersistentHashSet` from a list.
 -/
 @[inline]
-protected def ofList [BEq α] [Hashable α] (as : Array α) :
-    PersistentHashSet α :=
+protected def ofList [BEq α] [Hashable α] (as : Array α) : PersistentHashSet α :=
   PersistentHashSet.empty.insertMany as
 
 /--


### PR DESCRIPTION
With the changes in this commit, the APIs for the various set and map types are consistent:

- Lean.HashMap and Lean.PersistentHashMap have the same API as Std.Data.HashMap and Std.Data.PersistentHashMap.
- Lean.HashSet has the same API as Lean.PersistentHashSet.