### PR TITLE
feat: add a theorem about `String.Pos`

### DIFF
--- a/Std/Data/String/Lemmas.lean
+++ b/Std/Data/String/Lemmas.lean
@@ -47,6 +47,11 @@ theorem zero_addChar_byteIdx (c : Char) : ((0 : Pos) + c).byteIdx = csize c := b
 
 theorem zero_addChar_eq (c : Char) : (0 : Pos) + c = ⟨csize c⟩ := by rw [← zero_addChar_byteIdx]
 
+theorem addChar_right_comm (p : Pos) (c₁ c₂ : Char) : p + c₁ + c₂ = p + c₂ + c₁ := by
+  apply ext
+  repeat rw [pos_add_char]
+  apply Nat.add_right_comm
+
 theorem lt_addChar (p : Pos) (c : Char) : p < p + c := Nat.lt_add_of_pos_right (csize_pos _)
 
 theorem ne_of_lt {i₁ i₂ : Pos} (h : i₁ < i₂) : i₁ ≠ i₂ := mt ext_iff.1 (Nat.ne_of_lt h)


### PR DESCRIPTION
This theorem will be used to prove a theorem about `String.ltb` in `Mathlib.Data.String.Basic`.