### PR TITLE
feat: add monad instance for `Thunk`

### DIFF
--- a/Std/Classes/LawfulMonad.lean
+++ b/Std/Classes/LawfulMonad.lean
@@ -5,6 +5,16 @@ Authors: Mario Carneiro
 -/
 import Std.Logic
 
+/-- Monad instance for `Thunk`
+  Note that the old compiler does not know how to eliminate `pure _ >>= _` for `Thunk`,
+  so manual optimization may be better in some cases.
+  See <https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Why.20isn't.20Thunk.20a.20Monad.3F/near/321680164>
+-/
+instance : Monad Thunk where
+  pure := Thunk.pure
+  bind := Thunk.bind
+  map := Thunk.map
+
 /--
 An alternative constructor for `LawfulMonad` which has more
 defaultable fields in the common case.
@@ -51,6 +61,14 @@ instance : LawfulMonad Option := LawfulMonad.mk'
 
 instance : LawfulApplicative Option := inferInstance
 instance : LawfulFunctor Option := inferInstance
+
+instance : LawfulMonad Thunk := LawfulMonad.mk'
+  (id_map := fun _ => rfl)
+  (pure_bind := fun _ _ => rfl)
+  (bind_assoc := fun _ _ _ => rfl)
+
+instance : LawfulApplicative Thunk := inferInstance
+instance : LawfulFunctor Thunk := inferInstance
 
 /-!
 ## SatisfiesM


### PR DESCRIPTION
This is missing from core because the old compiler doesn't know how to eliminate `pure _ >>= _` for `Thunk`. Nevertheless, I think this is a useful instance and the issue may be fixed in the new compiler.

See [related discussion on Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Why.20isn't.20Thunk.20a.20Monad.3F/near/321680164).