### PR TITLE
chore: de-mathlib Data/List/Count.lean

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -32,6 +32,7 @@ import Std.Data.Int.Basic
 import Std.Data.Int.DivMod
 import Std.Data.Int.Lemmas
 import Std.Data.List.Basic
+import Std.Data.List.Count
 import Std.Data.List.Init.Lemmas
 import Std.Data.List.Lemmas
 import Std.Data.MLList.Basic

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -767,15 +767,15 @@ replacing `a → b` at the first value `a` in the list such that `f a = some b`.
     | some b => acc.toListAppend (b :: l)
     | none => go l (acc.push a)
 
-/-- `countp p l` is the number of elements of `l` that satisfy `p`. -/
-@[inline] def countp (p : α → Bool) (l : List α) : Nat := go l 0 where
-  /-- Auxiliary for `countp`: `countp.go p l acc = countp p l + acc`. -/
+/-- `countP p l` is the number of elements of `l` that satisfy `p`. -/
+@[inline] def countP (p : α → Bool) (l : List α) : Nat := go l 0 where
+  /-- Auxiliary for `countP`: `countP.go p l acc = countP p l + acc`. -/
   @[specialize] go : List α → Nat → Nat
   | [], acc => acc
   | x :: xs, acc => bif p x then go xs (acc + 1) else go xs acc
 
 /-- `count a l` is the number of occurrences of `a` in `l`. -/
-@[inline] def count [BEq α] (a : α) : List α → Nat := countp (· == a)
+@[inline] def count [BEq α] (a : α) : List α → Nat := countP (· == a)
 
 /--
 `isPrefix l₁ l₂`, or `l₁ <+: l₂`, means that `l₁` is a prefix of `l₂`,

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -136,7 +136,7 @@ section Count
 
 variable [DecidableEq α]
 
-@[simp 1100] theorem count_nil (a : α) : count a [] = 0 := rfl
+@[simp] theorem count_nil (a : α) : count a [] = 0 := rfl
 
 theorem count_cons (a b : α) (l : List α) :
     count a (b :: l) = count a l + if a = b then 1 else 0 := by conv =>
