### PR TITLE
feat: make `Rat.ofScientific` `@[irreducible]`

### DIFF
--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -102,7 +102,8 @@ def divInt : Int → Int → Rat
 @[inherit_doc] scoped infixl:70 " /. " => Rat.divInt
 
 /-- Implements "scientific notation" `123.4e-5` for rational numbers. (This definition is
-`@[irreducible]` because you don't want to unfold it. Use `Rat.ofScientific_def` instead.) -/
+`@[irreducible]` because you don't want to unfold it. Use `Rat.ofScientific_true_def` or
+`Rat.ofScientific_false_def` instead.) -/
 @[irreducible] protected def ofScientific (m : Nat) (s : Bool) (e : Nat) : Rat :=
   if s then
     Rat.normalize m (10 ^ e) <| Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide)

--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -102,7 +102,7 @@ def divInt : Int → Int → Rat
 @[inherit_doc] scoped infixl:70 " /. " => Rat.divInt
 
 /-- Implements "scientific notation" `123.4e-5` for rational numbers. (This definition is
-`@[irreducible]` because you don't want to unfold it over e.g. `RatCast.ratCast`.) -/
+`@[irreducible]` because you don't want to unfold it. Use `Rat.ofScientific_def` instead.) -/
 @[irreducible] protected def ofScientific (m : Nat) (s : Bool) (e : Nat) : Rat :=
   if s then
     Rat.normalize m (10 ^ e) <| Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide)

--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -102,8 +102,8 @@ def divInt : Int → Int → Rat
 @[inherit_doc] scoped infixl:70 " /. " => Rat.divInt
 
 /-- Implements "scientific notation" `123.4e-5` for rational numbers. (This definition is
-`@[irreducible]` because you don't want to unfold it. Use `Rat.ofScientific_true_def` or
-`Rat.ofScientific_false_def` instead.) -/
+`@[irreducible]` because you don't want to unfold it. Use `Rat.ofScientific_def`,
+`Rat.ofScientific_true_def`, or `Rat.ofScientific_false_def` instead.) -/
 @[irreducible] protected def ofScientific (m : Nat) (s : Bool) (e : Nat) : Rat :=
   if s then
     Rat.normalize m (10 ^ e) <| Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide)

--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -101,8 +101,9 @@ def divInt : Int → Int → Rat
 
 @[inherit_doc] scoped infixl:70 " /. " => Rat.divInt
 
-/-- Implements "scientific notation" `123.4e-5` for rational numbers. -/
-protected def ofScientific (m : Nat) (s : Bool) (e : Nat) : Rat :=
+/-- Implements "scientific notation" `123.4e-5` for rational numbers. (This definition is
+`@[irreducible]` because you don't want to unfold it over e.g. `RatCast.ratCast`.) -/
+@[irreducible] protected def ofScientific (m : Nat) (s : Bool) (e : Nat) : Rat :=
   if s then
     Rat.normalize m (10 ^ e) <| Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide)
   else

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -299,12 +299,7 @@ theorem inv_def (a : Rat) : a.inv = a.den /. a.num := by
 
 theorem div_def (a b : Rat) : a / b = a * b.inv := rfl
 
-theorem ofScientific_true_def : Rat.ofScientific m true e =
-    normalize m (10 ^ e) (Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide)) := by
-  unfold Rat.ofScientific
-  rfl
-
-theorem ofScientific_true_def' : Rat.ofScientific m true e = mkRat m (10 ^ e) := by
+theorem ofScientific_true_def : Rat.ofScientific m true e = mkRat m (10 ^ e) := by
   unfold Rat.ofScientific
   exact normalize_eq_mkRat (Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide))
 

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -307,6 +307,4 @@ theorem ofScientific_false_def : Rat.ofScientific m false e = (m * 10 ^ e : Nat)
 
 theorem ofScientific_def : Rat.ofScientific m s e =
     if s then mkRat m (10 ^ e) else (m * 10 ^ e : Nat) := by
-  cases s
-  · exact ofScientific_false_def
-  · exact ofScientific_true_def
+  cases s; exact ofScientific_false_def; exact ofScientific_true_def

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -298,3 +298,16 @@ theorem inv_def (a : Rat) : a.inv = a.den /. a.num := by
   simp [inv_def, divInt_mul_right zg]
 
 theorem div_def (a b : Rat) : a / b = a * b.inv := rfl
+
+theorem ofScientific_true_def : Rat.ofScientific m true e =
+    normalize m (10 ^ e) (Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide)) := by
+  unfold Rat.ofScientific
+  rfl
+
+theorem ofScientific_true_def' : Rat.ofScientific m true e = mkRat m (10 ^ e) := by
+  unfold Rat.ofScientific
+  exact normalize_eq_mkRat (Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide))
+
+theorem ofScientific_false_def : Rat.ofScientific m false e = (m * 10 ^ e : Nat) := by
+  unfold Rat.ofScientific
+  rfl

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -306,3 +306,9 @@ theorem ofScientific_true_def : Rat.ofScientific m true e = mkRat m (10 ^ e) := 
 theorem ofScientific_false_def : Rat.ofScientific m false e = (m * 10 ^ e : Nat) := by
   unfold Rat.ofScientific
   rfl
+
+theorem ofScientific_def : Rat.ofScientific m s e =
+    if s then mkRat m (10 ^ e) else (m * 10 ^ e : Nat) := by
+  cases s
+  · exact ofScientific_false_def
+  · exact ofScientific_true_def

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -300,12 +300,10 @@ theorem inv_def (a : Rat) : a.inv = a.den /. a.num := by
 theorem div_def (a b : Rat) : a / b = a * b.inv := rfl
 
 theorem ofScientific_true_def : Rat.ofScientific m true e = mkRat m (10 ^ e) := by
-  unfold Rat.ofScientific
-  exact normalize_eq_mkRat (Nat.ne_of_gt <| Nat.pos_pow_of_pos _ (by decide))
+  unfold Rat.ofScientific; rw [normalize_eq_mkRat]; rfl
 
 theorem ofScientific_false_def : Rat.ofScientific m false e = (m * 10 ^ e : Nat) := by
-  unfold Rat.ofScientific
-  rfl
+  unfold Rat.ofScientific; rfl
 
 theorem ofScientific_def : Rat.ofScientific m s e =
     if s then mkRat m (10 ^ e) else (m * 10 ^ e : Nat) := by


### PR DESCRIPTION
We make `Rat.ofScientific` irreducible to prevent it from being unfolded during defeq checks in which we'd rather unfold e.g. `RatCast.ratCast` on the rhs. See [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/finishing.20up.20ofScientific.20in.20norm_num).