### PR TITLE
fix: prevent `Int.ofNat` being used instead of `Nat.cast`

### DIFF
--- a/Std/Classes/Cast.lean
+++ b/Std/Classes/Cast.lean
@@ -12,6 +12,7 @@ class NatCast (R : Type u) where
   protected natCast : Nat → R
 
 instance : NatCast Nat where natCast n := n
+instance : NatCast Int where natCast n := Int.ofNat n
 
 /-- Canonical homomorphism from `Nat` to a additive monoid `R` with a `1`.
 This is just the bare function in order to aid in creating instances of `AddMonoidWithOne`. -/

--- a/Std/Classes/Cast.lean
+++ b/Std/Classes/Cast.lean
@@ -24,6 +24,9 @@ instance [NatCast R] : CoeTail Nat R where coe := Nat.cast
 -- see note [coercion into rings]
 instance [NatCast R] : CoeHTCT Nat R where coe := Nat.cast
 
+/-- This instance is needed to ensure that `instCoeNatInt` from core is not used. -/
+instance : Coe Nat Int where coe := Nat.cast
+
 /-- Type class for the canonical homomorphism `Int → R`. -/
 class IntCast (R : Type u) where
   /-- The canonical map `Int → R`. -/

--- a/Std/Data/Int/Lemmas.lean
+++ b/Std/Data/Int/Lemmas.lean
@@ -14,7 +14,6 @@ open Nat
 
 namespace Int
 
-instance : NatCast Int := ⟨ofNat⟩
 @[simp] theorem ofNat_eq_coe : ofNat n = Nat.cast n := rfl
 
 @[simp] theorem ofNat_zero : ((0 : Nat) : Int) = 0 := rfl


### PR DESCRIPTION
Not tested, I'm hoping CI will do that.