### PR TITLE
feat: additional config for `congr`

### DIFF
--- a/Std/Tactic/Congr.lean
+++ b/Std/Tactic/Congr.lean
@@ -105,8 +105,8 @@ and `congr with x` (or `congr; ext x`) would produce
 x : α ⊢ f x + 3 = g x + 3
 ```
 -/
-elab (name := rcongr) "rcongr" cfg:(Parser.Tactic.config)? ps:(ppSpace colGt rintroPat)* :
+elab (name := rcongr) "rcongr" cfg:((Parser.Tactic.config)?) ps:(ppSpace colGt rintroPat)* :
     tactic => do
-  let gs ← rcongrCore (← getMainGoal) (← Congr.elabConfig (mkOptionalNode cfg))
+  let gs ← rcongrCore (← getMainGoal) (← Congr.elabConfig cfg)
     (RCases.expandRIntroPats ps).toList #[]
   replaceMainGoal gs.toList

--- a/Std/Tactic/Congr.lean
+++ b/Std/Tactic/Congr.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro
+Authors: Mario Carneiro, Miyahara Kō
 -/
 import Lean.Meta.Tactic.Congr
 import Std.Tactic.RCases
@@ -11,6 +11,21 @@ import Std.Tactic.Ext
 
 namespace Std.Tactic
 open Lean Meta Elab Tactic Std.Tactic
+
+/-- Configuration options for `congr` & `rcongr` -/
+structure Congr.Config where
+  /-- If `closePre := true`, it will attempt to close new goals using `Eq.refl`, `HEq.refl`, and
+  `assumption` with reducible transparency. -/
+  closePre : Bool := true
+  /-- If `closePost := true`, it will try again on goals on which `congr` failed to make progress
+  with default transparency. -/
+  closePost : Bool := true
+
+/-- Function elaborating `Congr.Config` -/
+declare_config_elab Congr.elabConfig Congr.Config
+
+@[inherit_doc Lean.Parser.Tactic.congr]
+syntax (name := congrConfig) "congr" Parser.Tactic.config (ppSpace num)? : tactic
 
 /--
 Apply congruence (recursively) to goals of the form `⊢ f as = f bs` and `⊢ HEq (f as) (f bs)`.
@@ -27,26 +42,40 @@ Apply congruence (recursively) to goals of the form `⊢ f as = f bs` and `⊢ H
 syntax (name := congrWith) "congr" (ppSpace colGt num)?
   " with" (ppSpace colGt rintroPat)* (" : " num)? : tactic
 
