### PR TITLE
fix: remove `simp` attribute from getElem_fin/getElem?_fin/getElem!_fin

### DIFF
--- a/Std/Data/Array/Lemmas.lean
+++ b/Std/Data/Array/Lemmas.lean
@@ -11,13 +11,13 @@ import Std.Tactic.Simpa
 
 local macro_rules | `($x[$i]'$h) => `(getElem $x $i $h)
 
-@[simp] theorem getElem_fin [GetElem Cont Nat Elem Dom] (a : Cont) (i : Fin n) (h : Dom a i) :
+theorem getElem_fin [GetElem Cont Nat Elem Dom] (a : Cont) (i : Fin n) (h : Dom a i) :
     a[i] = a[i.1] := rfl
 
-@[simp] theorem getElem?_fin [GetElem Cont Nat Elem Dom] (a : Cont) (i : Fin n)
+theorem getElem?_fin [GetElem Cont Nat Elem Dom] (a : Cont) (i : Fin n)
     [Decidable (Dom a i)] : a[i]? = a[i.1]? := rfl
 
-@[simp] theorem getElem!_fin [GetElem Cont Nat Elem Dom] (a : Cont) (i : Fin n)
+theorem getElem!_fin [GetElem Cont Nat Elem Dom] (a : Cont) (i : Fin n)
     [Decidable (Dom a i)] [Inhabited Elem] : a[i]! = a[i.1]! := rfl
 
 theorem getElem?_pos [GetElem Cont Idx Elem Dom]


### PR DESCRIPTION
Having these as simp lemmas is making it more difficult to use the `getElem` notation as the simp normal form of indexing a `Vector` with a `Fin n`. 