### PR TITLE
doc: adjust library_note example

### DIFF
--- a/Std/Util/LibraryNote.lean
+++ b/Std/Util/LibraryNote.lean
@@ -26,8 +26,9 @@ initialize libraryNoteExt : SimplePersistentEnvExtension LibraryNoteEntry (Array
 open Lean Parser Command in
 /--
 ```
-/-- ... some explanation ... -/
-library_note "some tag"
+library_note "some tag"/--
+... some explanation ...
+-/
 ```
 creates a new "library note", which can then be cross-referenced using
 ```

--- a/Std/Util/LibraryNote.lean
+++ b/Std/Util/LibraryNote.lean
@@ -26,7 +26,7 @@ initialize libraryNoteExt : SimplePersistentEnvExtension LibraryNoteEntry (Array
 open Lean Parser Command in
 /--
 ```
-library_note "some tag"/--
+library_note "some tag" /--
 ... some explanation ...
 -/
 ```


### PR DESCRIPTION
This is the format used throughout mathlib; I don't know if there are any other library_note users.