### PR TITLE
chore: fix bug in `tryIntros`

### DIFF
--- a/Std/Tactic/Ext.lean
+++ b/Std/Tactic/Ext.lean
@@ -116,7 +116,7 @@ def tryIntros [Monad m] [MonadLiftT TermElabM m] (g : MVarId) (pats : List (TSyn
   | p::ps =>
     if (← (g.withContext g.getType' : TermElabM _)).isForall then
       for g in ← RCases.rintro #[p] none g do
-        k g ps
+        tryIntros g ps k
     else k g pats
 
 /--

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -42,3 +42,12 @@ def Set (α : Type u) := α → Prop
 @[ext] structure Pretrivialization {F : Type u} (proj : Z → β) extends LocalEquiv Z (β × F) where
   baseSet : Set β
   source_eq : source = baseSet ∘ proj
+
+-- allow `ext` lemmas that introduce more than 1 variable at once:
+@[ext 1002]
+theorem bad_ext_lemma {α β γ : Type} (f g : α → β → γ) (h : ∀ i j, f i j = g i j) : f = g := by
+  ext i j
+  exact h i j
+example {α β γ : Type} (f g : α → β → γ) (h : ∀ i j, f i j = g i j) : f = g := by
+  ext i j
+  exact h i j


### PR DESCRIPTION
`tryIntros` fails on `∀`-statements with more than one variable. This causes `ext i j` to fail if an `ext`-lemma of the form `∀ i j, M i j = N i j → M = N` is applied. The result is that `i` is introduced and the goal starts with `\∀j, _`. An example is added to the test cases.