### PR TITLE
feat: make `Acc.rec` and many related defs computable

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -101,3 +101,4 @@ import Std.Tactic.Unreachable
 import Std.Util.ExtendedBinder
 import Std.Util.LibraryNote
 import Std.Util.TermUnsafe
+import Std.WF

--- a/Std/WF.lean
+++ b/Std/WF.lean
@@ -3,80 +3,86 @@ Copyright (c) 2023 Miyahara Kō. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Miyahara Kō
 -/
-import Std.Tactic.Lint.Misc
 
-/-- `Accs r` is consisted of all accessible elements by `r`. -/
-structure Accs.{u} {α : Sort u} (r : α → α → Prop) where
-  /-- The accessible value. -/
-  val : α
-  /-- All elements in `Accs r` are accessible. -/
-  acc : Acc r val
+/-!
+# Computable Acc.rec and WellFounded.fix
 
-namespace Accs
+This file exports no public definitions / theorems, but by importing it the compiler will
+be able to compile `Acc.rec` and functions that use it. For example:
 
-universe u
-variable {α : Sort u} {r : α → α → Prop}
+Before:
+```
+-- failed to compile definition, consider marking it as 'noncomputable'
+-- because it depends on 'WellFounded.fix', and it does not have executable code
+def log2p1 : Nat → Nat :=
+  WellFounded.fix Nat.lt_wfRel.2 fun n IH =>
+    let m := n / 2
+    if h : m < n then
+      IH m h + 1
+    else
+      0
+```
 
-/-- The subrelation of `r` on this type is well-founded. -/
-@[nolint defLemma]
-def wf : WellFounded (InvImage r (val : Accs r → α)) := ⟨fun ac => InvImage.accessible _ ac.acc⟩
+After:
+```
+import Std.WF
 
-instance wfRel : WellFoundedRelation (Accs r) where
-  rel := InvImage r (val : Accs r → α)
-  wf  := Accs.wf
+def log2p1 : Nat → Nat := -- works!
+  WellFounded.fix Nat.lt_wfRel.2 fun n IH =>
+    let m := n / 2
+    if h : m < n then
+      IH m h + 1
+    else
+      0
 
-end Accs
+#eval log2p1 4   -- 3
+```
+-/
 
 namespace Acc
 
-universe v u
-variable {α : Sort u} {r : α → α → Prop}
+private local instance wfRel {r : α → α → Prop} : WellFoundedRelation { val // Acc r val } where
+  rel := InvImage r (·.1)
+  wf  := ⟨fun ac => InvImage.accessible _ ac.2⟩
 
 /-- A computable version of `Acc.rec`. Workaround until Lean has native support for this. -/
-@[elab_as_elim]
-def recC {motive : (a : α) → Acc r a → Sort v}
+@[elab_as_elim] private def recC {motive : (a : α) → Acc r a → Sort v}
     (intro : (x : α) → (h : ∀ (y : α), r y x → Acc r y) →
      ((y : α) → (hr : r y x) → motive y (h y hr)) → motive x (intro x h))
     {a : α} (t : Acc r a) : motive a t :=
   intro a (fun x h => t.inv h) (fun y hr => recC intro (t.inv hr))
-  termination_by recC a h => Accs.mk a h
+termination_by _ a h => Subtype.mk a h
 
-theorem recC_intro {motive : (a : α) → Acc r a → Sort v}
+private theorem recC_intro {motive : (a : α) → Acc r a → Sort v}
     (intro : (x : α) → (h : ∀ (y : α), r y x → Acc r y) →
      ((y : α) → (hr : r y x) → motive y (h y hr)) → motive x (intro x h))
     {a : α} (h : ∀ (y : α), r y a → Acc r y) :
     recC intro (Acc.intro _ h) = intro a h (fun y hr => recC intro (h y hr)) :=
   rfl
 
-@[csimp]
-theorem rec_eq_recC : @Acc.rec = @Acc.recC := by
+@[csimp] private theorem rec_eq_recC : @Acc.rec = @Acc.recC := by
   funext α r motive intro a t
   induction t with
   | intro x h ih =>
     dsimp only [recC_intro intro h]
-    congr
-    funext y hr
-    exact ih _ hr
+    congr; funext y hr; exact ih _ hr
 
 /-- A computable version of `Acc.ndrec`. Workaround until Lean has native support for this. -/
-abbrev ndrecC {C : α → Sort v}
+private abbrev ndrecC {C : α → Sort v}
     (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → (a : r y x) → C y) → C x)
     {a : α} (n : Acc r a) : C a :=
   n.recC m
 
