### PR TITLE
feat: `#instances` command to find applicable instances

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -92,6 +92,7 @@ import Std.Tactic.Ext.Attr
 import Std.Tactic.GuardExpr
 import Std.Tactic.GuardMsgs
 import Std.Tactic.HaveI
+import Std.Tactic.Instances
 import Std.Tactic.Lint
 import Std.Tactic.Lint.Basic
 import Std.Tactic.Lint.Frontend

--- a/Std/Tactic/Instances.lean
+++ b/Std/Tactic/Instances.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2023 Kyle Miller. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller
+-/
+import Lean
+
+/-! # `#instances` command
+
+The `#instances` command prints lists all instances that apply to the given type, if it is a class.
+It is similar to `#synth` but it only does the very first step of the instance synthesis algorithm,
+which is to enumerate potential instances.
+-/
+
+open Lean Elab Command Meta
+
+namespace Std.Tactic.Instances
+
+/-- `#instances term` prints all the instances for the given class.
+For example, `#instances Add _` gives all `Add` instances, and `#instances Add Nat` gives the
+`Nat` instance. The `term` can be any type that can appear in `[...]` binders.
+
+Trailing underscores can be omitted, and `#instances Add` and `#instances Add _` are equivalent;
+the command adds metavariables until the argument is no longer a function.
+
+The `#instances` command is closely related to `#synth`, but `#synth` does the full
+instance synthesis algorithm and `#instances` does the first step of finding potential instances. -/
+elab "#instances " stx:term : command => runTermElabM fun _ => do
+  let t ← Term.elabTerm stx none
+  -- allow t to be universally quantified
+  let t ← forallTelescope t fun xs t' => do
+    -- Throw in missing arguments using metavariables. This only makes sense in the
+    -- non-quantified case.
+    let (_, _, t') ← lambdaMetaTelescope (← etaExpand t')
+    mkForallFVars xs t'
+  let insts ← Lean.Meta.SynthInstance.getInstances t
+  if insts.isEmpty then
+    logInfo m!"No instances"
+  else
+    let mut results := []
+    for inst in insts do
+      let e := inst.val
+      -- Number the universe variables within each entry separately.
+      let type ← withoutModifyingState do Term.levelMVarToParam (← inferType e)
+      results := m!"{e} : {type}" :: results
+    let instances := if insts.size == 1 then "instance" else "instances"
+    logInfo m!"{insts.size} {instances}:\n\n{MessageData.joinSep results.reverse "\n"}"

--- a/Std/Tactic/Instances.lean
+++ b/Std/Tactic/Instances.lean
@@ -29,7 +29,7 @@ elab "#instances " stx:term : command => runTermElabM fun _ => do
   let t ← Term.elabTerm stx none
   -- allow t to be universally quantified
   let t ← forallTelescope t fun xs t' => do
-    -- Throw in missing arguments using metavariables. This only makes sense in the
+    -- Throw in missing arguments using metavariables. This can only do anything in the
     -- non-quantified case.
     let (_, _, t') ← lambdaMetaTelescope (← etaExpand t')
     mkForallFVars xs t'

--- a/Std/Tactic/Instances.lean
+++ b/Std/Tactic/Instances.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Lean
+import Lean.Elab.Command
 
 /-! # `#instances` command
 

--- a/test/instances.lean
+++ b/test/instances.lean
@@ -1,0 +1,61 @@
+import Std.Tactic.Instances
+import Std.Tactic.GuardMsgs
+
+/--
+error: type class instance expected
+  Fin 1
+-/
+#guard_msgs in
+#instances Fin 1
+
+/--
+info: 1 instance:
+
+instAddNat : Add Nat
+-/
+#guard_msgs in
+#instances Add Nat
+
+namespace Testing
+class A (α : Type)
+
+/-- info: No instances -/
+#guard_msgs in
+#instances A
+
+instance : A Nat := ⟨⟩
+instance : A Bool := ⟨⟩
+
+/--
+info: 2 instances:
+
+instANat : A Nat
+instABool : A Bool
+-/
+#guard_msgs in
+#instances A _
+
+/--
+info: 2 instances:
+
+instANat : A Nat
+instABool : A Bool
+-/
+#guard_msgs in
+#instances A
+
+/-- info: No instances -/
+#guard_msgs in
+#instances (α : Type) → A α
+
+instance : A α := ⟨⟩
+
+/--
+info: 1 instance:
+
+@instA : {α : Type} → A α
+-/
+#guard_msgs in
+#instances (α : Type) → A α
+
+end Testing

--- a/test/instances.lean
+++ b/test/instances.lean
@@ -1,6 +1,8 @@
 import Std.Tactic.Instances
 import Std.Tactic.GuardMsgs
 
+set_option linter.missingDocs false
+
 /--
 error: type class instance expected
   Fin 1
@@ -23,23 +25,26 @@ class A (α : Type)
 #guard_msgs in
 #instances A
 
-instance : A Nat := ⟨⟩
+instance (priority := high) : A Nat := ⟨⟩
+instance : A Int := ⟨⟩
 instance : A Bool := ⟨⟩
 
 /--
-info: 2 instances:
+info: 3 instances:
 
-instANat : A Nat
-instABool : A Bool
+(prio 10000) Testing.instANat : A Nat
+Testing.instABool : A Bool
+Testing.instAInt : A Int
 -/
 #guard_msgs in
 #instances A _
 
 /--
-info: 2 instances:
+info: 3 instances:
 
-instANat : A Nat
-instABool : A Bool
+(prio 10000) Testing.instANat : A Nat
+Testing.instABool : A Bool
+Testing.instAInt : A Int
 -/
 #guard_msgs in
 #instances A
@@ -51,9 +56,20 @@ instABool : A Bool
 instance : A α := ⟨⟩
 
 /--
+info: 5 instances:
+(local) inst✝ : A β
+(prio 10000) Testing.instANat : A Nat
+Testing.instABool : A Bool
+Testing.instAInt : A Int
+Testing.instA {α : Type} : A α
+-/
+#guard_msgs in
+#instances [A β] : A
+
+/--
 info: 1 instance:
 
-@instA : {α : Type} → A α
+Testing.instA {α : Type} : A α
 -/
 #guard_msgs in
 #instances (α : Type) → A α


### PR DESCRIPTION
This adds a command similar to `#synth` that finds all applicable instances. For example, `#instances Add _` looks for all instances whose conclusion unifies with `Add _`. Trailing underscores can be omitted, so `#instances Add` works as well. Another example is `#instances OfNat _ (nat_lit 0)`, which shows all instances of `OfNat` for `0`.