### PR TITLE
feat: function to find inverse for extended binders

### DIFF
--- a/test/extended_binder.lean
+++ b/test/extended_binder.lean
@@ -1,0 +1,31 @@
+import Std.Util.ExtendedBinder
+import Std.Tactic.GuardMsgs
+
+namespace Testing
+
+example (x : Nat) : (satisfies_binder_pred% x > 1) = (x > 1) := rfl
+example (x : Nat) : (satisfies_binder_pred% x ≥ 1) = (x ≥ 1) := rfl
+example (x : Nat) : (satisfies_binder_pred% x < 1) = (x < 1) := rfl
+example (x : Nat) : (satisfies_binder_pred% x ≤ 1) = (x ≤ 1) := rfl
+
+example : ∃ x < 5, x < 5 := ⟨0, by simp⟩
+
+open Lean Elab Std.ExtendedBinder in
+/-- Test function for getBinderPredOfProp -/
+def runGetBinderPredOfProp (t : Term) : TermElabM Unit := do
+  let res? ← liftMacroM <| getBinderPredOfProp t
+  if let some (x, bp) := res? then
+    logInfo m!"yes: {x},{bp}"
+  else
+    logInfo m!"no"
+
+/-- info: no -/
+#guard_msgs in #eval do runGetBinderPredOfProp (← `(x + 2))
+/-- info: yes: x✝, > 2 -/
+#guard_msgs in #eval do runGetBinderPredOfProp (← `(x > 2))
+/-- info: yes: x✝, ≥ 2 -/
+#guard_msgs in #eval do runGetBinderPredOfProp (← `(x ≥ 2))
+/-- info: yes: x✝, < 2 -/
+#guard_msgs in #eval do runGetBinderPredOfProp (← `(x < 2))
+/-- info: yes: x✝, ≤ 2 -/
+#guard_msgs in #eval do runGetBinderPredOfProp (← `(x ≤ 2))


### PR DESCRIPTION
Adds `getBinderPredOfProp` to query for inverse of `satisfies_binder_pred%` and extends `binder_predicate` notation to support this.

This can be applied to creating pretty printers that make use of extended binders.