### PR TITLE
Basic pow lemmas for Nat

### DIFF
--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -230,6 +230,9 @@ theorem sub_eq_sub_min (n m : Nat) : n - m = n - min n m := by
 protected theorem mul_right_comm (n m k : Nat) : n * m * k = n * k * m := by
   rw [Nat.mul_assoc, Nat.mul_comm m, ← Nat.mul_assoc]
 
+protected theorem mul_cross_comm (a b c d : Nat) : (a * b) * (c * d) = (a * c) * (b * d) := by
+  rw [Nat.mul_assoc, Nat.mul_assoc, Nat.mul_left_comm b]
+
 protected theorem mul_two (n : Nat) : n * 2 = n + n := by simp [Nat.mul_succ]
 
 protected theorem two_mul (n : Nat) : 2 * n = n + n := by simp [Nat.succ_mul]
@@ -791,6 +794,8 @@ theorem mul_mod (a b n : Nat) : a * b % n = (a % n) * (b % n) % n := by
 theorem add_mod (a b n : Nat) : (a + b) % n = ((a % n) + (b % n)) % n := by
   rw [add_mod_mod, mod_add_mod]
 
+/- pow -/
+
 theorem pow_succ' {m n : Nat} : m ^ n.succ = m * m ^ n := by
   rw [Nat.pow_succ, Nat.mul_comm]
 
@@ -804,9 +809,44 @@ theorem pow_succ' {m n : Nat} : m ^ n.succ = m * m ^ n := by
 
 theorem one_shiftLeft (n : Nat) : 1 <<< n = 2 ^ n := by rw [shiftLeft_eq, Nat.one_mul]
 
-/-! ### log2 -/
-
 attribute [simp] Nat.pow_zero
+
+theorem zero_pow {n : Nat} (H : 0 < n) : 0 ^ n = 0 := by
+  match n with
+  | 0 => contradiction
+  | n+1 => rw [Nat.pow_succ, Nat.mul_zero]
+
+@[simp] theorem one_pow (n : Nat) : 1 ^ n = 1 := by
+  induction n with
+  | zero => rfl
+  | succ _ ih => rw [Nat.pow_succ, Nat.mul_one, ih]
+
+@[simp] theorem pow_one (a : Nat) : a ^ 1 = a := by rw [Nat.pow_succ, Nat.pow_zero, Nat.one_mul]
+
+theorem pow_two (a : Nat) : a ^ 2 = a * a := by rw [Nat.pow_succ, Nat.pow_one]
+
+theorem pow_add (a m n : Nat) : a ^ (m + n) = a ^ m * a ^ n := by
+  induction n with
+  | zero => rw [Nat.add_zero, Nat.pow_zero, Nat.mul_one]
+  | succ _ ih => rw [Nat.add_succ, Nat.pow_succ, Nat.pow_succ, ih, Nat.mul_assoc]
+
+theorem pow_add' (a m n : Nat) : a ^ (m + n) = a ^ n * a ^ m := by rw [←Nat.pow_add, Nat.add_comm]
+
+theorem pow_mul (a m n : Nat) : a ^ (m * n) = (a ^ m) ^ n := by
+  induction n with
+  | zero => rw [Nat.mul_zero, Nat.pow_zero, Nat.pow_zero]
+  | succ _ ih => rw [Nat.mul_succ, Nat.pow_add, Nat.pow_succ, ih]
+
+theorem pow_mul' (a m n : Nat) : a ^ (m * n) = (a ^ n) ^ m := by rw [←Nat.pow_mul, Nat.mul_comm]
+
+theorem pow_right_comm (a m n : Nat) : (a ^ m) ^ n = (a ^ n) ^ m := by rw [←Nat.pow_mul, Nat.pow_mul']
+
+theorem mul_pow (a b n : Nat) : (a * b) ^ n = a ^ n * b ^ n := by
+  induction n with
+  | zero => rw [Nat.pow_zero, Nat.pow_zero, Nat.pow_zero, Nat.mul_one]
+  | succ _ ih => rw [Nat.pow_succ, Nat.pow_succ, Nat.pow_succ, Nat.mul_cross_comm, ih]
+
+/-! ### log2 -/
 
 theorem le_log2 (h : n ≠ 0) : k ≤ n.log2 ↔ 2 ^ k ≤ n := by
   match k with

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -230,7 +230,7 @@ theorem sub_eq_sub_min (n m : Nat) : n - m = n - min n m := by
 protected theorem mul_right_comm (n m k : Nat) : n * m * k = n * k * m := by
   rw [Nat.mul_assoc, Nat.mul_comm m, ← Nat.mul_assoc]
 
-protected theorem mul_cross_comm (a b c d : Nat) : (a * b) * (c * d) = (a * c) * (b * d) := by
+protected theorem mul_mul_mul_comm (a b c d : Nat) : (a * b) * (c * d) = (a * c) * (b * d) := by
   rw [Nat.mul_assoc, Nat.mul_assoc, Nat.mul_left_comm b]
 
 protected theorem mul_two (n : Nat) : n * 2 = n + n := by simp [Nat.mul_succ]
@@ -794,7 +794,7 @@ theorem mul_mod (a b n : Nat) : a * b % n = (a % n) * (b % n) % n := by
 theorem add_mod (a b n : Nat) : (a + b) % n = ((a % n) + (b % n)) % n := by
   rw [add_mod_mod, mod_add_mod]
 
-/- pow -/
+/-! ### pow -/
 
 theorem pow_succ' {m n : Nat} : m ^ n.succ = m * m ^ n := by
   rw [Nat.pow_succ, Nat.mul_comm]
@@ -844,7 +844,7 @@ theorem pow_right_comm (a m n : Nat) : (a ^ m) ^ n = (a ^ n) ^ m := by rw [←Na
 theorem mul_pow (a b n : Nat) : (a * b) ^ n = a ^ n * b ^ n := by
   induction n with
   | zero => rw [Nat.pow_zero, Nat.pow_zero, Nat.pow_zero, Nat.mul_one]
-  | succ _ ih => rw [Nat.pow_succ, Nat.pow_succ, Nat.pow_succ, Nat.mul_cross_comm, ih]
+  | succ _ ih => rw [Nat.pow_succ, Nat.pow_succ, Nat.pow_succ, Nat.mul_mul_mul_comm, ih]
 
 /-! ### log2 -/
 


### PR DESCRIPTION
The corresponding lemmas in Mathlib are based on a monoid class (Mathlib/Algebra/GroupPower/Basic.lean) so they won't be down-ported to Std. Core has very limited need for powers, so they are unlikely to appear there.