### PR TITLE
chore: don't inline `Rat.div` definition, for better instance transparency behaviour

### DIFF
--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -170,7 +170,11 @@ because you don't want to unfold it. Use `Rat.inv_def` instead.)
     a
 
 /-- Division of rational numbers. Note: `div a 0 = 0`. -/
-instance : Div Rat := ⟨(· * ·.inv)⟩
+protected def div : Rat → Rat → Rat := (· * ·.inv)
+
+/-- Division of rational numbers. Note: `div a 0 = 0`.  Written with a separate function `Rat.div`
+as a wrapper so that the definition is not unfolded at `.instance` transparency. -/
+instance : Div Rat := ⟨Rat.div⟩
 
 theorem add.aux (a b : Rat) {g ad bd} (hg : g = a.den.gcd b.den)
     (had : ad = a.den / g) (hbd : bd = b.den / g) :


### PR DESCRIPTION
This PR would hide the Rat division instance behind a layer `Rat.div`, so that it doesn't get unfolded to `a * b.inv` when working at the level of instance transparency.  This ensures that `Rat` behaves the same way as a generic `LinearOrderedField` in examples such as the following:

```lean
import Mathlib.Data.Rat.Order

variable [LinearOrderedField α]

/- `.reducible` transparency works correctly over `ℚ`. -/
example {a b : ℚ} : a / 2 ≤ b / 2 := by
  with_reducible (apply mul_le_mul) -- fails, as desired

/- `.instance` transparency works correctly over a generic field. -/
example {a b : α} : a / 2 ≤ b / 2 := by
  with_reducible_and_instances (apply mul_le_mul) -- fails, as desired

/- `.instance` transparency does not work correctly over `ℚ`. -/
example {a b : ℚ} : a / 2 ≤ b / 2 := by
  with_reducible_and_instances (apply mul_le_mul) -- succeeds, wanted it not to
  all_goals sorry
```

See discussion on Zulip:
https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Instance.20transparency.20issue.3F/near/323637092