### PR TITLE
feat: use whnf in ext, more like Lean3 behaviour

### DIFF
--- a/Std/Tactic/Ext.lean
+++ b/Std/Tactic/Ext.lean
@@ -204,3 +204,5 @@ attribute [ext] funext propext
 
 @[ext] protected theorem PUnit.ext (x y : PUnit) : x = y := rfl
 protected theorem Unit.ext (x y : Unit) : x = y := rfl
+
+example (p q : PUnit) : p = q := by ext

--- a/Std/Tactic/Ext/Attr.lean
+++ b/Std/Tactic/Ext/Attr.lean
@@ -35,7 +35,7 @@ ordered from high priority to low. -/
 @[inline] def getExtLemmas (ty : Expr) : MetaM (Array ExtTheorem) :=
   -- Using insertion sort because it is stable and the list of matches should be mostly sorted.
   -- Most ext lemmas have default priority.
-  return (← (extExtension.getState (← getEnv)).getMatch ty)
+  return (← (extExtension.getState (← getEnv)).getMatch (← whnf ty))
     |>.insertionSort (·.priority < ·.priority) |>.reverse
 
 /-- Registers an extensionality lemma.
@@ -66,7 +66,7 @@ initialize registerBuiltinAttribute {
         "@[ext] attribute only applies to structures or lemmas proving x = y, got {declTy}"
       let some (ty, lhs, rhs) := declTy.eq? | failNotEq
       unless lhs.isMVar && rhs.isMVar do failNotEq
-      let keys ← withReducible <| DiscrTree.mkPath ty
+      let keys ← withReducible <| DiscrTree.mkPath (← whnf ty)
       let priority ← liftCommandElabM do Elab.liftMacroM do
         evalPrio (prio.getD (← `(prio| default)))
       extExtension.add {declName, keys, priority} kind

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -77,6 +77,6 @@ example (f : Empty → Empty) : f = f := by
   ext ⟨⟩
 
 -- Check that `ext` uses `whnf` to look through the heads of definitions
--- when indexing applicable theorems.
+-- when indexing applicable theorems. (Such theorems are used after all theorems found directly.)
 def PUnit' := PUnit
 example (p q : PUnit') : p = q := by ext

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -75,3 +75,8 @@ example (f : ℕ × (ℕ → ℕ)) : f = f := by
 
 example (f : Empty → Empty) : f = f := by
   ext ⟨⟩
+
+-- Check that `ext` uses `whnf` to look through the heads of definitions
+-- when indexing applicable theorems.
+def PUnit' := PUnit
+example (p q : PUnit') : p = q := by ext


### PR DESCRIPTION
We restore Lean3-like behaviour to ext, by keeping track of two discrimation trees. The first is the current behaviour of `ext`, while the second indexes using `whnf`.

See https://github.com/leanprover-community/mathlib4/pull/5191 for examples of how this works out in mathlib4. (That PR is far from exhaustive.)

Obviously this will be slower, but I hope it's considered worth it for the simplifications available in mathlib4. Note this is still much faster than the mathlib3 behaviour (where there wasn't any discrimation tree at all, just a single big bucket of lemmas). `apply` is fast.