### PR TITLE
feat: 'Try this' support

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -64,10 +64,12 @@ import Std.Lean.Meta.LCtx
 import Std.Lean.Meta.SavedState
 import Std.Lean.Meta.UnusedNames
 import Std.Lean.MonadBacktrack
+import Std.Lean.Name
 import Std.Lean.NameMapAttribute
 import Std.Lean.Parser
 import Std.Lean.PersistentHashMap
 import Std.Lean.PersistentHashSet
+import Std.Lean.Position
 import Std.Lean.Tactic
 import Std.Lean.TagAttribute
 import Std.Linter

--- a/Std/Lean/Name.lean
+++ b/Std/Lean/Name.lean
@@ -1,0 +1,15 @@
+/-
+Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+
+import Lean
+
+namespace Lean.Name
+
+/-- Returns true if the name has any numeric components. -/
+def hasNum : Name → Bool
+  | .anonymous => false
+  | .str p _ => p.hasNum
+  | .num _ _ => true

--- a/Std/Lean/Position.lean
+++ b/Std/Lean/Position.lean
@@ -1,0 +1,14 @@
+/-
+Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean.Data.Lsp.Utf16
+
+/-- Gets the LSP range from a pair of positions. -/
+def Lean.FileMap.utf8PosToLspRange (text : FileMap) (start «end» : String.Pos) : Lsp.Range :=
+  { start := text.utf8PosToLspPos start, «end» := text.utf8PosToLspPos «end» }
+
+/-- Gets the LSP range of syntax `stx`. -/
+def Lean.FileMap.rangeOfStx? (text : FileMap) (stx : Syntax) : Option Lsp.Range :=
+  return text.utf8PosToLspRange (← stx.getPos?) (← stx.getTailPos?)

--- a/Std/Lean/Position.lean
+++ b/Std/Lean/Position.lean
@@ -3,12 +3,13 @@ Copyright (c) 2023 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Lean.Syntax
 import Lean.Data.Lsp.Utf16
 
-/-- Gets the LSP range from a pair of positions. -/
-def Lean.FileMap.utf8PosToLspRange (text : FileMap) (start «end» : String.Pos) : Lsp.Range :=
-  { start := text.utf8PosToLspPos start, «end» := text.utf8PosToLspPos «end» }
+/-- Gets the LSP range from a `String.Range`. -/
+def Lean.FileMap.utf8RangeToLspRange (text : FileMap) (range : String.Range) : Lsp.Range :=
+  { start := text.utf8PosToLspPos range.start, «end» := text.utf8PosToLspPos range.stop }
 
 /-- Gets the LSP range of syntax `stx`. -/
 def Lean.FileMap.rangeOfStx? (text : FileMap) (stx : Syntax) : Option Lsp.Range :=
-  return text.utf8PosToLspRange (← stx.getPos?) (← stx.getTailPos?)
+  text.utf8RangeToLspRange <$> stx.getRange?

--- a/Std/Lean/Position.lean
+++ b/Std/Lean/Position.lean
@@ -13,3 +13,13 @@ def Lean.FileMap.utf8RangeToLspRange (text : FileMap) (range : String.Range) : L
 /-- Gets the LSP range of syntax `stx`. -/
 def Lean.FileMap.rangeOfStx? (text : FileMap) (stx : Syntax) : Option Lsp.Range :=
   text.utf8RangeToLspRange <$> stx.getRange?
+
+/-- Returns a synthetic Syntax which has the specified `String.Range`. -/
+def Lean.Syntax.ofRange (range : String.Range) (canonical := true) : Lean.Syntax :=
+  .atom (.synthetic range.start range.stop canonical) ""
+
+/-- Returns the position of the start of (1-based) line `line`. -/
+def Lean.FileMap.lineStart (map : FileMap) (line : Nat) : String.Pos :=
+  if h : line - 1 < map.positions.size then
+    map.positions.get ⟨line - 1, h⟩
+  else map.positions.back?.getD 0

--- a/Std/Tactic/ShowTerm.lean
+++ b/Std/Tactic/ShowTerm.lean
@@ -18,10 +18,7 @@ open Lean Elab Tactic TryThis
 elab (name := showTermTac) tk:"show_term " t:tacticSeq : tactic => withMainContext do
   let g ← getMainGoal
   evalTactic t
