### PR TITLE
feat: forall_exists_index

### DIFF
--- a/Std/Logic.lean
+++ b/Std/Logic.lean
@@ -349,6 +349,10 @@ variable {p q : α → Prop} {b : Prop}
 theorem forall_imp (h : ∀ a, p a → q a) : (∀ a, p a) → ∀ a, q a :=
 fun h' a => h a (h' a)
 
+@[simp] theorem forall_exists_index {q : (∃ x, p x) → Prop} :
+    (∀ h, q h) ↔ ∀ x (h : p x), q ⟨x, h⟩ :=
+  ⟨fun h x hpx => h ⟨x, hpx⟩, fun h ⟨x, hpx⟩ => h x hpx⟩
+
 theorem Exists.imp (h : ∀ a, p a → q a) : (∃ a, p a) → ∃ a, q a
   | ⟨a, hp⟩ => ⟨a, h a hp⟩
 
@@ -356,8 +360,8 @@ theorem Exists.imp' {β} {q : β → Prop} (f : α → β) (hpq : ∀ a, p a →
     (∃ a, p a) → ∃ b, q b
   | ⟨_, hp⟩ => ⟨_, hpq _ hp⟩
 
-@[simp] theorem exists_imp : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
-  ⟨fun h x hpx => h ⟨x, hpx⟩, fun h ⟨x, hpx⟩ => h x hpx⟩
+theorem exists_imp : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
+  by apply forall_exists_index
 
 section forall_congr
 

--- a/Std/Logic.lean
+++ b/Std/Logic.lean
@@ -360,8 +360,7 @@ theorem Exists.imp' {β} {q : β → Prop} (f : α → β) (hpq : ∀ a, p a →
     (∃ a, p a) → ∃ b, q b
   | ⟨_, hp⟩ => ⟨_, hpq _ hp⟩
 
-theorem exists_imp : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
-  by apply forall_exists_index
+theorem exists_imp : ((∃ x, p x) → b) ↔ ∀ x, p x → b := forall_exists_index
 
 section forall_congr
 


### PR DESCRIPTION
Adds `forall_exists_index`. Statement pulled from mathlib4.