+@[inherit_doc Std.Tactic.congrWith]
+syntax (name := congrConfigWith) "congr" Parser.Tactic.config (ppSpace colGt num)?
+  " with" (ppSpace colGt rintroPat)* (" : " num)? : tactic
+
+elab_rules : tactic
+  | `(tactic| congr $cfg:config $[$n?]?) => do
+    let config ← Congr.elabConfig (mkOptionalNode cfg)
+    let hugeDepth := 1000000
+    let depth := n?.map (·.getNat) |>.getD hugeDepth
+    liftMetaTactic fun mvarId =>
+      mvarId.congrN depth (closePre := config.closePre) (closePost := config.closePost)
+
 macro_rules
   | `(tactic| congr $(depth)? with $ps* $[: $n]?) =>
     `(tactic| congr $(depth)? <;> ext $ps* $[: $n]?)
+  | `(tactic| congr $config:config $(depth)? with $ps* $[: $n]?) =>
+    `(tactic| congr $config:config $(depth)? <;> ext $ps* $[: $n]?)
 
 /--
 Recursive core of `rcongr`. Calls `ext pats <;> congr` and then itself recursively,
 unless `ext pats <;> congr` made no progress.
 -/
-partial def rcongrCore (g : MVarId) (pats : List (TSyntax `rcasesPat))
+partial def rcongrCore (g : MVarId) (config : Congr.Config) (pats : List (TSyntax `rcasesPat))
     (acc : Array MVarId) : TermElabM (Array MVarId) := do
   let mut acc := acc
   for (g, qs) in (← Ext.extCore g pats (failIfUnchanged := false)).2 do
     let s ← saveState
-    let gs ← g.congrN 1000000
+    let gs ← g.congrN 1000000 (closePre := config.closePre) (closePost := config.closePost)
     if ← not <$> g.isAssigned <||> gs.anyM fun g' => return (← g'.getType).eqv (← g.getType) then
       s.restore
       acc := acc.push g
     else
       for g in gs do
-        acc ← rcongrCore g qs acc
+        acc ← rcongrCore g config qs acc
   pure acc
 
 /--
@@ -59,7 +88,7 @@ There are two ways this tactic stops:
 
 For example, when the goal is
 ```
-⊢ (λ x, f x + 3) '' s = (λ x, g x + 3) '' s
+⊢ (fun x => f x + 3) '' s = (fun x => g x + 3) '' s
 ```
 then `rcongr x` produces the goal
 ```
@@ -69,13 +98,15 @@ This gives the same result as `congr; ext x; congr`.
 
 In contrast, `congr` would produce
 ```
-⊢ (λ x, f x + 3) = (λ x, g x + 3)
+⊢ (fun x => f x + 3) = (fun x => g x + 3)
 ```
 and `congr with x` (or `congr; ext x`) would produce
 ```
 x : α ⊢ f x + 3 = g x + 3
 ```
 -/
-elab (name := rcongr) "rcongr" ps:(ppSpace colGt rintroPat)* : tactic => do
-  let gs ← rcongrCore (← getMainGoal) (RCases.expandRIntroPats ps).toList #[]
+elab (name := rcongr) "rcongr" cfg:(Parser.Tactic.config)? ps:(ppSpace colGt rintroPat)* :
+    tactic => do
+  let gs ← rcongrCore (← getMainGoal) (← Congr.elabConfig (mkOptionalNode cfg))
+    (RCases.expandRIntroPats ps).toList #[]
   replaceMainGoal gs.toList

--- a/Std/Tactic/Congr.lean
+++ b/Std/Tactic/Congr.lean
@@ -39,11 +39,7 @@ Apply congruence (recursively) to goals of the form `⊢ f as = f bs` and `⊢ H
   For example, if the goal is `⊢ f '' s = g '' s` then `congr with x` generates the goal
   `x : α ⊢ f x = g x`.
 -/
-syntax (name := congrWith) "congr" (ppSpace colGt num)?
-  " with" (ppSpace colGt rintroPat)* (" : " num)? : tactic
-
-@[inherit_doc Std.Tactic.congrWith]
-syntax (name := congrConfigWith) "congr" Parser.Tactic.config (ppSpace colGt num)?
+syntax (name := congrConfigWith) "congr" (Parser.Tactic.config)? (ppSpace colGt num)?
   " with" (ppSpace colGt rintroPat)* (" : " num)? : tactic
 
 elab_rules : tactic
@@ -55,10 +51,10 @@ elab_rules : tactic
       mvarId.congrN depth (closePre := config.closePre) (closePost := config.closePost)
 
 macro_rules
-  | `(tactic| congr $(depth)? with $ps* $[: $n]?) =>
-    `(tactic| congr $(depth)? <;> ext $ps* $[: $n]?)
-  | `(tactic| congr $config:config $(depth)? with $ps* $[: $n]?) =>
-    `(tactic| congr $config:config $(depth)? <;> ext $ps* $[: $n]?)
+  | `(tactic| congr $(cfg)? $(depth)? with $ps* $[: $n]?) =>
+    match cfg with
+    | none => `(tactic| congr $(depth)? <;> ext $ps* $[: $n]?)
+    | some cfg => `(tactic| congr $cfg $(depth)? <;> ext $ps* $[: $n]?)
 
 /--
 Recursive core of `rcongr`. Calls `ext pats <;> congr` and then itself recursively,

--- a/test/congr.lean
+++ b/test/congr.lean
@@ -54,6 +54,11 @@ example : 0 = 0 := by rcongr
 
 example {α} (a : α) : a = a := by congr
 
+example : { f : Nat → Nat // f = id } :=
+  ⟨_, by
+    congr (config := { closePre := false, closePost := false }) with x
+    exact Nat.zero_add x⟩
+
 -- FIXME(?): congr doesn't fail
 -- example {α} (a b : α) (h : False) : a = b := by
 --   fail_if_success congr


### PR DESCRIPTION
The `MetaM` version of `congr` (`Lean.MVarId.congrN`) has 2 configs: `closePre` and `closePost`.
Especially, `closePost` is significant to prevent timeout.
This file adds a config for the `congr` & `rcongr` tactic.