-  -- TODO: At the moment it is more useful to use an Expr MessageData
-  -- instead of a Syntax because the former is clickable in the infoview
-  -- addExactSuggestion tk (← instantiateMVars (mkMVar g)).headBeta
-  logInfoAt tk (← instantiateMVars (mkMVar g)).headBeta
+  addExactSuggestion tk (← instantiateMVars (mkMVar g)).headBeta (ref? := ← getRef)
 
 /--
 `show_term e` elaborates `e`, then prints the generated term.
@@ -31,8 +28,5 @@ elab (name := showTermTac) tk:"show_term " t:tacticSeq : tactic => withMainConte
 elab (name := showTerm) tk:"show_term " t:term : term <= ty => do
   let e ← Term.elabTermEnsuringType t ty
   Term.synthesizeSyntheticMVarsNoPostponing
-  -- TODO: At the moment it is more useful to use an Expr MessageData
-  -- instead of a Syntax because the former is clickable in the infoview
-  -- addTermSuggestion tk (← instantiateMVars e).headBeta
-  logInfoAt tk (← instantiateMVars e).headBeta
+  addTermSuggestion tk (← instantiateMVars e).headBeta (ref? := ← getRef)
   pure e

--- a/Std/Tactic/ShowTerm.lean
+++ b/Std/Tactic/ShowTerm.lean
@@ -18,7 +18,7 @@ open Lean Elab Tactic TryThis
 elab (name := showTermTac) tk:"show_term " t:tacticSeq : tactic => withMainContext do
   let g ← getMainGoal
   evalTactic t
-  addExactSuggestion tk (← instantiateMVars (mkMVar g)).headBeta (ref? := ← getRef)
+  addExactSuggestion tk (← instantiateMVars (mkMVar g)).headBeta (origSpan? := ← getRef)
 
 /--
 `show_term e` elaborates `e`, then prints the generated term.
@@ -28,5 +28,5 @@ elab (name := showTermTac) tk:"show_term " t:tacticSeq : tactic => withMainConte
 elab (name := showTerm) tk:"show_term " t:term : term <= ty => do
   let e ← Term.elabTermEnsuringType t ty
   Term.synthesizeSyntheticMVarsNoPostponing
-  addTermSuggestion tk (← instantiateMVars e).headBeta (ref? := ← getRef)
+  addTermSuggestion tk (← instantiateMVars e).headBeta (origSpan? := ← getRef)
   pure e

--- a/Std/Tactic/TryThis.lean
+++ b/Std/Tactic/TryThis.lean
@@ -85,7 +85,7 @@ The parameters are:
 * `ref`: the span of the info diagnostic
 * `suggestion`: the replacement syntax
 * `suggestionForMessage?`: the message to display in the info diagnostic (only).
-  The widget message uses only `suggestion`. If not provided, it uses `suggestion` in both places.
+  The widget message uses only `suggestion`. If not provided, `suggestion` is used in both places.
 * `origSpan?`: a syntax object whose span is the actual text to be replaced by `suggestion`.
   If not provided it defaults to `ref`.
 * `extraMsg`: an extra piece of message text to apply to the widget message (only).

--- a/Std/Tactic/TryThis.lean
+++ b/Std/Tactic/TryThis.lean
@@ -19,38 +19,6 @@ namespace Std.Tactic.TryThis
 
 open Lean Elab Elab.Tactic PrettyPrinter Meta Server Lsp RequestM
 