-@[csimp]
-theorem ndrec_eq_ndrecC : @Acc.ndrec = @Acc.ndrecC := by
+@[csimp] private theorem ndrec_eq_ndrecC : @Acc.ndrec = @Acc.ndrecC := by
   funext α r motive intro a t
   rw [Acc.ndrec, rec_eq_recC, Acc.ndrecC]
 
 /-- A computable version of `Acc.ndrecOn`. Workaround until Lean has native support for this. -/
-abbrev ndrecOnC {C : α → Sort v}
-    {a : α} (n : Acc r a)
-    (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → (a : r y x) → C y) → C x) : C a :=
+private abbrev ndrecOnC {C : α → Sort v} {a : α} (n : Acc r a)
+    (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → r y x → C y) → C x) : C a :=
   n.recC m
 
-@[csimp]
-theorem ndrecOn_eq_ndrecOnC : @Acc.ndrecOn = @Acc.ndrecOnC := by
+@[csimp] private theorem ndrecOn_eq_ndrecOnC : @Acc.ndrecOn = @Acc.ndrecOnC := by
   funext α r motive intro a t
   rw [Acc.ndrecOn, rec_eq_recC, Acc.ndrecOnC]
 
@@ -84,30 +90,24 @@ end Acc
 
 namespace WellFounded
 
-universe u v
-variable {α : Sort u}
-
 /-- A computable version of `WellFounded.fixF`.
 Workaround until Lean has native support for this. -/
-def fixFC {r : α → α → Prop}
+private def fixFC {α : Sort u} {r : α → α → Prop}
     {C : α → Sort v} (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) (a : Acc r x) : C x := by
   induction a using Acc.recC with
   | intro x₁ _ ih => exact F x₁ ih
 
-@[csimp]
-theorem fixF_eq_fixFC : @WellFounded.fixF = @WellFounded.fixFC := by
+@[csimp] private theorem fixF_eq_fixFC : @fixF = @fixFC := by
   funext α r C F x a
-  rw [WellFounded.fixF, Acc.rec_eq_recC, WellFounded.fixFC]
+  rw [fixF, Acc.rec_eq_recC, fixFC]
 
-/-- A computable version of `WellFounded.fix`.
-Workaround until Lean has native support for this. -/
-def fixC {C : α → Sort v} {r : α → α → Prop} (hwf : WellFounded r)
+/-- A computable version of `fix`. Workaround until Lean has native support for this. -/
+private def fixC {α : Sort u} {C : α → Sort v} {r : α → α → Prop} (hwf : WellFounded r)
     (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) : C x :=
   fixFC F x (apply hwf x)
 
-@[csimp]
-theorem fix_eq_fixC : @WellFounded.fix = @WellFounded.fixC := by
+@[csimp] private theorem fix_eq_fixC : @fix = @fixC := by
   funext α C r hwf F x
-  rw [WellFounded.fix, fixF_eq_fixFC, WellFounded.fixC]
+  rw [fix, fixF_eq_fixFC, fixC]
 
 end WellFounded

