### PR TITLE
feat: make linter output errors using errorformat

### DIFF
--- a/Std/Tactic/Lint/Frontend.lean
+++ b/Std/Tactic/Lint/Frontend.lean
@@ -125,9 +125,8 @@ def printWarning (declName : Name) (warning : MessageData) (useErrorFormat : Boo
 def printWarnings (results : HashMap Name MessageData) (filepath : System.FilePath := default)
   (useErrorFormat : Bool := False) : CoreM MessageData := do
   (MessageData.joinSep ·.toList Format.line) <$>
-    (← sortResults results).mapM
-      fun (declName, warning) => printWarning declName warning (useErrorFormat := useErrorFormat)
-        (filepath := filepath)
+    (← sortResults results).mapM fun (declName, warning) =>
+      printWarning declName warning (useErrorFormat := useErrorFormat) (filepath := filepath)
 
 /--
 Formats a map of linter warnings grouped by filename with `-- filename` comments.

--- a/Std/Tactic/Lint/Frontend.lean
+++ b/Std/Tactic/Lint/Frontend.lean
@@ -154,7 +154,7 @@ def formatLinterResults
     (decls : Array Name)
     (groupByFilename : Bool)
     (whereDesc : String) (runSlowLinters : Bool)
-    (verbose : LintVerbosity) (numLinters : Nat) (useErrorFormat : Bool := False) :
+    (verbose : LintVerbosity) (numLinters : Nat) (useErrorFormat : Bool := false) :
     CoreM MessageData := do
   let formattedResults ← results.filterMapM fun (linter, results) => do
     if !results.isEmpty then

--- a/Std/Tactic/Lint/Frontend.lean
+++ b/Std/Tactic/Lint/Frontend.lean
@@ -159,7 +159,7 @@ def formatLinterResults
   let formattedResults ← results.filterMapM fun (linter, results) => do
     if !results.isEmpty then
       let warnings ←
-        if groupByFilename ∨ useErrorFormat then
+        if groupByFilename || useErrorFormat then
           groupedByFilename results (useErrorFormat := useErrorFormat)
         else
           printWarnings results

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -63,7 +63,7 @@ unsafe def main (args : List String) : IO Unit := do
       let failed := results.any (!·.2.isEmpty)
       if failed then
         let fmtResults ←
-          formatLinterResults results decls (groupByFilename := true)
+          formatLinterResults results decls (groupByFilename := true) (useErrorFormat := True)
             "in Std" (runSlowLinters := true) .medium linters.size
         IO.print (← fmtResults.toString)
         IO.Process.exit 1

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -63,7 +63,7 @@ unsafe def main (args : List String) : IO Unit := do
       let failed := results.any (!·.2.isEmpty)
       if failed then
         let fmtResults ←
-          formatLinterResults results decls (groupByFilename := true) (useErrorFormat := True)
+          formatLinterResults results decls (groupByFilename := true) (useErrorFormat := true)
             "in Std" (runSlowLinters := true) .medium linters.size
         IO.print (← fmtResults.toString)
         IO.Process.exit 1


### PR DESCRIPTION
This prints linter errors in the following form:
```
./build/bin/runLinter
-- Found 1 error in 4260 declarations (plus 16946 automatically generated ones) in Std with 12 linters

/- The `synTaut` linter reports:
THE FOLLOWING DECLARATIONS ARE SYNTACTIC TAUTOLOGIES. This usually means that they are of the form `∀ a b ... z, e₁ = e₂` where `e₁` and `e₂` are identical expressions. We call declarations of this form syntactic tautologies. Such lemmas are (mostly) useless and sometimes introduced unintentionally when proving basic facts using `rfl`, when elaboration results in a different term than the user intended. You should check that the declaration really says what you think it does. -/
-- Std.Tactic.Lint.Frontend
./Std/Tactic/Lint/Frontend.lean:137:1: error: Std.Tactic.Lint.h LHS equals RHS syntactically
make: *** [lint] Error 1
```
the advantage of this is that errors printed in this form are recognised by a number of tools (vscode ctrl+click from terminal, vim's default quickfix errorformat, and can be matched by github actions problem matchers https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md).

We will use this to implement github annotations easily for mathlib (this will be a 3 line change in the workflow), this should make it easier to tell at a glance what is wrong with a given PR from the changes tab (which should speed up porting).

Currently this PR turns the option useErrorFormat on by default for std also for the `runLinter` program, with the logic that people running runLinter from command line are more likely to find this useful than #check lines producing a valid lean file.

This setting when activated will always group linter errors by file, as this lead to a clean implementation and seemed more useful.