### PR TITLE
chore: ext doesn't reorder goals

### DIFF
--- a/Std/Tactic/Ext.lean
+++ b/Std/Tactic/Ext.lean
@@ -106,7 +106,9 @@ def applyExtLemma (goal : MVarId) : MetaM (List MVarId) := goal.withContext do
         let c ← mkConstWithFreshMVarLevels lem.declName
         let (_, _, declTy) ← withDefault <| forallMetaTelescopeReducing (← inferType c)
         guard (← isDefEq tgt declTy)
-      return ← goal.apply (← mkConstWithFreshMVarLevels lem.declName)
+      -- We use `newGoals := .all` as this is
+      -- more useful in practice with dependently typed arguments of `@[ext]` lemmas.
+      return ← goal.apply (cfg := { newGoals := .all }) (← mkConstWithFreshMVarLevels lem.declName)
     catch _ => s.restore
   throwError "no applicable extensionality lemma found for{indentExpr ty}"
 


### PR DESCRIPTION
This is relevant for `@[ext]` lemmas in mathlib4 such as 
```
theorem ext {X Y : PresheafedSpace C} (α β : X ⟶ Y) (w : α.base = β.base)
    (h : α.c ≫ whiskerRight (eqToHom (by rw [w])) _ = β.c) : α = β :=
```
We usually apply these using `fapply`, as one needs to solve `w` before `h`. It would be nice to have `ext` be helpful on this.