### PR TITLE
feat: `LawfulBEq` instances for `Option` types

### DIFF
--- a/Std/Data/Option/Basic.lean
+++ b/Std/Data/Option/Basic.lean
@@ -144,3 +144,17 @@ result.
   match x with
   | some a => pure a
   | none => y
+
+instance (α) [BEq α] [LawfulBEq α] : LawfulBEq (Option α) where
+  rfl {x} :=
+    match x with
+    | some x => show x == x from LawfulBEq.rfl
+    | none => rfl
+  eq_of_beq {x y h} := by
+    match x, y with
+    | some x, some y =>
+      have h : x == y := h
+      rw [LawfulBEq.eq_of_beq h]
+    | some _, none => contradiction
+    | none, some _ => contradiction
+    | none, none => rfl

--- a/Std/Data/Option/Basic.lean
+++ b/Std/Data/Option/Basic.lean
@@ -148,13 +148,9 @@ result.
 instance (α) [BEq α] [LawfulBEq α] : LawfulBEq (Option α) where
   rfl {x} :=
     match x with
-    | some x => show x == x from LawfulBEq.rfl
+    | some x => LawfulBEq.rfl (α := α)
     | none => rfl
   eq_of_beq {x y h} := by
     match x, y with
-    | some x, some y =>
-      have h : x == y := h
-      rw [LawfulBEq.eq_of_beq h]
-    | some _, none => contradiction
-    | none, some _ => contradiction
+    | some x, some y => rw [LawfulBEq.eq_of_beq (α := α) h]
     | none, none => rfl


### PR DESCRIPTION
The `show` and `have` are because the derive handler in core makes the actual implementation of `BEq` private, which means it can't be unfolded easily. Fortunately, it's pretty easy to figure out what it does in this particular case.