@@ -176,7 +176,7 @@ theorem count_concat (a : α) (l : List α) : count a (concat l a) = succ (count
 theorem count_pos_iff_mem {a : α} {l : List α} : 0 < count a l ↔ a ∈ l := by
   simp only [count, countp_pos, beq_iff_eq, exists_eq_right]
 
-@[simp] theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a l = 0 :=
+@[simp 900] theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a l = 0 :=
   Decidable.byContradiction fun h' => h <| count_pos_iff_mem.1 (Nat.pos_of_ne_zero h')
 
 theorem not_mem_of_count_eq_zero {a : α} {l : List α} (h : count a l = 0) : a ∉ l :=

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -205,8 +205,7 @@ theorem filter_beq (l : List α) (a : α) : l.filter (a == ·) = replicate (coun
 theorem le_count_iff_replicate_sublist {l : List α} : n ≤ count a l ↔ replicate n a <+ l := by
   refine ⟨fun h => ?_, fun h => ?_⟩
   · exact ((replicate_sublist_replicate a).2 h).trans <| filter_eq l a ▸ filter_sublist _
-  · have := h.count_le a
-    simpa only [count_replicate_self]
+  · simpa only [count_replicate_self] using h.count_le a
 
 theorem replicate_count_eq_of_count_eq_length {l : List α} (h : count a l = length l) :
     replicate (count a l) a = l :=

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -143,24 +143,17 @@ variable [DecidableEq α]
 
 @[simp] theorem count_nil (a : α) : count a [] = 0 := rfl
 
-theorem count_cons' (a b : α) (l : List α) :
+theorem count_cons (a b : α) (l : List α) :
     count a (b :: l) = count a l + if a = b then 1 else 0 := by conv =>
   simp [count, countp_cons]
   lhs
   simp only [eq_comm]
 
-theorem count_cons (a b : α) (l : List α) :
-    count a (b :: l) = if a = b then succ (count a l) else count a l := by
-  simp [count_cons']
-  split <;> rfl
+@[simp] theorem count_cons_self (a : α) (l : List α) : count a (a :: l) = count a l + 1 := by
+  simp [count_cons]
 
-@[simp]
-theorem count_cons_self (a : α) (l : List α) : count a (a :: l) = count a l + 1 := by
-  simp [count_cons']
-
-@[simp]
-theorem count_cons_of_ne (h : a ≠ b) (l : List α) : count a (b :: l) = count a l := by
-  simp [count_cons', h]
+@[simp] theorem count_cons_of_ne (h : a ≠ b) (l : List α) : count a (b :: l) = count a l := by
+  simp [count_cons, h]
 
 theorem count_tail : ∀ (l : List α) (a : α) (h : 0 < l.length),
       l.tail.count a = l.count a - if a = get l ⟨0, h⟩ then 1 else 0

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -1,0 +1,315 @@
+/-
+Copyright (c) 2014 Parikshit Khanna. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
+-/
+import Std.Data.List.Basic
+import Std.Data.List.Lemmas
+
+/-!
+# Counting in lists
+
+This file proves basic properties of `List.countp` and `List.count`, which count the number of
+elements of a list satisfying a predicate and equal to a given element respectively. Their
+definitions can be found in `Std.Data.List.Basic`.
+-/
+
+
+open Nat
+
+variable {l : List α}
+
+namespace List
+
+section Countp
+
+variable (p q : α → Bool)
+
+@[simp]
+theorem countp_nil : countp p [] = 0 := rfl
+
+protected theorem countp_go_eq_add (l) : countp.go p l n = n + countp.go p l 0 := by
+  induction l generalizing n with
+  | nil => rfl
+  | cons head tail ih =>
+    unfold countp.go
+    rw [ih (n := n + 1), ih (n := n), ih (n := 1)]
+    by_cases h : p head
+    · simp [h, Nat.add_assoc]
+    · simp [h]
+
+@[simp]
+theorem countp_cons_of_pos {a : α} (l) (pa : p a) : countp p (a :: l) = countp p l + 1 := by
+  have : countp.go p (a :: l) 0 = countp.go p l 1 := by
+    suffices (bif _ then _ else _) = countp.go _ _ _ from this
+    rw [pa]
+    rfl
+  unfold countp
+  rw [this, Nat.add_comm, List.countp_go_eq_add]
+
+@[simp]
+theorem countp_cons_of_neg {a : α} (l) (pa : ¬p a) : countp p (a :: l) = countp p l := by
+  suffices (bif _ then _ else _) = countp.go _ _ _ from this
+  rw [Bool.of_not_eq_true pa]
+  rfl
+
+theorem countp_cons (a : α) (l) : countp p (a :: l) = countp p l + if p a then 1 else 0 := by
+  by_cases h : p a <;> simp [h]
+
+theorem length_eq_countp_add_countp (l) : length l = countp p l + countp (fun a => ¬p a) l := by
+  induction l with
+  | nil => rfl
+  | cons x h ih =>
+    by_cases h : p x
+    · rw [countp_cons_of_pos _ _ h, countp_cons_of_neg _ _ _, length, ih]
+      · rw [Nat.add_assoc, Nat.add_comm _ 1, Nat.add_assoc]
+      · simp only [h]
+    · rw [countp_cons_of_pos (fun a => ¬p a) _ _, countp_cons_of_neg _ _ h, length, ih]
+      · rfl
+      · simp only [h]
+
+theorem countp_eq_length_filter (l) : countp p l = length (filter p l) := by
+  induction l with
+  | nil => rfl
+  | cons x l ih =>
+    by_cases h : p x
+    · rw [countp_cons_of_pos p l h, ih, filter_cons_of_pos l h, length]
+    · rw [countp_cons_of_neg p l h, ih, filter_cons_of_neg l h]
+
+theorem countp_le_length : countp p l ≤ l.length := by
+  simp only [countp_eq_length_filter]
+  apply length_filter_le
+
+@[simp]
+theorem countp_append (l₁ l₂) : countp p (l₁ ++ l₂) = countp p l₁ + countp p l₂ := by
+  simp only [countp_eq_length_filter, filter_append, length_append]
+
+theorem countp_pos : 0 < countp p l ↔ ∃ a ∈ l, p a := by
+  simp only [countp_eq_length_filter, length_pos_iff_exists_mem, mem_filter, exists_prop]
+
+@[simp]
+theorem countp_eq_zero : countp p l = 0 ↔ ∀ a ∈ l, ¬p a := by
+  rw [countp_eq_length_filter, length_eq_zero, eq_nil_iff_forall_not_mem]
+  constructor <;> intro h a ha
+  next =>
+    intro hcontra
+    apply h a
+    apply mem_filter.mpr ⟨ha,hcontra⟩
+  next =>
+    have ⟨h1, h2⟩ := mem_filter.mp ha
+    apply h a h1
+    exact h2
+
+@[simp]
+theorem countp_eq_length : countp p l = l.length ↔ ∀ a ∈ l, p a := by
+  rw [countp_eq_length_filter, filter_length_eq_length]
+
+theorem length_filter_lt_length_iff_exists (l) :
+    length (filter p l) < length l ↔ ∃ x ∈ l, ¬p x := by
+  have := countp_pos (fun x => ¬p x) (l := l)
+  simp [length_eq_countp_add_countp p l, countp_eq_length_filter] at this ⊢
+  rw [←this]
+  generalize length (filter p l) = x
+  generalize length (filter _ _) = y
+  rw [Nat.lt_add_right_iff_pos]
+
+theorem Sublist.countp_le (s : l₁ <+ l₂) : countp p l₁ ≤ countp p l₂ := by
+  simp only [countp_eq_length_filter]
+  apply s.filter.length_le
+
+@[simp]
+theorem countp_filter (l : List α) : countp p (filter q l) = countp (fun a => p a ∧ q a) l := by
+  simp only [countp_eq_length_filter, filter_filter]
+
+@[simp]
+theorem countp_true : (l.countp fun _ => true) = l.length := by simp
+
+@[simp]
+theorem countp_false : (l.countp fun _ => false) = 0 := by simp
+
+@[simp]
+theorem countp_map (p : β → Bool) (f : α → β) :
+    ∀ l, countp p (map f l) = countp (p ∘ f) l
+  | [] => rfl
+  | a :: l => by rw [map_cons, countp_cons, countp_cons, countp_map p f l]; rfl
+
+variable {p q}
+
+theorem countp_mono_left (h : ∀ x ∈ l, p x → q x) : countp p l ≤ countp q l := by
+  induction l with
+  | nil => apply Nat.le_refl
+  | cons a l ihl =>
+    rw [forall_mem_cons] at h
+    have ⟨ha, hl⟩ := h
+    simp [countp_cons]
+    cases h : p a
+    . simp
+      apply Nat.le_trans ?_ (Nat.le_add_right _ _)
+      apply ihl hl
+    . simp [ha h, Nat.add_one]
+      apply Nat.succ_le_succ
+      apply ihl hl
+
+theorem countp_congr (h : ∀ x ∈ l, p x ↔ q x) : countp p l = countp q l :=
+  Nat.le_antisymm
+    (countp_mono_left fun x hx => (h x hx).1)
+    (countp_mono_left fun x hx => (h x hx).2)
+
+end Countp
+
+/-! ### count -/
+
+section Count
+
+variable [DecidableEq α]
+
+@[simp]
+theorem count_nil (a : α) : count a [] = 0 := rfl
+
+theorem count_cons' (a b : α) (l : List α) :
+    count a (b :: l) = count a l + if a = b then 1 else 0 := by conv =>
+  simp [count, countp_cons]
+  lhs
+  simp only [eq_comm]
+
+theorem count_cons (a b : α) (l : List α) :
+    count a (b :: l) = if a = b then succ (count a l) else count a l := by
+  simp [count_cons']
+  split <;> rfl
+
+@[simp]
+theorem count_cons_self (a : α) (l : List α) : count a (a :: l) = count a l + 1 := by
+  simp [count_cons']
+
+@[simp]
+theorem count_cons_of_ne (h : a ≠ b) (l : List α) : count a (b :: l) = count a l := by
+  simp [count_cons', h]
+
+theorem count_tail :
+    ∀ (l : List α) (a : α) (h : 0 < l.length),
+      l.tail.count a = l.count a - if a = List.get l ⟨0, h⟩ then 1 else 0
+  | head :: tail, a, h => by
+    rw [count_cons']
+    split <;>
+      next h => simp [h] at *
+
+theorem count_le_length (a : α) (l : List α) : count a l ≤ l.length :=
+  countp_le_length _
+
+theorem Sublist.count_le (h : l₁ <+ l₂) (a : α) : count a l₁ ≤ count a l₂ :=
+  h.countp_le _
+
+theorem count_le_count_cons (a b : α) (l : List α) : count a l ≤ count a (b :: l) :=
+  (sublist_cons _ _).count_le _
+
+theorem count_singleton (a : α) : count a [a] = 1 := by
+  rw [count_cons]
+  simp
+
+theorem count_singleton' (a b : α) : count a [b] = if a = b then 1 else 0 := by
+  rw [count_cons]
+  rfl
+
+@[simp]
+theorem count_append (a : α) : ∀ l₁ l₂, count a (l₁ ++ l₂) = count a l₁ + count a l₂ :=
+  countp_append _
+
+theorem count_concat (a : α) (l : List α) : count a (concat l a) = succ (count a l) := by simp
+
+@[simp]
+theorem count_pos {a : α} {l : List α} : 0 < count a l ↔ a ∈ l := by
+  simp only [count, countp_pos, beq_iff_eq, exists_eq_right]
+
+@[simp]
+theorem one_le_count_iff_mem {a : α} {l : List α} : 1 ≤ count a l ↔ a ∈ l := count_pos
+
+theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a l = 0 :=
+  Decidable.byContradiction fun h' => h <| count_pos.1 (Nat.pos_of_ne_zero h')
+
+theorem not_mem_of_count_eq_zero {a : α} {l : List α} (h : count a l = 0) : a ∉ l :=
+  fun h' => Nat.ne_of_lt (count_pos.2 h') h.symm
+
+@[simp]
+theorem count_eq_zero : count a l = 0 ↔ a ∉ l :=
+  ⟨not_mem_of_count_eq_zero, count_eq_zero_of_not_mem⟩
+
+@[simp]
+theorem count_eq_length : count a l = l.length ↔ ∀ b ∈ l, a = b := by
+  rw [count, countp_eq_length]
+  refine ⟨fun h b hb => ?h₁, fun h b hb => ?h₂⟩
+  · refine' Eq.symm _
+    have := h b hb
+    simp at this
+    exact this
+  · rw [h b hb, beq_self_eq_true]
+
+@[simp]
+theorem count_replicate_self (a : α) (n : Nat) : count a (replicate n a) = n :=
+  (count_eq_length.2 <| fun _ h => (eq_of_mem_replicate h).symm).trans (length_replicate _ _)
+
+theorem count_replicate (a b : α) (n : Nat) : count a (replicate n b) = if a = b then n else 0 := by
+  split
+  exacts [‹a = b› ▸ count_replicate_self _ _, count_eq_zero.2 <| mt eq_of_mem_replicate ‹a ≠ b›]
+
+theorem filter_beq' (l : List α) (a : α) : l.filter (· == a) = replicate (count a l) a := by
+  simp only [count, countp_eq_length_filter, eq_replicate, mem_filter, beq_iff_eq]
+  exact ⟨trivial, fun _ h => h.2⟩
+
+theorem filter_eq' (l : List α) (a : α) : l.filter (· = a) = replicate (count a l) a :=
+  filter_beq' l a
+
+theorem filter_eq (l : List α) (a : α) : l.filter (a = ·) = replicate (count a l) a := by
+  have := filter_eq' l a
+  simp only [eq_comm] at this ⊢
+  exact this
+
+theorem filter_beq (l : List α) (a : α) : l.filter (a == ·) = replicate (count a l) a :=
+  filter_eq l a
+
+theorem le_count_iff_replicate_sublist : n ≤ count a l ↔ replicate n a <+ l :=
+  ⟨fun h =>
+    ((replicate_sublist_replicate a).2 h).trans <| filter_eq l a ▸ filter_sublist _,
+    fun h => by
+      have := h.count_le a
+      simp only [count_replicate_self] at this ⊢
+      exact this⟩
+
+theorem replicate_count_eq_of_count_eq_length (h : count a l = length l) :
+    replicate (count a l) a = l :=
+  (le_count_iff_replicate_sublist.mp (Nat.le_refl _)).eq_of_length <|
+    (length_replicate (count a l) a).trans h
+
+@[simp]
+theorem count_filter (h : p a) : count a (filter p l) = count a l := by
+  rw [count, countp_filter]
+  congr
+  funext b
+  rw [(by rfl : (b == a) = decide (b = a))]
+  rw [decide_eq_decide_iff_iff]
+  simp; intro heq; exact heq ▸ h
+
+theorem count_le_count_map [DecidableEq β] (l : List α) (f : α → β) (x : α) :
+    count x l ≤ count (f x) (map f l) := by
+  rw [count, count, countp_map]
+  exact countp_mono_left <| by simp (config := {contextual := true})
+
+theorem count_erase (a b : α) :
+    ∀ l : List α, count a (l.erase b) = count a l - if a = b then 1 else 0
+  | [] => by simp
+  | c :: l => by
+    rw [erase_cons]
+    by_cases hc : c = b
+    · rw [if_pos hc, hc, count_cons', Nat.add_sub_cancel]
+    · rw [if_neg hc, count_cons', count_cons', count_erase a b l]
+      by_cases ha : a = b
+      · rw [← ha, eq_comm] at hc
+        rw [if_pos ha, if_neg hc, Nat.add_zero, Nat.add_zero]
+      · rw [if_neg ha, Nat.sub_zero, Nat.sub_zero]
+
+@[simp]
+theorem count_erase_self (a : α) (l : List α) : count a (List.erase l a) = count a l - 1 := by
+  rw [count_erase, if_pos rfl]
+
+@[simp]
+theorem count_erase_of_ne (ab : a ≠ b) (l : List α) : count a (l.erase b) = count a l :=
+  by rw [count_erase, if_neg ab, Nat.sub_zero]

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -87,7 +87,7 @@ theorem countp_pos : 0 < countp p l ↔ ∃ a ∈ l, p a := by
 
 theorem Sublist.countp_le (s : l₁ <+ l₂) : countp p l₁ ≤ countp p l₂ := by
   simp only [countp_eq_length_filter]
-  apply s.filter.length_le
+  apply s.filter _ |>.length_le
 
 @[simp] theorem countp_filter (l : List α) :
     countp p (filter q l) = countp (fun a => p a ∧ q a) l := by

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -132,7 +132,7 @@ section Count
 
 variable [DecidableEq α]
 
-@[simp] theorem count_nil (a : α) : count a [] = 0 := rfl
+@[simp 1100] theorem count_nil (a : α) : count a [] = 0 := rfl
 
 theorem count_cons (a b : α) (l : List α) :
     count a (b :: l) = count a l + if a = b then 1 else 0 := by conv =>
@@ -174,7 +174,7 @@ theorem count_concat (a : α) (l : List α) : count a (concat l a) = succ (count
 
 @[simp] theorem one_le_count_iff_mem {a : α} {l : List α} : 1 ≤ count a l ↔ a ∈ l := count_pos
 
-theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a l = 0 :=
+@[simp] theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a l = 0 :=
   Decidable.byContradiction fun h' => h <| count_pos.1 (Nat.pos_of_ne_zero h')
 
 theorem not_mem_of_count_eq_zero {a : α} {l : List α} (h : count a l = 0) : a ∉ l :=

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -9,7 +9,7 @@ import Std.Data.List.Lemmas
 /-!
 # Counting in lists
 
-This file proves basic properties of `List.countp` and `List.count`, which count the number of
+This file proves basic properties of `List.countP` and `List.count`, which count the number of
 elements of a list satisfying a predicate and equal to a given element respectively. Their
 definitions can be found in `Std.Data.List.Basic`.
 -/
@@ -19,102 +19,102 @@ open Nat
 
 namespace List
 
-section Countp
+section countP
 
 variable (p q : α → Bool)
 
-@[simp] theorem countp_nil : countp p [] = 0 := rfl
+@[simp] theorem countP_nil : countP p [] = 0 := rfl
 
-protected theorem countp_go_eq_add (l) : countp.go p l n = n + countp.go p l 0 := by
+protected theorem countP_go_eq_add (l) : countP.go p l n = n + countP.go p l 0 := by
   induction l generalizing n with
   | nil => rfl
   | cons head tail ih =>
-    unfold countp.go
+    unfold countP.go
     rw [ih (n := n + 1), ih (n := n), ih (n := 1)]
     by_cases h : p head
     · simp [h, Nat.add_assoc]
     · simp [h]
 
-@[simp] theorem countp_cons_of_pos (l) (pa : p a) : countp p (a :: l) = countp p l + 1 := by
-  have : countp.go p (a :: l) 0 = countp.go p l 1 := by
-    suffices (bif _ then _ else _) = countp.go _ _ _ from this
+@[simp] theorem countP_cons_of_pos (l) (pa : p a) : countP p (a :: l) = countP p l + 1 := by
+  have : countP.go p (a :: l) 0 = countP.go p l 1 := by
+    suffices (bif _ then _ else _) = countP.go _ _ _ from this
     rw [pa]
     rfl
-  unfold countp
-  rw [this, Nat.add_comm, List.countp_go_eq_add]
+  unfold countP
+  rw [this, Nat.add_comm, List.countP_go_eq_add]
 
-@[simp] theorem countp_cons_of_neg (l) (pa : ¬p a) : countp p (a :: l) = countp p l := by
-  simp [countp, countp.go, pa]
+@[simp] theorem countP_cons_of_neg (l) (pa : ¬p a) : countP p (a :: l) = countP p l := by
+  simp [countP, countP.go, pa]
 
-theorem countp_cons (a : α) (l) : countp p (a :: l) = countp p l + if p a then 1 else 0 := by
+theorem countP_cons (a : α) (l) : countP p (a :: l) = countP p l + if p a then 1 else 0 := by
   by_cases h : p a <;> simp [h]
 
-theorem length_eq_countp_add_countp (l) : length l = countp p l + countp (fun a => ¬p a) l := by
+theorem length_eq_countP_add_countP (l) : length l = countP p l + countP (fun a => ¬p a) l := by
   induction l with
   | nil => rfl
   | cons x h ih =>
     by_cases h : p x
-    · rw [countp_cons_of_pos _ _ h, countp_cons_of_neg _ _ _, length, ih]
+    · rw [countP_cons_of_pos _ _ h, countP_cons_of_neg _ _ _, length, ih]
       · rw [Nat.add_assoc, Nat.add_comm _ 1, Nat.add_assoc]
       · simp only [h]
-    · rw [countp_cons_of_pos (fun a => ¬p a) _ _, countp_cons_of_neg _ _ h, length, ih]
+    · rw [countP_cons_of_pos (fun a => ¬p a) _ _, countP_cons_of_neg _ _ h, length, ih]
       · rfl
       · simp only [h]
 
-theorem countp_eq_length_filter (l) : countp p l = length (filter p l) := by
+theorem countP_eq_length_filter (l) : countP p l = length (filter p l) := by
   induction l with
   | nil => rfl
   | cons x l ih =>
     by_cases h : p x
-    · rw [countp_cons_of_pos p l h, ih, filter_cons_of_pos l h, length]
-    · rw [countp_cons_of_neg p l h, ih, filter_cons_of_neg l h]
+    · rw [countP_cons_of_pos p l h, ih, filter_cons_of_pos l h, length]
+    · rw [countP_cons_of_neg p l h, ih, filter_cons_of_neg l h]
 
-theorem countp_le_length : countp p l ≤ l.length := by
-  simp only [countp_eq_length_filter]
+theorem countP_le_length : countP p l ≤ l.length := by
+  simp only [countP_eq_length_filter]
   apply length_filter_le
 
-@[simp] theorem countp_append (l₁ l₂) : countp p (l₁ ++ l₂) = countp p l₁ + countp p l₂ := by
-  simp only [countp_eq_length_filter, filter_append, length_append]
+@[simp] theorem countP_append (l₁ l₂) : countP p (l₁ ++ l₂) = countP p l₁ + countP p l₂ := by
+  simp only [countP_eq_length_filter, filter_append, length_append]
 
-theorem countp_pos : 0 < countp p l ↔ ∃ a ∈ l, p a := by
-  simp only [countp_eq_length_filter, length_pos_iff_exists_mem, mem_filter, exists_prop]
+theorem countP_pos : 0 < countP p l ↔ ∃ a ∈ l, p a := by
+  simp only [countP_eq_length_filter, length_pos_iff_exists_mem, mem_filter, exists_prop]
 
-theorem countp_eq_zero : countp p l = 0 ↔ ∀ a ∈ l, ¬p a := by
-  simp only [countp_eq_length_filter, length_eq_zero, filter_eq_nil]
+theorem countP_eq_zero : countP p l = 0 ↔ ∀ a ∈ l, ¬p a := by
+  simp only [countP_eq_length_filter, length_eq_zero, filter_eq_nil]
 
-theorem countp_eq_length : countp p l = l.length ↔ ∀ a ∈ l, p a := by
-  rw [countp_eq_length_filter, filter_length_eq_length]
+theorem countP_eq_length : countP p l = l.length ↔ ∀ a ∈ l, p a := by
+  rw [countP_eq_length_filter, filter_length_eq_length]
 
-theorem Sublist.countp_le (s : l₁ <+ l₂) : countp p l₁ ≤ countp p l₂ := by
-  simp only [countp_eq_length_filter]
+theorem Sublist.countP_le (s : l₁ <+ l₂) : countP p l₁ ≤ countP p l₂ := by
+  simp only [countP_eq_length_filter]
   apply s.filter _ |>.length_le
 
-theorem countp_filter (l : List α) :
-    countp p (filter q l) = countp (fun a => p a ∧ q a) l := by
-  simp only [countp_eq_length_filter, filter_filter]
+theorem countP_filter (l : List α) :
+    countP p (filter q l) = countP (fun a => p a ∧ q a) l := by
+  simp only [countP_eq_length_filter, filter_filter]
 
-@[simp] theorem countp_true {l : List α} : (l.countp fun _ => true) = l.length := by
-  rw [countp_eq_length]
+@[simp] theorem countP_true {l : List α} : (l.countP fun _ => true) = l.length := by
+  rw [countP_eq_length]
   simp
 
-@[simp] theorem countp_false {l : List α} : (l.countp fun _ => false) = 0 := by
-  rw [countp_eq_zero]
+@[simp] theorem countP_false {l : List α} : (l.countP fun _ => false) = 0 := by
+  rw [countP_eq_zero]
   simp
 
-@[simp] theorem countp_map (p : β → Bool) (f : α → β) :
-    ∀ l, countp p (map f l) = countp (p ∘ f) l
+@[simp] theorem countP_map (p : β → Bool) (f : α → β) :
+    ∀ l, countP p (map f l) = countP (p ∘ f) l
   | [] => rfl
-  | a :: l => by rw [map_cons, countp_cons, countp_cons, countp_map p f l]; rfl
+  | a :: l => by rw [map_cons, countP_cons, countP_cons, countP_map p f l]; rfl
 
 variable {p q}
 
-theorem countp_mono_left (h : ∀ x ∈ l, p x → q x) : countp p l ≤ countp q l := by
+theorem countP_mono_left (h : ∀ x ∈ l, p x → q x) : countP p l ≤ countP q l := by
   induction l with
   | nil => apply Nat.le_refl
   | cons a l ihl =>
     rw [forall_mem_cons] at h
     have ⟨ha, hl⟩ := h
-    simp [countp_cons]
+    simp [countP_cons]
     cases h : p a
     . simp
       apply Nat.le_trans ?_ (Nat.le_add_right _ _)
@@ -123,16 +123,16 @@ theorem countp_mono_left (h : ∀ x ∈ l, p x → q x) : countp p l ≤ countp 
       apply Nat.succ_le_succ
       apply ihl hl
 
-theorem countp_congr (h : ∀ x ∈ l, p x ↔ q x) : countp p l = countp q l :=
+theorem countP_congr (h : ∀ x ∈ l, p x ↔ q x) : countP p l = countP q l :=
   Nat.le_antisymm
-    (countp_mono_left fun x hx => (h x hx).1)
-    (countp_mono_left fun x hx => (h x hx).2)
+    (countP_mono_left fun x hx => (h x hx).1)
+    (countP_mono_left fun x hx => (h x hx).2)
 
-end Countp
+end countP
 
 /-! ### count -/
 
-section Count
+section count
 
 variable [DecidableEq α]
 
@@ -140,7 +140,7 @@ variable [DecidableEq α]
 
 theorem count_cons (a b : α) (l : List α) :
     count a (b :: l) = count a l + if a = b then 1 else 0 := by conv =>
-  simp [count, countp_cons]
+  simp [count, countP_cons]
   lhs
   simp only [eq_comm]
 
@@ -155,10 +155,10 @@ theorem count_tail : ∀ (l : List α) (a : α) (h : 0 < l.length),
   | head :: tail, a, h => by simp [count_cons]
 
 theorem count_le_length (a : α) (l : List α) : count a l ≤ l.length :=
-  countp_le_length _
+  countP_le_length _
 
 theorem Sublist.count_le (h : l₁ <+ l₂) (a : α) : count a l₁ ≤ count a l₂ :=
-  h.countp_le _
+  h.countP_le _
 
 theorem count_le_count_cons (a b : α) (l : List α) : count a l ≤ count a (b :: l) :=
   (sublist_cons _ _).count_le _
@@ -169,12 +169,12 @@ theorem count_singleton' (a b : α) : count a [b] = if a = b then 1 else 0 := by
   simp [count_cons]
 
 @[simp] theorem count_append (a : α) : ∀ l₁ l₂, count a (l₁ ++ l₂) = count a l₁ + count a l₂ :=
-  countp_append _
+  countP_append _
 
 theorem count_concat (a : α) (l : List α) : count a (concat l a) = succ (count a l) := by simp
 
 theorem count_pos_iff_mem {a : α} {l : List α} : 0 < count a l ↔ a ∈ l := by
-  simp only [count, countp_pos, beq_iff_eq, exists_eq_right]
+  simp only [count, countP_pos, beq_iff_eq, exists_eq_right]
 
 @[simp 900] theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a l = 0 :=
   Decidable.byContradiction fun h' => h <| count_pos_iff_mem.1 (Nat.pos_of_ne_zero h')
@@ -186,7 +186,7 @@ theorem count_eq_zero {l : List α} : count a l = 0 ↔ a ∉ l :=
   ⟨not_mem_of_count_eq_zero, count_eq_zero_of_not_mem⟩
 
 theorem count_eq_length {l : List α} : count a l = l.length ↔ ∀ b ∈ l, a = b := by
-  rw [count, countp_eq_length]
+  rw [count, countP_eq_length]
   refine ⟨fun h b hb => ?h₁, fun h b hb => ?h₂⟩
   · refine' Eq.symm _
     have := h b hb
@@ -202,7 +202,7 @@ theorem count_replicate (a b : α) (n : Nat) : count a (replicate n b) = if a = 
   exacts [‹a = b› ▸ count_replicate_self .., count_eq_zero.2 <| mt eq_of_mem_replicate ‹a ≠ b›]
 
 theorem filter_beq' (l : List α) (a : α) : l.filter (· == a) = replicate (count a l) a := by
-  simp only [count, countp_eq_length_filter, eq_replicate, mem_filter, beq_iff_eq]
+  simp only [count, countP_eq_length_filter, eq_replicate, mem_filter, beq_iff_eq]
   exact ⟨trivial, fun _ h => h.2⟩
 
 theorem filter_eq' (l : List α) (a : α) : l.filter (· = a) = replicate (count a l) a :=
@@ -230,7 +230,7 @@ theorem replicate_count_eq_of_count_eq_length {l : List α} (h : count a l = len
     (length_replicate (count a l) a).trans h
 
 @[simp] theorem count_filter {l : List α} (h : p a) : count a (filter p l) = count a l := by
-  rw [count, countp_filter]
+  rw [count, countP_filter]
   congr
   funext b
   rw [(by rfl : (b == a) = decide (b = a))]
@@ -239,8 +239,8 @@ theorem replicate_count_eq_of_count_eq_length {l : List α} (h : count a l = len
 
 theorem count_le_count_map [DecidableEq β] (l : List α) (f : α → β) (x : α) :
     count x l ≤ count (f x) (map f l) := by
-  rw [count, count, countp_map]
-  exact countp_mono_left <| by simp (config := {contextual := true})
+  rw [count, count, countP_map]
+  exact countP_mono_left <| by simp (config := {contextual := true})
 
 theorem count_erase (a b : α) :
     ∀ l : List α, count a (l.erase b) = count a l - if a = b then 1 else 0

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -17,16 +17,13 @@ definitions can be found in `Std.Data.List.Basic`.
 
 open Nat
 
-variable {l : List α}
-
 namespace List
 
 section Countp
 
 variable (p q : α → Bool)
 
-@[simp]
-theorem countp_nil : countp p [] = 0 := rfl
+@[simp] theorem countp_nil : countp p [] = 0 := rfl
 
 protected theorem countp_go_eq_add (l) : countp.go p l n = n + countp.go p l 0 := by
   induction l generalizing n with
@@ -38,8 +35,7 @@ protected theorem countp_go_eq_add (l) : countp.go p l n = n + countp.go p l 0 :
     · simp [h, Nat.add_assoc]
     · simp [h]
 
-@[simp]
-theorem countp_cons_of_pos {a : α} (l) (pa : p a) : countp p (a :: l) = countp p l + 1 := by
+@[simp] theorem countp_cons_of_pos (l) (pa : p a) : countp p (a :: l) = countp p l + 1 := by
   have : countp.go p (a :: l) 0 = countp.go p l 1 := by
     suffices (bif _ then _ else _) = countp.go _ _ _ from this
     rw [pa]
@@ -47,11 +43,8 @@ theorem countp_cons_of_pos {a : α} (l) (pa : p a) : countp p (a :: l) = countp 
   unfold countp
   rw [this, Nat.add_comm, List.countp_go_eq_add]
 
-@[simp]
-theorem countp_cons_of_neg {a : α} (l) (pa : ¬p a) : countp p (a :: l) = countp p l := by
-  suffices (bif _ then _ else _) = countp.go _ _ _ from this
-  rw [Bool.of_not_eq_true pa]
-  rfl
+@[simp] theorem countp_cons_of_neg (l) (pa : ¬p a) : countp p (a :: l) = countp p l := by
+  simp [countp, countp.go, pa]
 
 theorem countp_cons (a : α) (l) : countp p (a :: l) = countp p l + if p a then 1 else 0 := by
   by_cases h : p a <;> simp [h]
@@ -80,28 +73,16 @@ theorem countp_le_length : countp p l ≤ l.length := by
   simp only [countp_eq_length_filter]
   apply length_filter_le
 
-@[simp]
-theorem countp_append (l₁ l₂) : countp p (l₁ ++ l₂) = countp p l₁ + countp p l₂ := by
+@[simp] theorem countp_append (l₁ l₂) : countp p (l₁ ++ l₂) = countp p l₁ + countp p l₂ := by
   simp only [countp_eq_length_filter, filter_append, length_append]
 
 theorem countp_pos : 0 < countp p l ↔ ∃ a ∈ l, p a := by
   simp only [countp_eq_length_filter, length_pos_iff_exists_mem, mem_filter, exists_prop]
 
-@[simp]
-theorem countp_eq_zero : countp p l = 0 ↔ ∀ a ∈ l, ¬p a := by
-  rw [countp_eq_length_filter, length_eq_zero, eq_nil_iff_forall_not_mem]
-  constructor <;> intro h a ha
-  next =>
-    intro hcontra
-    apply h a
-    apply mem_filter.mpr ⟨ha,hcontra⟩
-  next =>
-    have ⟨h1, h2⟩ := mem_filter.mp ha
-    apply h a h1
-    exact h2
+@[simp] theorem countp_eq_zero : countp p l = 0 ↔ ∀ a ∈ l, ¬p a := by
+  simp only [countp_eq_length_filter, length_eq_zero, filter_eq_nil]
 
-@[simp]
-theorem countp_eq_length : countp p l = l.length ↔ ∀ a ∈ l, p a := by
+@[simp] theorem countp_eq_length : countp p l = l.length ↔ ∀ a ∈ l, p a := by
   rw [countp_eq_length_filter, filter_length_eq_length]
 
 theorem length_filter_lt_length_iff_exists (l) :
@@ -117,18 +98,15 @@ theorem Sublist.countp_le (s : l₁ <+ l₂) : countp p l₁ ≤ countp p l₂ :
   simp only [countp_eq_length_filter]
   apply s.filter.length_le
 
-@[simp]
-theorem countp_filter (l : List α) : countp p (filter q l) = countp (fun a => p a ∧ q a) l := by
+@[simp] theorem countp_filter (l : List α) :
+    countp p (filter q l) = countp (fun a => p a ∧ q a) l := by
   simp only [countp_eq_length_filter, filter_filter]
 
-@[simp]
-theorem countp_true : (l.countp fun _ => true) = l.length := by simp
+@[simp] theorem countp_true {l : List α} : (l.countp fun _ => true) = l.length := by simp
 
-@[simp]
-theorem countp_false : (l.countp fun _ => false) = 0 := by simp
+@[simp] theorem countp_false {l : List α} : (l.countp fun _ => false) = 0 := by simp
 
-@[simp]
-theorem countp_map (p : β → Bool) (f : α → β) :
+@[simp] theorem countp_map (p : β → Bool) (f : α → β) :
     ∀ l, countp p (map f l) = countp (p ∘ f) l
   | [] => rfl
   | a :: l => by rw [map_cons, countp_cons, countp_cons, countp_map p f l]; rfl
@@ -163,8 +141,7 @@ section Count
 
 variable [DecidableEq α]
 
-@[simp]
-theorem count_nil (a : α) : count a [] = 0 := rfl
+@[simp] theorem count_nil (a : α) : count a [] = 0 := rfl
 
 theorem count_cons' (a b : α) (l : List α) :
     count a (b :: l) = count a l + if a = b then 1 else 0 := by conv =>
@@ -185,13 +162,9 @@ theorem count_cons_self (a : α) (l : List α) : count a (a :: l) = count a l + 
 theorem count_cons_of_ne (h : a ≠ b) (l : List α) : count a (b :: l) = count a l := by
   simp [count_cons', h]
 
-theorem count_tail :
-    ∀ (l : List α) (a : α) (h : 0 < l.length),
-      l.tail.count a = l.count a - if a = List.get l ⟨0, h⟩ then 1 else 0
-  | head :: tail, a, h => by
-    rw [count_cons']
-    split <;>
-      next h => simp [h] at *
+theorem count_tail : ∀ (l : List α) (a : α) (h : 0 < l.length),
+      l.tail.count a = l.count a - if a = get l ⟨0, h⟩ then 1 else 0
+  | head :: tail, a, h => by simp [count_cons]
 
 theorem count_le_length (a : α) (l : List α) : count a l ≤ l.length :=
   countp_le_length _
@@ -203,21 +176,17 @@ theorem count_le_count_cons (a b : α) (l : List α) : count a l ≤ count a (b 
   (sublist_cons _ _).count_le _
 
 theorem count_singleton (a : α) : count a [a] = 1 := by
-  rw [count_cons]
-  simp
+  simp [count_cons]
 
 theorem count_singleton' (a b : α) : count a [b] = if a = b then 1 else 0 := by
-  rw [count_cons]
-  rfl
+  simp [count_cons]
 
-@[simp]
-theorem count_append (a : α) : ∀ l₁ l₂, count a (l₁ ++ l₂) = count a l₁ + count a l₂ :=
+@[simp] theorem count_append (a : α) : ∀ l₁ l₂, count a (l₁ ++ l₂) = count a l₁ + count a l₂ :=
   countp_append _
 
 theorem count_concat (a : α) (l : List α) : count a (concat l a) = succ (count a l) := by simp
 
-@[simp]
-theorem count_pos {a : α} {l : List α} : 0 < count a l ↔ a ∈ l := by
+@[simp] theorem count_pos {a : α} {l : List α} : 0 < count a l ↔ a ∈ l := by
   simp only [count, countp_pos, beq_iff_eq, exists_eq_right]
 
 @[simp]
@@ -229,12 +198,10 @@ theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a 
 theorem not_mem_of_count_eq_zero {a : α} {l : List α} (h : count a l = 0) : a ∉ l :=
   fun h' => Nat.ne_of_lt (count_pos.2 h') h.symm
 
-@[simp]
-theorem count_eq_zero : count a l = 0 ↔ a ∉ l :=
+@[simp] theorem count_eq_zero {l : List α} : count a l = 0 ↔ a ∉ l :=
   ⟨not_mem_of_count_eq_zero, count_eq_zero_of_not_mem⟩
 
-@[simp]
-theorem count_eq_length : count a l = l.length ↔ ∀ b ∈ l, a = b := by
+@[simp] theorem count_eq_length {l : List α} : count a l = l.length ↔ ∀ b ∈ l, a = b := by
   rw [count, countp_eq_length]
   refine ⟨fun h b hb => ?h₁, fun h b hb => ?h₂⟩
   · refine' Eq.symm _
@@ -243,13 +210,12 @@ theorem count_eq_length : count a l = l.length ↔ ∀ b ∈ l, a = b := by
     exact this
   · rw [h b hb, beq_self_eq_true]
 
-@[simp]
-theorem count_replicate_self (a : α) (n : Nat) : count a (replicate n a) = n :=
-  (count_eq_length.2 <| fun _ h => (eq_of_mem_replicate h).symm).trans (length_replicate _ _)
+@[simp] theorem count_replicate_self (a : α) (n : Nat) : count a (replicate n a) = n :=
+  (count_eq_length.2 <| fun _ h => (eq_of_mem_replicate h).symm).trans (length_replicate ..)
 
 theorem count_replicate (a b : α) (n : Nat) : count a (replicate n b) = if a = b then n else 0 := by
   split
-  exacts [‹a = b› ▸ count_replicate_self _ _, count_eq_zero.2 <| mt eq_of_mem_replicate ‹a ≠ b›]
+  exacts [‹a = b› ▸ count_replicate_self .., count_eq_zero.2 <| mt eq_of_mem_replicate ‹a ≠ b›]
 
 theorem filter_beq' (l : List α) (a : α) : l.filter (· == a) = replicate (count a l) a := by
   simp only [count, countp_eq_length_filter, eq_replicate, mem_filter, beq_iff_eq]
@@ -266,7 +232,7 @@ theorem filter_eq (l : List α) (a : α) : l.filter (a = ·) = replicate (count 
 theorem filter_beq (l : List α) (a : α) : l.filter (a == ·) = replicate (count a l) a :=
   filter_eq l a
 
-theorem le_count_iff_replicate_sublist : n ≤ count a l ↔ replicate n a <+ l :=
+theorem le_count_iff_replicate_sublist {l : List α} : n ≤ count a l ↔ replicate n a <+ l :=
   ⟨fun h =>
     ((replicate_sublist_replicate a).2 h).trans <| filter_eq l a ▸ filter_sublist _,
     fun h => by
@@ -274,13 +240,12 @@ theorem le_count_iff_replicate_sublist : n ≤ count a l ↔ replicate n a <+ l 
       simp only [count_replicate_self] at this ⊢
       exact this⟩
 
-theorem replicate_count_eq_of_count_eq_length (h : count a l = length l) :
+theorem replicate_count_eq_of_count_eq_length {l : List α} (h : count a l = length l) :
     replicate (count a l) a = l :=
   (le_count_iff_replicate_sublist.mp (Nat.le_refl _)).eq_of_length <|
     (length_replicate (count a l) a).trans h
 
-@[simp]
-theorem count_filter (h : p a) : count a (filter p l) = count a l := by
+@[simp] theorem count_filter {l : List α} (h : p a) : count a (filter p l) = count a l := by
   rw [count, countp_filter]
   congr
   funext b
@@ -299,17 +264,15 @@ theorem count_erase (a b : α) :
   | c :: l => by
     rw [erase_cons]
     by_cases hc : c = b
-    · rw [if_pos hc, hc, count_cons', Nat.add_sub_cancel]
-    · rw [if_neg hc, count_cons', count_cons', count_erase a b l]
+    · rw [if_pos hc, hc, count_cons, Nat.add_sub_cancel]
+    · rw [if_neg hc, count_cons, count_cons, count_erase a b l]
       by_cases ha : a = b
       · rw [← ha, eq_comm] at hc
         rw [if_pos ha, if_neg hc, Nat.add_zero, Nat.add_zero]
       · rw [if_neg ha, Nat.sub_zero, Nat.sub_zero]
 
-@[simp]
-theorem count_erase_self (a : α) (l : List α) : count a (List.erase l a) = count a l - 1 := by
+@[simp] theorem count_erase_self (a : α) (l : List α) : count a (List.erase l a) = count a l - 1 := by
   rw [count_erase, if_pos rfl]
 
-@[simp]
-theorem count_erase_of_ne (ab : a ≠ b) (l : List α) : count a (l.erase b) = count a l :=
+@[simp] theorem count_erase_of_ne (ab : a ≠ b) (l : List α) : count a (l.erase b) = count a l :=
   by rw [count_erase, if_neg ab, Nat.sub_zero]

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -85,15 +85,6 @@ theorem countp_pos : 0 < countp p l ↔ ∃ a ∈ l, p a := by
 @[simp] theorem countp_eq_length : countp p l = l.length ↔ ∀ a ∈ l, p a := by
   rw [countp_eq_length_filter, filter_length_eq_length]
 
-theorem length_filter_lt_length_iff_exists (l) :
-    length (filter p l) < length l ↔ ∃ x ∈ l, ¬p x := by
-  have := countp_pos (fun x => ¬p x) (l := l)
-  simp [length_eq_countp_add_countp p l, countp_eq_length_filter] at this ⊢
-  rw [←this]
-  generalize length (filter p l) = x
-  generalize length (filter _ _) = y
-  rw [Nat.lt_add_right_iff_pos]
-
 theorem Sublist.countp_le (s : l₁ <+ l₂) : countp p l₁ ≤ countp p l₂ := by
   simp only [countp_eq_length_filter]
   apply s.filter.length_le
@@ -182,8 +173,7 @@ theorem count_concat (a : α) (l : List α) : count a (concat l a) = succ (count
 @[simp] theorem count_pos {a : α} {l : List α} : 0 < count a l ↔ a ∈ l := by
   simp only [count, countp_pos, beq_iff_eq, exists_eq_right]
 
-@[simp]
-theorem one_le_count_iff_mem {a : α} {l : List α} : 1 ≤ count a l ↔ a ∈ l := count_pos
+@[simp] theorem one_le_count_iff_mem {a : α} {l : List α} : 1 ≤ count a l ↔ a ∈ l := count_pos
 
 theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a l = 0 :=
   Decidable.byContradiction fun h' => h <| count_pos.1 (Nat.pos_of_ne_zero h')

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -285,7 +285,7 @@ theorem count_filter (h : p a) : count a (filter p l) = count a l := by
   congr
   funext b
   rw [(by rfl : (b == a) = decide (b = a))]
-  rw [decide_eq_decide_iff_iff]
+  rw [decide_eq_decide]
   simp; intro heq; exact heq ▸ h
 
 theorem count_le_count_map [DecidableEq β] (l : List α) (f : α → β) (x : α) :

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -159,8 +159,7 @@ theorem Sublist.count_le (h : l₁ <+ l₂) (a : α) : count a l₁ ≤ count a 
 theorem count_le_count_cons (a b : α) (l : List α) : count a l ≤ count a (b :: l) :=
   (sublist_cons _ _).count_le _
 
-theorem count_singleton (a : α) : count a [a] = 1 := by
-  simp [count_cons]
+theorem count_singleton (a : α) : count a [a] = 1 := by simp
 
 theorem count_singleton' (a b : α) : count a [b] = if a = b then 1 else 0 := by
   simp [count_cons]

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -255,8 +255,8 @@ theorem count_erase (a b : α) :
         rw [if_pos ha, if_neg hc, Nat.add_zero, Nat.add_zero]
       · rw [if_neg ha, Nat.sub_zero, Nat.sub_zero]
 
-@[simp] theorem count_erase_self (a : α) (l : List α) : count a (List.erase l a) = count a l - 1 := by
-  rw [count_erase, if_pos rfl]
+@[simp] theorem count_erase_self (a : α) (l : List α) :
+    count a (List.erase l a) = count a l - 1 := by rw [count_erase, if_pos rfl]
 
 @[simp] theorem count_erase_of_ne (ab : a ≠ b) (l : List α) : count a (l.erase b) = count a l :=
   by rw [count_erase, if_neg ab, Nat.sub_zero]

--- a/Std/Data/List/Count.lean
+++ b/Std/Data/List/Count.lean
@@ -79,23 +79,27 @@ theorem countp_le_length : countp p l ≤ l.length := by
 theorem countp_pos : 0 < countp p l ↔ ∃ a ∈ l, p a := by
   simp only [countp_eq_length_filter, length_pos_iff_exists_mem, mem_filter, exists_prop]
 
-@[simp] theorem countp_eq_zero : countp p l = 0 ↔ ∀ a ∈ l, ¬p a := by
+theorem countp_eq_zero : countp p l = 0 ↔ ∀ a ∈ l, ¬p a := by
   simp only [countp_eq_length_filter, length_eq_zero, filter_eq_nil]
 
-@[simp] theorem countp_eq_length : countp p l = l.length ↔ ∀ a ∈ l, p a := by
+theorem countp_eq_length : countp p l = l.length ↔ ∀ a ∈ l, p a := by
   rw [countp_eq_length_filter, filter_length_eq_length]
 
 theorem Sublist.countp_le (s : l₁ <+ l₂) : countp p l₁ ≤ countp p l₂ := by
   simp only [countp_eq_length_filter]
   apply s.filter _ |>.length_le
 
-@[simp] theorem countp_filter (l : List α) :
+theorem countp_filter (l : List α) :
     countp p (filter q l) = countp (fun a => p a ∧ q a) l := by
   simp only [countp_eq_length_filter, filter_filter]
 
-@[simp] theorem countp_true {l : List α} : (l.countp fun _ => true) = l.length := by simp
+@[simp] theorem countp_true {l : List α} : (l.countp fun _ => true) = l.length := by
+  rw [countp_eq_length]
+  simp
 
-@[simp] theorem countp_false {l : List α} : (l.countp fun _ => false) = 0 := by simp
+@[simp] theorem countp_false {l : List α} : (l.countp fun _ => false) = 0 := by
+  rw [countp_eq_zero]
+  simp
 
 @[simp] theorem countp_map (p : β → Bool) (f : α → β) :
     ∀ l, countp p (map f l) = countp (p ∘ f) l
@@ -169,21 +173,19 @@ theorem count_singleton' (a b : α) : count a [b] = if a = b then 1 else 0 := by
 
 theorem count_concat (a : α) (l : List α) : count a (concat l a) = succ (count a l) := by simp
 
-@[simp] theorem count_pos {a : α} {l : List α} : 0 < count a l ↔ a ∈ l := by
+theorem count_pos_iff_mem {a : α} {l : List α} : 0 < count a l ↔ a ∈ l := by
   simp only [count, countp_pos, beq_iff_eq, exists_eq_right]
 
-@[simp] theorem one_le_count_iff_mem {a : α} {l : List α} : 1 ≤ count a l ↔ a ∈ l := count_pos
-
 @[simp] theorem count_eq_zero_of_not_mem {a : α} {l : List α} (h : a ∉ l) : count a l = 0 :=
-  Decidable.byContradiction fun h' => h <| count_pos.1 (Nat.pos_of_ne_zero h')
+  Decidable.byContradiction fun h' => h <| count_pos_iff_mem.1 (Nat.pos_of_ne_zero h')
 
 theorem not_mem_of_count_eq_zero {a : α} {l : List α} (h : count a l = 0) : a ∉ l :=
-  fun h' => Nat.ne_of_lt (count_pos.2 h') h.symm
+  fun h' => Nat.ne_of_lt (count_pos_iff_mem.2 h') h.symm
 
-@[simp] theorem count_eq_zero {l : List α} : count a l = 0 ↔ a ∉ l :=
+theorem count_eq_zero {l : List α} : count a l = 0 ↔ a ∉ l :=
   ⟨not_mem_of_count_eq_zero, count_eq_zero_of_not_mem⟩
 
-@[simp] theorem count_eq_length {l : List α} : count a l = l.length ↔ ∀ b ∈ l, a = b := by
+theorem count_eq_length {l : List α} : count a l = l.length ↔ ∀ b ∈ l, a = b := by
   rw [count, countp_eq_length]
   refine ⟨fun h b hb => ?h₁, fun h b hb => ?h₂⟩
   · refine' Eq.symm _


### PR DESCRIPTION
Moves `Mathlib/Data/List/Count.lean` to Std. I believe there are no notable changes from mathlib, aside from dropping various lemmas about prod.

Depends on ~~#98 #96 #94 #97~~. EDIT: all merged :)