--- a/Std/WF.lean
+++ b/Std/WF.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2023 Miyahara Kō. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Miyahara Kō
+-/
+
+/-- `Accs r` is consisted of all accessible elements by `r`. -/
+structure Accs.{u} {α : Sort u} (r : α → α → Prop) where
+  /-- The accessible value. -/
+  val : α
+  /-- All elements in `Accs r` are accessible. -/
+  acc : Acc r val
+
+namespace Accs
+
+universe u
+variable {α : Sort u} {r : α → α → Prop}
+
+/-- The subrelation of `r` on this type is well-founded. -/
+def wf : WellFounded (InvImage r (val : Accs r → α)) := ⟨fun ac => InvImage.accessible _ ac.acc⟩
+
+instance wfRel : WellFoundedRelation (Accs r) where
+  rel := InvImage r (val : Accs r → α)
+  wf  := Accs.wf
+
+end Accs
+
+namespace Acc
+
+universe v u
+variable {α : Sort u} {r : α → α → Prop}
+
+/-- A computable version of `Acc.rec`. Workaround until Lean has native support for this. -/
+@[elab_as_elim]
+def recC {motive : (a : α) → Acc r a → Sort v}
+    (intro : (x : α) → (h : ∀ (y : α), r y x → Acc r y) →
+     ((y : α) → (hr : r y x) → motive y (h y hr)) → motive x (intro x h))
+    {a : α} (t : Acc r a) : motive a t :=
+  intro a (fun x h => t.inv h) (fun y hr => recC intro (t.inv hr))
+  termination_by recC a h => Accs.mk a h
+
+theorem recC_intro {motive : (a : α) → Acc r a → Sort v}
+    (intro : (x : α) → (h : ∀ (y : α), r y x → Acc r y) →
+     ((y : α) → (hr : r y x) → motive y (h y hr)) → motive x (intro x h))
+    {a : α} (h : ∀ (y : α), r y a → Acc r y) :
+    recC intro (Acc.intro _ h) = intro a h (fun y hr => recC intro (h y hr)) :=
+  rfl
+
+@[csimp]
+theorem rec_eq_recC : @Acc.rec = @Acc.recC := by
+  funext α r motive intro a t
+  induction t with
+  | intro x h ih =>
+    dsimp only [recC_intro intro h]
+    congr
+    funext y hr
+    exact ih _ hr
+
+/-- A computable version of `Acc.ndrec`. Workaround until Lean has native support for this. -/
+abbrev ndrecC {C : α → Sort v}
+    (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → (a : r y x) → C y) → C x)
+    {a : α} (n : Acc r a) : C a :=
+  n.recC m
+
+@[csimp]
+theorem ndrec_eq_ndrecC : @Acc.ndrec = @Acc.ndrecC := by
+  funext α r motive intro a t
+  rw [Acc.ndrec, rec_eq_recC, Acc.ndrecC]
+
+/-- A computable version of `Acc.ndrecOn`. Workaround until Lean has native support for this. -/
+abbrev ndrecOnC {C : α → Sort v}
+    {a : α} (n : Acc r a)
+    (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → (a : r y x) → C y) → C x) : C a :=
+  n.recC m
+
+@[csimp]
+theorem ndrecOn_eq_ndrecOnC : @Acc.ndrecOn = @Acc.ndrecOnC := by
+  funext α r motive intro a t
+  rw [Acc.ndrecOn, rec_eq_recC, Acc.ndrecOnC]
+
+end Acc
+
+namespace WellFounded
+
+universe u v
+variable {α : Sort u}
+
+/-- A computable version of `WellFounded.fixF`.
+Workaround until Lean has native support for this. -/
+def fixFC {r : α → α → Prop}
+    {C : α → Sort v} (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) (a : Acc r x) : C x := by
+  induction a using Acc.recC with
+  | intro x₁ _ ih => exact F x₁ ih
+
+@[csimp]
+theorem fixF_eq_fixFC : @WellFounded.fixF = @WellFounded.fixFC := by
+  funext α r C F x a
+  rw [WellFounded.fixF, Acc.rec_eq_recC, WellFounded.fixFC]
+
+/-- A computable version of `WellFounded.fix`.
+Workaround until Lean has native support for this. -/
+def fixC {C : α → Sort v} {r : α → α → Prop} (hwf : WellFounded r)
+    (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) : C x :=
+  fixFC F x (apply hwf x)
+
+@[csimp]
+theorem fix_eq_fixC : @WellFounded.fix = @WellFounded.fixC := by
+  funext α C r hwf F x
+  rw [WellFounded.fix, fixF_eq_fixFC, WellFounded.fixC]
+
+end WellFounded

--- a/Std/WF.lean
+++ b/Std/WF.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Miyahara Kō. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Miyahara Kō
 -/
+import Std.Tactic.Lint.Misc
 
 /-- `Accs r` is consisted of all accessible elements by `r`. -/
 structure Accs.{u} {α : Sort u} (r : α → α → Prop) where
@@ -17,6 +18,7 @@ universe u
 variable {α : Sort u} {r : α → α → Prop}
 
 /-- The subrelation of `r` on this type is well-founded. -/
+@[nolint defLemma]
 def wf : WellFounded (InvImage r (val : Accs r → α)) := ⟨fun ac => InvImage.accessible _ ac.acc⟩
 
 instance wfRel : WellFoundedRelation (Accs r) where


### PR DESCRIPTION
Lean 4 code generator has had no native supports for `Acc.rec`.
This PR makes `Acc.rec` computable.
This change makes many defs computable, like `WellFounded.fix`.