### PR TITLE
fix: ignore optParam in simpNF conditional detection

### DIFF
--- a/Std/Tactic/Lint/Simp.lean
+++ b/Std/Tactic/Lint/Simp.lean
@@ -38,7 +38,8 @@ def isConditionalHyps (lhs : Expr) : List Expr → MetaM Bool
   | h :: hs => do
     let ldecl ← getFVarLocalDecl h
     if !ldecl.binderInfo.isInstImplicit
-        && !(← hs.anyM fun h' => do pure $ (← inferType h').containsFVar h.fvarId!)
+        && !(← hs.anyM fun h' =>
+          return (← inferType h').consumeTypeAnnotations.containsFVar h.fvarId!)
         && !lhs.containsFVar h.fvarId! then
       return true
     isConditionalHyps lhs hs


### PR DESCRIPTION
This fixes an issue discovered in leanprover-community/mathlib4#966.