### PR TITLE
feat: add `LawfulAlternative` class

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -1,6 +1,7 @@
 import Std.Classes.BEq
 import Std.Classes.Cast
 import Std.Classes.Dvd
+import Std.Classes.LawfulAlternative
 import Std.Classes.LawfulMonad
 import Std.Classes.Order
 import Std.Classes.RatCast

--- a/Std/Classes/LawfulAlternative.lean
+++ b/Std/Classes/LawfulAlternative.lean
@@ -1,17 +1,21 @@
 import Std.Classes.LawfulMonad
+import Lean.Linter
 
-/-- combination class of `Monad` and `Alternative` with a common `Applicative` component -/
+/-- Combination class of `Monad` and `Alternative` with a common `Applicative` component -/
 class MonadAlternative (m : Type _ → Type _) extends Monad m, Alternative m
 
-/-- basic laws for `Alternative` -/
+-- Missing docs in core
+attribute [nolint docBlame] MonadAlternative.failure MonadAlternative.orElse
+
+/-- Basic laws for `Alternative` -/
 class LawfulAlternative (f : Type _ → Type _) [Alternative f] extends LawfulApplicative f : Prop where
-  /-- map failure is failure -/
+  /-- Map failure is failure -/
   map_failure (g : α → β) : g <$> (failure : f α) = failure
-  /-- map distributes over `orElse` -/
+  /-- Map distributes over `orElse` -/
   map_orElse (g : α → b) (x y : f α) : g <$> (x <|> y) = (g <$> x <|> g <$> y)
-  /-- failure is left identity for `orElse`  -/
+  /-- Failure is a left identity for `orElse`  -/
   failure_orElse (x : f α) : (failure <|> x) = x
-  /-- failure is right identity for `orElse` -/
+  /-- Failure is a right identity for `orElse` -/
   orElse_failure (x : f α) : (x <|> failure) = x
   /-- `orElse` is associative -/
   orElse_assoc (x y z : f α) : (x <|> (y <|> z)) = ((x <|> y) <|> z)
@@ -20,7 +24,7 @@ class LawfulAlternative (f : Type _ → Type _) [Alternative f] extends LawfulAp
 
 export LawfulAlternative (map_failure map_orElse failure_orElse orElse_failure orElse_assoc pure_orElse)
 
-attribute [simp] map_failure failure_orElse orElse_failure pure_orElse
+attribute [simp] map_failure failure_orElse pure_orElse
 
 instance : LawfulAlternative Option where
   map_failure        := by intros; rfl
