### PR TITLE
feat: `#guard_expr` command and adjust handling of expected types for `guard_expr` tactics

### DIFF
--- a/test/guardexpr.lean
+++ b/test/guardexpr.lean
@@ -16,3 +16,43 @@ example (n : Nat) : Nat := by
     lhs
     guard_target = 1
   exact 0
+
+-- Now with a generic type to test that default instances work correctly
+example [∀ n, OfNat α n] (n : α) : α := by
+  guard_hyp n :ₛ α
+  let q : α := 1
+  guard_expr (1 : α) =ₛ 1
+  fail_if_success guard_expr 1 =ₛ (2 : α)
+  fail_if_success guard_expr 1 =ₛ (by exact (2 : α))
+  guard_hyp q := 1
+  guard_hyp q : α := 1
+  guard_hyp q : (λ x => x) α :=~ id 1
+  guard_target = α
+  have : (1 : α) = 1 := by conv =>
+    guard_hyp q := 1
+    guard_expr ‹α› = q
+    fail_if_success guard_target = 1
+    lhs
+    guard_target = 1
+  exact 0
+
+#guard_expr 1 = 1
+#guard_expr 1 =ₛ 1
+#guard_expr 2 = 1 + 1
+
+section
+variable {α : Type} [∀ n, OfNat α n]
+#guard_expr (1 : α) = 1
+end
+
+#guard true
+#guard 2 == 1 + 1
+#guard 2 = 1 + 1
+
+instance (p : Bool → Prop) [DecidablePred p] : Decidable (∀ b, p b) :=
+  if h : p false ∧ p true then
+    isTrue (by { intro b; cases h; cases b <;> assumption })
+  else
+    isFalse (by { intro h'; simp [h'] at h })
+
+#guard ∀ (b : Bool), b = !!b


### PR DESCRIPTION
This adds `#guard_expr`, which is a command version of the `guard_expr` tactic

Furthermore, this adjusts the handling of expected types so that when synthetic metavariables are synthesized then instances are more likely to be correct. This affects numeric literals for example, which otherwise might become `Nat`s due to the default instance.

Lastly, adds a `#guard` command that uses the evaluator to check if the given expression evaluates to true.

This PR is moving commands defined in a testing file from [mathlib4#3427](https://github.com/leanprover-community/mathlib4/pull/3427) to std4.