### PR TITLE
fix: add `local` modifier to `simp` attribute

### DIFF
--- a/Std/Data/String/Lemmas.lean
+++ b/Std/Data/String/Lemmas.lean
@@ -243,7 +243,7 @@ end Substring
 
 namespace String
 
-attribute [simp] toList -- prefer `String.data` over `String.toList` in lemmas
+attribute [local simp] toList -- prefer `String.data` over `String.toList` in lemmas
 
 @[simp] theorem drop_empty {n : Nat} : "".drop n = "" := by induction n <;> [rfl, assumption]
 


### PR DESCRIPTION
Restrict the scope of the `simp` attribute to `Std.Data.String.Lemmas`.