### PR TITLE
`Int.fmod_nonneg` variant

### DIFF
--- a/Std/Data/Int/DivMod.lean
+++ b/Std/Data/Int/DivMod.lean
@@ -373,6 +373,9 @@ theorem emod_nonneg : ∀ (a : Int) {b : Int}, b ≠ 0 → 0 ≤ a % b
 theorem fmod_nonneg {a b : Int} (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a.fmod b :=
   fmod_eq_mod ha hb ▸ mod_nonneg _ ha
 
+theorem fmod_nonneg' (a : Int) {b : Int} (hb : 0 < b) : 0 ≤ a.fmod b := 
+  fmod_eq_emod _ hb.le ▸ emod_nonneg _ hb.ne'
+
 theorem mod_lt_of_pos (a : Int) {b : Int} (H : 0 < b) : mod a b < b :=
   match a, b, eq_succ_of_zero_lt H with
   | ofNat _, _, ⟨n, rfl⟩ => ofNat_lt.2 <| Nat.mod_lt _ n.succ_pos

--- a/Std/Data/Int/DivMod.lean
+++ b/Std/Data/Int/DivMod.lean
@@ -374,7 +374,7 @@ theorem fmod_nonneg {a b : Int} (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a.fmod b :
   fmod_eq_mod ha hb ▸ mod_nonneg _ ha
 
 theorem fmod_nonneg' (a : Int) {b : Int} (hb : 0 < b) : 0 ≤ a.fmod b := 
-  fmod_eq_emod _ hb.le ▸ emod_nonneg _ hb.ne'
+  fmod_eq_emod _ (Int.le_of_lt hb) ▸ emod_nonneg _ (Int.ne_of_lt hb).symm
 
 theorem mod_lt_of_pos (a : Int) {b : Int} (H : 0 < b) : mod a b < b :=
   match a, b, eq_succ_of_zero_lt H with


### PR DESCRIPTION
I needed this variant of `Int.fmod_nonneg` with a weaker condition on `a` and a stronger condition on `b`.  Not sure if Std is yet in the "accepting random useful lemmas" stage of its existence, but I'm passing it along in case it is.