@@ -40,7 +44,7 @@ instance [MonadAlternative m] [LawfulAlternative m] : LawfulAlternative (ReaderT
   map_failure    := by intros; apply ext; intros; simp
   map_orElse     := by intros; apply ext; intros; simp [map_orElse]
   failure_orElse := by intros; apply ext; intros; simp
-  orElse_failure := by intros; apply ext; intros; simp
+  orElse_failure := by intros; apply ext; intros; simp [orElse_failure]
   orElse_assoc   := by intros; apply ext; intros; simp [orElse_assoc]
   pure_orElse    := by intros; apply ext; intros; simp
 
@@ -62,7 +66,7 @@ instance [MonadAlternative m] [LawfulMonad m] [LawfulAlternative m] : LawfulAlte
   map_failure    := by intros; apply ext; intros; simp
   map_orElse     := by intros; apply ext; intros; simp [map_orElse]
   failure_orElse := by intros; apply ext; intros; simp
-  orElse_failure := by intros; apply ext; intros; simp
+  orElse_failure := by intros; apply ext; intros; simp [orElse_failure]
   orElse_assoc   := by intros; apply ext; intros; simp [orElse_assoc]
   pure_orElse    := by intros; apply ext; intros; simp
 

--- a/Std/Classes/LawfulAlternative.lean
+++ b/Std/Classes/LawfulAlternative.lean
@@ -18,13 +18,11 @@ class LawfulAlternative (f : Type _ → Type _) [Alternative f] extends LawfulAp
   /-- Failure is a right identity for `orElse` -/
   orElse_failure (x : f α) : (x <|> failure) = x
   /-- `orElse` is associative -/
-  orElse_assoc (x y z : f α) : (x <|> (y <|> z)) = ((x <|> y) <|> z)
-  /-- `pure` always succeeds -/
-  pure_orElse (x : α) (y : f α) : (pure x <|> y) = pure x
+  orElse_assoc (x y z : f α) : ((x <|> y) <|> z) = (x <|> (y <|> z))
 
-export LawfulAlternative (map_failure map_orElse failure_orElse orElse_failure orElse_assoc pure_orElse)
+export LawfulAlternative (map_failure map_orElse failure_orElse orElse_failure orElse_assoc)
 
-attribute [simp] map_failure failure_orElse pure_orElse
+attribute [simp] map_failure failure_orElse
 
 instance : LawfulAlternative Option where
   map_failure        := by intros; rfl
@@ -32,7 +30,6 @@ instance : LawfulAlternative Option where
   failure_orElse     := by intros; rfl
   orElse_failure x   := by cases x <;> rfl
   orElse_assoc x _ _ := by cases x <;> rfl
-  pure_orElse        := by intros; rfl
 
 namespace ReaderT
 
@@ -46,7 +43,6 @@ instance [MonadAlternative m] [LawfulAlternative m] : LawfulAlternative (ReaderT
   failure_orElse := by intros; apply ext; intros; simp
   orElse_failure := by intros; apply ext; intros; simp [orElse_failure]
   orElse_assoc   := by intros; apply ext; intros; simp [orElse_assoc]
-  pure_orElse    := by intros; apply ext; intros; simp
 
 end ReaderT
 
@@ -68,6 +64,5 @@ instance [MonadAlternative m] [LawfulMonad m] [LawfulAlternative m] : LawfulAlte
   failure_orElse := by intros; apply ext; intros; simp
   orElse_failure := by intros; apply ext; intros; simp [orElse_failure]
   orElse_assoc   := by intros; apply ext; intros; simp [orElse_assoc]
-  pure_orElse    := by intros; apply ext; intros; simp
 
 end StateT

--- a/Std/Classes/LawfulAlternative.lean
+++ b/Std/Classes/LawfulAlternative.lean
@@ -1,0 +1,69 @@
+import Std.Classes.LawfulMonad
+
+/-- combination class of `Monad` and `Alternative` with a common `Applicative` component -/
+class MonadAlternative (m : Type _ → Type _) extends Monad m, Alternative m
+
+/-- basic laws for `Alternative` -/
+class LawfulAlternative (f : Type _ → Type _) [Alternative f] extends LawfulApplicative f : Prop where
+  /-- map failure is failure -/
+  map_failure (g : α → β) : g <$> (failure : f α) = failure
+  /-- map distributes over `orElse` -/
+  map_orElse (g : α → b) (x y : f α) : g <$> (x <|> y) = (g <$> x <|> g <$> y)
+  /-- failure is left identity for `orElse`  -/
+  failure_orElse (x : f α) : (failure <|> x) = x
+  /-- failure is right identity for `orElse` -/
+  orElse_failure (x : f α) : (x <|> failure) = x
+  /-- `orElse` is associative -/
+  orElse_assoc (x y z : f α) : (x <|> (y <|> z)) = ((x <|> y) <|> z)
+  /-- `pure` always succeeds -/
+  pure_orElse (x : α) (y : f α) : (pure x <|> y) = pure x
+
+export LawfulAlternative (map_failure map_orElse failure_orElse orElse_failure orElse_assoc pure_orElse)
+
+attribute [simp] map_failure failure_orElse orElse_failure pure_orElse
+
+instance : LawfulAlternative Option where
+  map_failure        := by intros; rfl
+  map_orElse _ x _   := by cases x <;> rfl
+  failure_orElse     := by intros; rfl
+  orElse_failure x   := by cases x <;> rfl
+  orElse_assoc x _ _ := by cases x <;> rfl
+  pure_orElse        := by intros; rfl
+
+namespace ReaderT
+
+@[simp] theorem run_failure [Monad m] [Alternative m] (ctx : ρ) : (failure : ReaderT ρ m α).run ctx = failure := rfl
+
+@[simp] theorem run_orElse [Monad m] [Alternative m] (x y : ReaderT ρ m α) (ctx : ρ) : (x <|> y).run ctx = (x.run ctx <|> y.run ctx) := rfl
+
+instance [MonadAlternative m] [LawfulAlternative m] : LawfulAlternative (ReaderT ρ m) where
+  map_failure    := by intros; apply ext; intros; simp
+  map_orElse     := by intros; apply ext; intros; simp [map_orElse]
+  failure_orElse := by intros; apply ext; intros; simp
+  orElse_failure := by intros; apply ext; intros; simp
+  orElse_assoc   := by intros; apply ext; intros; simp [orElse_assoc]
+  pure_orElse    := by intros; apply ext; intros; simp
+
+end ReaderT
+
+instance [Monad m] [LawfulMonad m] : LawfulMonad (StateRefT' ω σ m) :=
+  inferInstanceAs (LawfulMonad (ReaderT (ST.Ref ω σ) m))
+
+instance [MonadAlternative m] [LawfulAlternative m] : LawfulAlternative (StateRefT' ω σ m) :=
+  inferInstanceAs (LawfulAlternative (ReaderT (ST.Ref ω σ) m))
+
+namespace StateT
+
+@[simp] theorem run_failure {α σ : Type u} [Monad m] [Alternative m] (s : σ) : (failure : StateT σ m α).run s = failure := rfl
+
+@[simp] theorem run_orElse {α σ : Type u} [Monad m] [Alternative m] (x y : StateT σ m α) (s : σ) : (x <|> y).run s = (x.run s <|> y.run s) := rfl
+
+instance [MonadAlternative m] [LawfulMonad m] [LawfulAlternative m] : LawfulAlternative (StateT σ m) where
+  map_failure    := by intros; apply ext; intros; simp
+  map_orElse     := by intros; apply ext; intros; simp [map_orElse]
+  failure_orElse := by intros; apply ext; intros; simp
+  orElse_failure := by intros; apply ext; intros; simp
+  orElse_assoc   := by intros; apply ext; intros; simp [orElse_assoc]
+  pure_orElse    := by intros; apply ext; intros; simp
+
+end StateT


### PR DESCRIPTION
Mostly for completeness, the main use case is `Option`. Another would be a `NonDet` monad.

I only included "linear" alternative laws (everything is evaluated the same number of times on both sides) since these are the only ones we can expect for a control-type monad. For data-type monads, there are additional distributive laws like `((a <|> b) >>= f) = ((a >>= f) <|> (b >>= f))` that might be expected to hold. These probably belong in a `MonadPlus` extension, or similar.

Migrated from closed PR [lean4#1999](https://github.com/leanprover/lean4/pull/1999)