### PR TITLE
feat: add option for ext to flatten structure fields

### DIFF
--- a/Std/Tactic/Ext.lean
+++ b/Std/Tactic/Ext.lean
@@ -178,7 +178,6 @@ def extCore (g : MVarId) (pats : List (TSyntax `rcasesPat))
 * `ext pat*`: Apply extensionality lemmas as much as possible,
   using `pat*` to introduce the variables in extensionality lemmas like `funext`.
 * `ext`: introduce anonymous variables whenever needed.
-* `ext (flat := false) pat*`: Do not flatten structure fields.
 -/
 syntax "ext" (colGt ppSpace rintroPat)* (" : " num)? : tactic
 elab_rules : tactic

--- a/Std/Tactic/Ext.lean
+++ b/Std/Tactic/Ext.lean
@@ -10,6 +10,7 @@ import Std.Tactic.Ext.Attr
 namespace Std.Tactic.Ext
 open Lean Meta Elab Tactic
 
+
 /--
 Constructs the hypotheses for the extensionality lemma.
 Calls the continuation `k` with the list of parameters to the structure,
@@ -29,7 +30,6 @@ def withExtHyps (struct : Name) (flat := true)
       getStructureFieldsFlattened (← getEnv) struct (includeSubobjectFields := false)
     else
       getStructureFields (← getEnv) struct
-
     for field in structureFields do
       let x_f ← mkProjection x field
       let y_f ← mkProjection y field
@@ -53,7 +53,6 @@ scoped elab "ext_type%" struct:ident flat:extFlatOption ? : term => do
     | `(extFlatOption| (flat := true)) => pure ()
     | `(extFlatOption| (flat := false)) => flat' := false
     | _ => throwUnsupportedSyntax
-  --logInfo m!"flat is: {flat'}"
   withExtHyps (← resolveGlobalConstNoOverloadWithInfo struct) flat' fun params x y hyps => do
     let ty := hyps.foldr (init := ← mkEq x y) fun (f, h) ty =>
       mkForall f BinderInfo.default h ty

--- a/Std/Tactic/Ext/Attr.lean
+++ b/Std/Tactic/Ext/Attr.lean
@@ -47,7 +47,8 @@ and registers them for the `ext` tactic.
 When `@[ext]` is applied to a theorem,
 the theorem is registered for the `ext` tactic.
 
-You can use `@[ext 9000]` to specify a priority for the attribute. -/
+* You can use `@[ext 9000]` to specify a priority for the attribute.
+* Using `@[ext (flat := false)]` prevents `ext` from flattening structure fields. -/
 syntax (name := ext) "ext" extFlatOption ? prio ? : attr
 
 initialize registerBuiltinAttribute {

--- a/Std/Tactic/Ext/Attr.lean
+++ b/Std/Tactic/Ext/Attr.lean
@@ -9,8 +9,8 @@ import Std.Lean.Command
 namespace Std.Tactic.Ext
 open Lean Meta
 
-/-- An `flat := ...` option for `ext`. -/
-syntax extFlatOption := "(" &"flat" ":=" term ")" -- TODO
+/-- A `flat := ...` option for `ext`. -/
+syntax extFlatOption := "(" &"flat" ":=" term ")"
 
 /-- `declare_ext_theorems_for A` declares the extensionality theorems for the structure `A`. -/
 syntax "declare_ext_theorems_for" ident extFlatOption ? prio ? : command

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -42,3 +42,14 @@ def Set (α : Type u) := α → Prop
 @[ext] structure Pretrivialization {F : Type u} (proj : Z → β) extends LocalEquiv Z (β × F) where
   baseSet : Set β
   source_eq : source = baseSet ∘ proj
+
+-- When dealing with a structure extending another structur,
+-- he generated `ext` Lemma should say `x.toProd = y.toProd → x = y`.
+
+set_option tactic.ext.flatten false in
+@[ext]
+structure NonemptyInterval (α : Type _) [LE α] extends Prod α α where
+  fst_le_snd : fst ≤ snd
+example {α : Type _} [LE α](x y : NonemptyInterval α)  (h : x.toProd = y.toProd) : x = y := by
+  ext1
+  exact h

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -3,6 +3,8 @@ import Std.Logic
 
 set_option linter.missingDocs false
 
+set_option pp.rawOnError true
+
 structure A (n : Nat) where
   a : Nat
 
@@ -45,11 +47,9 @@ def Set (α : Type u) := α → Prop
 
 -- When dealing with a structure extending another structur,
 -- he generated `ext` Lemma should say `x.toProd = y.toProd → x = y`.
-
-set_option tactic.ext.flatten false in
-@[ext]
+@[ext (flat := false) 3]
 structure NonemptyInterval (α : Type _) [LE α] extends Prod α α where
   fst_le_snd : fst ≤ snd
 example {α : Type _} [LE α](x y : NonemptyInterval α)  (h : x.toProd = y.toProd) : x = y := by
-  ext1
+  ext
   exact h

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -3,8 +3,6 @@ import Std.Logic
 
 set_option linter.missingDocs false
 
-set_option pp.rawOnError true
-
 structure A (n : Nat) where
   a : Nat
 


### PR DESCRIPTION
This has come up in the mathlib port: [zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.233360.20new.20ext.20lemma.20generation/near/351104097), in particular in leanprover-community/mathlib4#3360

```
@[ext]
structure NonemptyInterval (α : Type _) [LE α] extends Prod α α where
  fst_le_snd : fst ≤ snd
```

here we would like the generated `ext`-lemma to be `x.toProd = y.toProd → x = y` instead of
`(x.toProd.fst = y.toProd.fst) → (x.toProd.snd = y.toProd.snd) → x = y`.

The suggested syntax is `@[ext (flat := false)]` for not flattening structure fields. The default value is `true` which keeps flattening them as it currently does.