-/-- An info-tree data node corresponding to an application of the "Try this" command. -/
-structure TryThisInfo where
-  /-- The suggested replacement for this syntax, usually the rendering of another tactic syntax. -/
-  suggestion : String
-  /-- This is the span to replace with `suggestion`. If not supplied it will default to
-  the span of the syntax on which this info node is placed. -/
-  span? : Option (String.Pos × String.Pos) := none
-  deriving TypeName
-
-/--
-This is a code action provider that looks for `TryThisInfo` nodes and supplies a code action to
-apply the replacement.
--/
-@[codeActionProvider] def tryThisProvider : CodeActionProvider := fun params snap => do
-  let doc ← readDoc
-  let startPos := doc.meta.text.lspPosToUtf8Pos params.range.start
-  let endPos := doc.meta.text.lspPosToUtf8Pos params.range.end
-  pure <| snap.infoTree.foldInfo (init := #[]) fun _ctx info result => Id.run do
-    let .ofCustomInfo info := info | result
-    let some tti := info.value.get? TryThisInfo | result
-    let some (head, tail) := (tti.span? <|> return (← info.stx.getPos?, ← info.stx.getTailPos?))
-      | result
-    unless head ≤ endPos && startPos ≤ tail do return result
-    result.push {
-      eager.title := "Apply 'Try this'"
-      eager.kind? := "refactor"
-      eager.edit? := WorkspaceEdit.ofTextEdit params.textDocument.uri {
-        range := doc.meta.text.utf8PosToLspRange head tail
-        newText := tti.suggestion
-      }
-    }
-
 /--
 This is a widget which is placed by `TryThis.addSuggestion`; it says `Try this: <replacement>`
 where `<replacement>` is a link which will perform the replacement.
@@ -75,6 +43,25 @@ export default function(props) {
   ]))
 }"
 
