### PR TITLE
fix: rename theorems on `String.csize`

### DIFF
--- a/Std/Data/Char.lean
+++ b/Std/Data/Char.lean
@@ -19,3 +19,5 @@ theorem csize_pos (c) : 0 < csize c := by
 
 theorem csize_le_4 (c) : csize c ≤ 4 := by
   rcases csize_eq c with _|_|_|_ <;> simp_all
+  
+end String

--- a/Std/Data/Char.lean
+++ b/Std/Data/Char.lean
@@ -6,16 +6,16 @@ Authors: Jannis Limperg
 
 import Std.Tactic.RCases
 
-namespace Char
+namespace String
 
 private theorem csize_eq (c) :
-    String.csize c = 1 ∨ String.csize c = 2 ∨ String.csize c = 3 ∨
-    String.csize c = 4 := by
-  simp only [String.csize, utf8Size]
+    csize c = 1 ∨ csize c = 2 ∨ csize c = 3 ∨
+    csize c = 4 := by
+  simp only [csize, Char.utf8Size]
   repeat (first | split | (solve | simp))
 
-theorem csize_pos (c) : 0 < String.csize c := by
+theorem csize_pos (c) : 0 < csize c := by
   rcases csize_eq c with _|_|_|_ <;> simp_all
 
-theorem csize_le_4 (c) : String.csize c ≤ 4 := by
+theorem csize_le_4 (c) : csize c ≤ 4 := by
   rcases csize_eq c with _|_|_|_ <;> simp_all

--- a/Std/Data/String/Basic.lean
+++ b/Std/Data/String/Basic.lean
@@ -24,10 +24,10 @@ where
       let cp := pre.get start
       if cs == cp then
         have : start.byteIdx + String.csize cs ≤ stop.byteIdx + 4 :=
-          Nat.add_le_add (Nat.le_of_lt $ Nat.not_le.mp h) (Char.csize_le_4 _)
+          Nat.add_le_add (Nat.le_of_lt $ Nat.not_le.mp h) (String.csize_le_4 _)
         have : stop.byteIdx + 4 - (start.byteIdx + String.csize cs) <
                 stop.byteIdx + 4 - start.byteIdx :=
-          Nat.sub_add_lt_sub this (Char.csize_pos _)
+          Nat.sub_add_lt_sub this (String.csize_pos _)
         go (start + cs) stop
       else
         none


### PR DESCRIPTION
Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/.60Char.2Ecsize_pos.60.20and.20.60String.2Ecsize_pos.60.20are.20the.20same