### PR TITLE
feat: move `RatCast` into std4

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -3,6 +3,7 @@ import Std.Classes.Cast
 import Std.Classes.Dvd
 import Std.Classes.LawfulMonad
 import Std.Classes.Order
+import Std.Classes.RatCast
 import Std.Classes.SetNotation
 import Std.Control.ForInStep
 import Std.Control.ForInStep.Basic

--- a/Std/Classes/Cast.lean
+++ b/Std/Classes/Cast.lean
@@ -11,6 +11,8 @@ class NatCast (R : Type u) where
   /-- The canonical map `Nat → R`. -/
   protected natCast : Nat → R
 
+instance : NatCast Nat where natCast := id
+
 /-- Canonical homomorphism from `Nat` to a additive monoid `R` with a `1`.
 This is just the bare function in order to aid in creating instances of `AddMonoidWithOne`. -/
 @[coe, match_pattern] protected def Nat.cast {R : Type u} [NatCast R] : Nat → R := NatCast.natCast
@@ -25,6 +27,8 @@ instance [NatCast R] : CoeHTCT Nat R where coe := Nat.cast
 class IntCast (R : Type u) where
   /-- The canonical map `Int → R`. -/
   protected intCast : Int → R
+
+instance : IntCast Int where intCast := id
 
 /-- Canonical homomorphism from `Int` to a additive group `R` with a `1`.
 This is just the bare function in order to aid in creating instances of `AddGroupWithOne`. -/

--- a/Std/Classes/Cast.lean
+++ b/Std/Classes/Cast.lean
@@ -11,7 +11,7 @@ class NatCast (R : Type u) where
   /-- The canonical map `Nat → R`. -/
   protected natCast : Nat → R
 
-instance : NatCast Nat where natCast := id
+instance : NatCast Nat where natCast n := n
 
 /-- Canonical homomorphism from `Nat` to a additive monoid `R` with a `1`.
 This is just the bare function in order to aid in creating instances of `AddMonoidWithOne`. -/

--- a/Std/Classes/Cast.lean
+++ b/Std/Classes/Cast.lean
@@ -29,7 +29,7 @@ class IntCast (R : Type u) where
   /-- The canonical map `Int → R`. -/
   protected intCast : Int → R
 
-instance : IntCast Int where intCast := id
+instance : IntCast Int where intCast n := n
 
 /-- Canonical homomorphism from `Int` to a additive group `R` with a `1`.
 This is just the bare function in order to aid in creating instances of `AddGroupWithOne`. -/

--- a/Std/Classes/Cast.lean
+++ b/Std/Classes/Cast.lean
@@ -15,7 +15,8 @@ instance : NatCast Nat where natCast := id
 
 /-- Canonical homomorphism from `Nat` to a additive monoid `R` with a `1`.
 This is just the bare function in order to aid in creating instances of `AddMonoidWithOne`. -/
-@[coe, match_pattern] protected def Nat.cast {R : Type u} [NatCast R] : Nat → R := NatCast.natCast
+@[coe, reducible, match_pattern] protected def Nat.cast {R : Type u} [NatCast R] : Nat → R :=
+  NatCast.natCast
 
 -- see note [coercion into rings]
 instance [NatCast R] : CoeTail Nat R where coe := Nat.cast
@@ -32,7 +33,8 @@ instance : IntCast Int where intCast := id
 
 /-- Canonical homomorphism from `Int` to a additive group `R` with a `1`.
 This is just the bare function in order to aid in creating instances of `AddGroupWithOne`. -/
-@[coe, match_pattern] protected def Int.cast {R : Type u} [IntCast R] : Int → R := IntCast.intCast
+@[coe, reducible, match_pattern] protected def Int.cast {R : Type u} [IntCast R] : Int → R :=
+  IntCast.intCast
 
 -- see note [coercion into rings]
 instance [IntCast R] : CoeTail Int R where coe := Int.cast

--- a/Std/Classes/RatCast.lean
+++ b/Std/Classes/RatCast.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2014 Robert Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Lewis, Leonardo de Moura, Johannes Hölzl, Mario Carneiro, Gabriel Ebner
+-/
+import Std.Data.Rat.Basic
+
+/-- Type class for the canonical homomorphism `Rat → K`. -/
+class RatCast (K : Type u) where
+  /-- The canonical homomorphism `Rat → K`. -/
+  protected ratCast : Rat → K
+
+/-- Canonical homomorphism from `Rat` to a division ring `K`.
+This is just the bare function in order to aid in creating instances of `DivisionRing`. -/
+@[coe, match_pattern] protected def Rat.cast {K : Type u} [RatCast K] : Rat → K := RatCast.ratCast
+
+-- see note [coercion into rings]
+instance [RatCast K] : CoeTail Rat K where coe := Rat.cast
+
+-- see note [coercion into rings]
+instance [RatCast K] : CoeHTCT Rat K where coe := Rat.cast
+

--- a/Std/Classes/RatCast.lean
+++ b/Std/Classes/RatCast.lean
@@ -10,6 +10,8 @@ class RatCast (K : Type u) where
   /-- The canonical homomorphism `Rat → K`. -/
   protected ratCast : Rat → K
 
+instance : RatCast Rat where ratCast := id
+
 /-- Canonical homomorphism from `Rat` to a division ring `K`.
 This is just the bare function in order to aid in creating instances of `DivisionRing`. -/
 @[coe, match_pattern] protected def Rat.cast {K : Type u} [RatCast K] : Rat → K := RatCast.ratCast

--- a/Std/Classes/RatCast.lean
+++ b/Std/Classes/RatCast.lean
@@ -10,7 +10,7 @@ class RatCast (K : Type u) where
   /-- The canonical homomorphism `Rat → K`. -/
   protected ratCast : Rat → K
 
-instance : RatCast Rat where ratCast := id
+instance : RatCast Rat where ratCast n := n
 
 /-- Canonical homomorphism from `Rat` to a division ring `K`.
 This is just the bare function in order to aid in creating instances of `DivisionRing`. -/

--- a/Std/Classes/RatCast.lean
+++ b/Std/Classes/RatCast.lean
@@ -14,11 +14,11 @@ instance : RatCast Rat where ratCast := id
 
 /-- Canonical homomorphism from `Rat` to a division ring `K`.
 This is just the bare function in order to aid in creating instances of `DivisionRing`. -/
-@[coe, match_pattern] protected def Rat.cast {K : Type u} [RatCast K] : Rat → K := RatCast.ratCast
+@[coe, reducible, match_pattern] protected def Rat.cast {K : Type u} [RatCast K] : Rat → K :=
+  RatCast.ratCast
 
 -- see note [coercion into rings]
 instance [RatCast K] : CoeTail Rat K where coe := Rat.cast
 
 -- see note [coercion into rings]
 instance [RatCast K] : CoeHTCT Rat K where coe := Rat.cast
-


### PR DESCRIPTION
This is used for leanprover-community/mathlib4#1707.

This also makes `Nat.cast`, `Int.cast`, and `Rat.cast` reducible.

We:
* move `RatCast` into std4
* define `Rat.cast` and give it coercion instances, in parallel to `Int.cast` and `Nat.cast`
* add reflexive instances for `NatCast`, `IntCast`, and `RatCast` (e.g. `NatCast Nat where natCast x := x`)
* add `@[reducible]` to (`Nat`/`Int`/`Rat`)`.cast`