+/--
+This is a code action provider that looks for `TryThisInfo` nodes and supplies a code action to
+apply the replacement.
+-/
+@[codeActionProvider] def tryThisProvider : CodeActionProvider := fun params snap => do
+  pure <| snap.infoTree.foldInfo (init := #[]) fun _ctx info result => Id.run do
+    let .ofUserWidgetInfo { widgetId := ``tryThisWidget, props, .. } := info | result
+    let .ok newText := props.getObjValAs? String "suggestion" | panic! "bad type"
+    let .ok range := props.getObjValAs? Lsp.Range "range" | panic! "bad type"
+    unless
+        range.start.line ≤ params.range.end.line &&
+        params.range.start.line ≤ range.end.line do
+      return result
+    result.push {
+      eager.title := "Apply 'Try this'"
+      eager.kind? := "refactor"
+      eager.edit? := WorkspaceEdit.ofTextEdit params.textDocument.uri { range, newText }
+    }
+
 /-- Replace subexpressions like `?m.1234` with `?_` so it can be copy-pasted. -/
 partial def replaceMVarsByUnderscores [Monad m] [MonadQuotation m]
     (s : Syntax) : m Syntax :=
@@ -86,28 +73,44 @@ partial def replaceMVarsByUnderscores [Monad m] [MonadQuotation m]
 def delabToRefinableSyntax (e : Expr) : TermElabM Term :=
   return ⟨← replaceMVarsByUnderscores (← delab e)⟩
 
-/-- Add a "try this" suggestion. -/
-def addSuggestion (origStx : Syntax) {kind : Name} (suggestion : TSyntax kind)
-    (suggestionForMessage : Option MessageData := none)
-    (ref? : Option Syntax := none)
+/-- Add a "try this" suggestion. This has three effects:
+
+* An info diagnostic is displayed saying `Try this: <suggestion>`
+* A widget is registered, saying `Try this: <suggestion>` with a link on `<suggestion>` to apply
+  the suggestion
+* A code action `Apply 'Try this'` is added, which will apply the suggestion.
+
+The parameters are:
+* `ref`: the span of the info diagnostic
+* `suggestion`: the replacement syntax
+* `suggestionForMessage?`: the message to display in the info diagnostic (only).
+  The widget message uses only `suggestion`. If not provided, it uses `suggestion` in both places.
+* `origSpan?`: a syntax object whose span is the actual text to be replaced by `suggestion`.
+  If not provided it defaults to `ref`.
+* `extraMsg`: an extra piece of message text to apply to the widget message (only).
+-/
+def addSuggestion (ref : Syntax) {kind : Name} (suggestion : TSyntax kind)
+    (suggestionForMessage? : Option MessageData := none)
+    (origSpan? : Option Syntax := none)
     (extraMsg : String := "") : MetaM Unit := do
-  logInfoAt origStx m!"Try this: {suggestionForMessage.getD suggestion}"
+  logInfoAt ref m!"Try this: {suggestionForMessage?.getD suggestion}"
   -- TODO: use the right indentation
   let text := Format.pretty (← PrettyPrinter.ppCategory kind suggestion)
-  let span? := do let e ← ref?; pure (← e.getPos?, ← e.getTailPos?)
-  pushInfoLeaf <| .ofCustomInfo {
-    stx := origStx
-    value := Dynamic.mk (TryThisInfo.mk text span?)
-  }
-  if let some (head, tail) := span? <|> return (← origStx.getPos?, ← origStx.getTailPos?) then
-    let map ← getFileMap
-    let range := Lsp.Range.mk (map.utf8PosToLspPos head) (map.utf8PosToLspPos tail)
+  if let some range := (origSpan?.getD ref).getRange? then
+    let range := (← getFileMap).utf8RangeToLspRange range
     let json := Json.mkObj [("suggestion", text), ("range", toJson range), ("info", extraMsg)]
-    Widget.saveWidgetInfo ``tryThisWidget json origStx
+    Widget.saveWidgetInfo ``tryThisWidget json (ref.updateTrailing "".toSubstring)
 
-/-- Add a `exact e` or `refine e` suggestion. -/
-def addExactSuggestion (origTac : Syntax) (e : Expr)
-    (ref? : Option Syntax := none) : TermElabM Unit := do
+/-- Add a `exact e` or `refine e` suggestion.
+
+The parameters are:
+* `ref`: the original syntax to be replaced
+* `e`: the replacement expression
+* `origSpan?`: a syntax object whose span is the actual text to be replaced by `suggestion`.
+  If not provided it defaults to `ref`.
+-/
+def addExactSuggestion (ref : Syntax) (e : Expr)
+    (origSpan? : Option Syntax := none) : TermElabM Unit := do
   let stx ← delabToRefinableSyntax e
   let mvars ← getMVars e
   let tac ← if mvars.isEmpty then `(tactic| exact $stx) else `(tactic| refine $stx)
@@ -118,9 +121,18 @@ def addExactSuggestion (origTac : Syntax) (e : Expr)
       let e ← PrettyPrinter.ppExpr (← instantiateMVars (← g.getType))
       str := str ++ Format.pretty ("\n⊢ " ++ e)
     pure (m!"refine {e}", str)
-  addSuggestion origTac tac (suggestionForMessage := msg) (ref? := ref?) (extraMsg := extraMsg)
+  addSuggestion ref tac (suggestionForMessage? := msg)
+    (origSpan? := origSpan?) (extraMsg := extraMsg)
 
-/-- Add a term suggestion. -/
-def addTermSuggestion (origTerm : Syntax) (e : Expr)
-    (ref? : Option Syntax := none) : TermElabM Unit := do
-  addSuggestion origTerm (← delabToRefinableSyntax e) (suggestionForMessage := e) (ref? := ref?)
+/-- Add a term suggestion.
+
+The parameters are:
+* `ref`: the original syntax to be replaced
+* `e`: the replacement expression
+* `origSpan?`: a syntax object whose span is the actual text to be replaced by `suggestion`.
+  If not provided it defaults to `ref`.
+-/
+def addTermSuggestion (ref : Syntax) (e : Expr)
+    (origSpan? : Option Syntax := none) : TermElabM Unit := do
+  addSuggestion ref (← delabToRefinableSyntax e)
+    (suggestionForMessage? := e) (origSpan? := origSpan?)

--- a/Std/Tactic/TryThis.lean
+++ b/Std/Tactic/TryThis.lean
@@ -98,9 +98,14 @@ def addSuggestion (ref : Syntax) {kind : Name} (suggestion : TSyntax kind)
   -- TODO: use the right indentation
   let text := Format.pretty (← PrettyPrinter.ppCategory kind suggestion)
   if let some range := (origSpan?.getD ref).getRange? then
-    let range := (← getFileMap).utf8RangeToLspRange range
+    let stxRange := ref.getRange?.getD range
+    let map ← getFileMap
+    let stxRange :=
+    { start := map.lineStart (map.toPosition stxRange.start).line
+      stop := map.lineStart ((map.toPosition stxRange.stop).line + 1) }
+    let range := map.utf8RangeToLspRange range
     let json := Json.mkObj [("suggestion", text), ("range", toJson range), ("info", extraMsg)]
-    Widget.saveWidgetInfo ``tryThisWidget json (ref.updateTrailing "".toSubstring)
+    Widget.saveWidgetInfo ``tryThisWidget json (.ofRange stxRange)
 
 /-- Add a `exact e` or `refine e` suggestion.
 

--- a/Std/Tactic/TryThis.lean
+++ b/Std/Tactic/TryThis.lean
@@ -110,7 +110,7 @@ def addSuggestion (ref : Syntax) {kind : Name} (suggestion : TSyntax kind)
 /-- Add a `exact e` or `refine e` suggestion.
 
 The parameters are:
-* `ref`: the original syntax to be replaced
+* `ref`: the span of the info diagnostic
 * `e`: the replacement expression
 * `origSpan?`: a syntax object whose span is the actual text to be replaced by `suggestion`.
   If not provided it defaults to `ref`.
@@ -133,7 +133,7 @@ def addExactSuggestion (ref : Syntax) (e : Expr)
 /-- Add a term suggestion.
 
 The parameters are:
-* `ref`: the original syntax to be replaced
+* `ref`: the span of the info diagnostic
 * `e`: the replacement expression
 * `origSpan?`: a syntax object whose span is the actual text to be replaced by `suggestion`.
   If not provided it defaults to `ref`.

--- a/Std/Tactic/TryThis.lean
+++ b/Std/Tactic/TryThis.lean
@@ -1,42 +1,115 @@
 /-
 Copyright (c) 2021 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Gabriel Ebner
+Authors: Gabriel Ebner, Mario Carneiro
 -/
-import Lean.PrettyPrinter.Delaborator.Basic
+import Lean.Server.CodeActions
+import Lean.Widget.UserWidget
+import Std.Lean.Name
+import Std.Lean.Position
 
 /-!
-# Stub for try-this support
+# "Try this" support
 
-Lean 4 does not yet support code actions
-to present tactic suggestions in the editor.
-This file contains a preliminary API
-that tactics can call to show suggestions.
+This implements a mechanism for tactics to print a message saying `Try this: <suggestion>`,
+where `<suggestion>` is a link to a replacement tactic. Users can either click on the link
+in the suggestion (provided by a widget), or use a code action which applies the suggestion.
 -/
 namespace Std.Tactic.TryThis
 
-open Lean Elab Elab.Tactic PrettyPrinter Meta
+open Lean Elab Elab.Tactic PrettyPrinter Meta Server Lsp RequestM
+
+/-- An info-tree data node corresponding to an application of the "Try this" command. -/
+structure TryThisInfo where
+  /-- The suggested replacement for this syntax, usually the rendering of another tactic syntax. -/
+  suggestion : String
+  /-- This is the span to replace with `suggestion`. If not supplied it will default to
+  the span of the syntax on which this info node is placed. -/
+  span? : Option (String.Pos × String.Pos) := none
+  deriving TypeName
+
+/--
+This is a code action provider that looks for `TryThisInfo` nodes and supplies a code action to
+apply the replacement.
+-/
+@[codeActionProvider] def tryThisProvider : CodeActionProvider := fun params snap => do
+  let doc ← readDoc
+  let startPos := doc.meta.text.lspPosToUtf8Pos params.range.start
+  let endPos := doc.meta.text.lspPosToUtf8Pos params.range.end
+  pure <| snap.infoTree.foldInfo (init := #[]) fun _ctx info result => Id.run do
+    let .ofCustomInfo info := info | result
+    let some tti := info.value.get? TryThisInfo | result
+    let some (head, tail) := (tti.span? <|> return (← info.stx.getPos?, ← info.stx.getTailPos?))
+      | result
+    unless head ≤ endPos && startPos ≤ tail do return result
+    result.push {
+      eager.title := "Apply 'Try this'"
+      eager.kind? := "refactor"
+      eager.edit? := WorkspaceEdit.ofTextEdit params.textDocument.uri {
+        range := doc.meta.text.utf8PosToLspRange head tail
+        newText := tti.suggestion
+      }
+    }
+
+/--
+This is a widget which is placed by `TryThis.addSuggestion`; it says `Try this: <replacement>`
+where `<replacement>` is a link which will perform the replacement.
+-/
+@[widget] def tryThisWidget : Widget.UserWidgetDefinition where
+  name := "Tactic replacement"
+  javascript := "
+import * as React from 'react';
+import { EditorContext } from '@leanprover/infoview';
+const e = React.createElement;
+export default function(props) {
+  const editorConnection = React.useContext(EditorContext)
+  function onClick() {
+    editorConnection.api.applyEdit({
+      changes: { [props.pos.uri]: [{ range: props.range, newText: props.suggestion }] }
+    })
+  }
+  return e('div', {className: 'ml1'}, e('pre', {className: 'font-code pre-wrap'},
+    ['Try this: ', e('a', {onClick, title: 'Apply suggestion'}, props.suggestion)]))
+}"
 
 /-- Replace subexpressions like `?m.1234` with `?_` so it can be copy-pasted. -/
 partial def replaceMVarsByUnderscores [Monad m] [MonadQuotation m]
     (s : Syntax) : m Syntax :=
-  s.replaceM fun s => if let `(?$_:ident) := s then `(?_) else pure none
+  s.replaceM fun s => do
+    let `(?$id:ident) := s | pure none
+    if id.getId.hasNum || id.getId.isInternal then `(?_) else pure none
 
 /-- Delaborate `e` into an expression suitable for use in `refine`. -/
 def delabToRefinableSyntax (e : Expr) : TermElabM Term :=
   return ⟨← replaceMVarsByUnderscores (← delab e)⟩
 
-/-- Add a "try this" suggestion. (TODO: this depends on code action support) -/
-def addSuggestion [Monad m] [MonadLog m] [AddMessageContext m] [MonadOptions m]
-    (origStx : Syntax) (suggestion : Syntax) : m Unit :=
-  logInfoAt origStx m!"{suggestion}"
+/-- Add a "try this" suggestion. -/
+def addSuggestion (origStx : Syntax) {kind : Name} (suggestion : TSyntax kind)
+    (suggestionForMessage : Option MessageData := none)
+    (ref? : Option Syntax := none) : MetaM Unit := do
+  logInfoAt origStx m!"Try this: {suggestionForMessage.getD suggestion}"
+  -- TODO: use the right indentation
+  let text := Format.pretty (← PrettyPrinter.ppCategory kind suggestion)
+  let span? := do let e ← ref?; pure (← e.getPos?, ← e.getTailPos?)
+  pushInfoLeaf <| .ofCustomInfo {
+    stx := origStx
+    value := Dynamic.mk (TryThisInfo.mk text span?)
+  }
+  if let some (head, tail) := span? <|> return (← origStx.getPos?, ← origStx.getTailPos?) then
+    let map ← getFileMap
+    let range := Lsp.Range.mk (map.utf8PosToLspPos head) (map.utf8PosToLspPos tail)
+    let json := Json.mkObj [("suggestion", text), ("range", toJson range)]
+    Widget.saveWidgetInfo ``tryThisWidget json origStx
 
-/-- Add a `exact e` or `refine e` suggestion. (TODO: this depends on code action support) -/
-def addExactSuggestion (origTac : Syntax) (e : Expr) : TermElabM Unit := do
+/-- Add a `exact e` or `refine e` suggestion. -/
+def addExactSuggestion (origTac : Syntax) (e : Expr)
+    (ref? : Option Syntax := none) : TermElabM Unit := do
   let stx ← delabToRefinableSyntax e
   let tac ← if e.hasExprMVar then `(tactic| refine $stx) else `(tactic| exact $stx)
-  addSuggestion origTac tac
+  let msg := if e.hasExprMVar then m!"refine {e}" else m!"exact {e}"
+  addSuggestion origTac tac (suggestionForMessage := msg) (ref? := ref?)
 
-/-- Add a term suggestion. (TODO: this depends on code action support) -/
-def addTermSuggestion (origTerm : Syntax) (e : Expr) : TermElabM Unit := do
-  addSuggestion origTerm (← delabToRefinableSyntax e)
+/-- Add a term suggestion. -/
+def addTermSuggestion (origTerm : Syntax) (e : Expr)
+    (ref? : Option Syntax := none) : TermElabM Unit := do
+  addSuggestion origTerm (← delabToRefinableSyntax e) (suggestionForMessage := e) (ref? := ref?)


### PR DESCRIPTION
Adds proper widget / code action support for "try this" prompts in tactics. Still open: merging the widget into the message itself, depends on leanprover/lean4#2064 .