### PR TITLE
feat: DepArray

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -21,6 +21,7 @@ import Std.Data.AssocList
 import Std.Data.BinomialHeap
 import Std.Data.Char
 import Std.Data.DList
+import Std.Data.DepArray.Basic
 import Std.Data.Fin.Lemmas
 import Std.Data.HashMap
 import Std.Data.HashMap.Basic
@@ -116,4 +117,5 @@ import Std.Tactic.Where
 import Std.Util.ExtendedBinder
 import Std.Util.LibraryNote
 import Std.Util.TermUnsafe
+import Std.Util.TypeErased
 import Std.WF

--- a/Std/Data/DepArray/Basic.lean
+++ b/Std/Data/DepArray/Basic.lean
@@ -1,0 +1,89 @@
+import Std.Data.Array.Basic
+import Std.Data.Array.Lemmas
+import Std.Data.Fin.Lemmas
+import Std.Util.TypeErased
+
+/-! # DepArray
+Array whose element types depend on the index of the element. -/
+
+namespace Std
+
+/-- (Index-)Dependent arrays. -/
+structure DepArray (size : Nat) (τ : Fin size → Type u) : Type u where
+  /-- The underlying, untyped data -/
+  data : Array TypeErased.{u}
+  /-- `data` is the correct size -/
+  h_size : size = data.size
+  /-- The elements of `data` have types as described by `τ`. -/
+  h_tys : ∀ i, (data[i.cast h_size]).type = τ i
+
+namespace DepArray
+
+/-- Get the value at index `i`. -/
+def get (i : Fin size) (A : DepArray size τ) : τ i :=
+  A.data[i.cast A.h_size] |>.cast (A.h_tys i)
+
+/-- Build a `DepArray size τ` from a dependent function on its indices. -/
+def ofFn (size : Nat) (τ : Fin size → Type u) (f : (i : Fin size) → τ i) : DepArray size τ where
+  data := Array.ofFn (fun i => TypeErased.mk <| f i)
+  h_size := by simp
+  h_tys := by simp
+
+@[simp] theorem get_ofFn (size τ) (f : (i : Fin size) → τ i) (i) : get i (ofFn size τ f) = f i := by
+  simp [get, ofFn, cast]
+
+/-- Set index `i` to `x`. See `set'` for a version which modifies the type at `i` as well. -/
+def set (i : Fin size) (x : τ i) (A : DepArray size τ) : DepArray size τ where
+  data := A.data.set (i.cast A.h_size) (.mk x)
+  h_size := by simp; exact A.h_size
+  h_tys := by
+    intro j; simp; rw [Array.get_set]
+    cases i; cases j
+    split
+    . simp at *; simp [*]
+    . simp; rw [←A.h_tys]; congr; intro j i _; exact A.h_size ▸ j.isLt
+
+theorem get_set (A : DepArray size τ) (i x j) : (set i x A).get j = if h : i = j then h ▸ x else A.get j := by
+  simp [get, set]
+  cases A; next data h_size h_tys =>
+  cases h_size
+  simp
+  split
+  next h =>
+    cases h; cases i
+    rw [TypeErased.cast_rw _ (Array.get_set ..)]
+    . simp [cast]
+    . simp [*]
+  next h =>
+    congr 1
+    apply Array.get_set_ne
+    simp [Fin.val_ne_of_ne h]
+
+/-- Set index `i` to `x`.
+
+NB: This changes the type at index `i`. See `set` for a version which does not change the type. -/
+def set' (i : Fin size) (x : β) (A : DepArray size τ) : DepArray size (fun j => if i = j then β else τ j) where
+  data := A.data.set (i.cast A.h_size) (.mk x)
+  h_size := by simp; exact A.h_size
+  h_tys := by
+    intro j; simp; rw [Array.get_set]
+    cases i; cases j
+    split
+    . simp at *; simp [*]
+    . simp at *; simp [*]; rw [←A.h_tys]; congr; intro j _; exact A.h_size ▸ j.isLt
+
+theorem cast_compose (h1 : β = γ) (h2 : α = β) (x : α) : cast h1 (cast h2 x) = (cast (h2.trans h1) x) := by
+  cases h1; cases h2; simp [cast]
+
+@[simp] theorem get_set'_eq (A : DepArray size τ) (i) (x : β) : (set' i x A).get i = cast (by simp) x := by
+  simp [get, set']
+  rw [TypeErased.cast_rw _ (Array.get_set ..)]
+  . simp
+  . exact A.h_size ▸ i.isLt
+
+@[simp] theorem get_set'_ne (A : DepArray size τ) (i) (x : β) (j) (h : i ≠ j)
+  : (set' i x A).get j = cast (by simp [h]) (A.get j) := by
+  simp [get, set']
+  congr 1
+  apply Array.get_set_ne
+  simp [Fin.val_ne_of_ne h]

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -17,6 +17,12 @@ namespace Fin
 @[simp] theorem modn_val (a : Fin n) (b : Nat) : (a.modn b).val = a.val % b :=
   Nat.mod_eq_of_lt (Nat.lt_of_le_of_lt (Nat.mod_le ..) a.2)
 
+/-- Embed `a` into an equivalent `Fin m` -/
+def cast (h : n = m) (a : Fin n) : Fin m := ⟨a.1, h ▸ a.2⟩
+
+@[simp] theorem cast_val : (cast h a).val = a.val := by simp [cast]
+@[simp] theorem cast_mk : cast h ⟨i,hi⟩ = ⟨i, h ▸ hi⟩ := by simp [cast]
+
 end Fin
 
 namespace USize

--- a/Std/Util/TypeErased.lean
+++ b/Std/Util/TypeErased.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2023 James Gallicchio.
+
+Authors: James Gallicchio
+-/
+
+namespace Std.TypeErased
+
+private structure Intf.{u} where
+  TypeErased : Type u
+  type : TypeErased → Type u
+  proj (t : TypeErased) : type t
+  inj : α → TypeErased
+  type_inj (a : α) : type (inj a) = α
+  proj_inj (a : α) : proj (inj a) = cast (type_inj a).symm a
+
+/-- States that `Intf.TypeErased` is a safe interface. -/
+axiom InftSafe.{u} : Nonempty (TypeErased.Intf.{u})
+
+attribute [instance] InftSafe in
+private noncomputable opaque Impl.{u} : TypeErased.Intf.{u}
+
+end TypeErased
+
+/-- A value of some noncomputable type. -/
+def TypeErased.{u} : Type u := TypeErased.Impl.TypeErased
+
+namespace TypeErased
+
+/-- The type of `v`. -/
+noncomputable def type : (v : TypeErased) → Type u := Impl.type
+
+/- Actual implementation of the computable portion of the interface. -/
+private unsafe def getUnsafe (v : TypeErased.{u}) : v.type := unsafeCast v
+private unsafe def mkUnsafe {α : Type u} (a : α) : TypeErased.{u} := unsafeCast a
+
+/-- Project `v` to the underlying value, of type `v.type`. -/
+@[implemented_by getUnsafe] def get (v : TypeErased.{u}) : v.type := Impl.proj v
+/-- Erase the type of `a`. -/
+@[implemented_by mkUnsafe] def mk (a : α) : TypeErased := Impl.inj a
+
+/-- Project `v` to the underlying value of type `α`. -/
+protected def cast (v : TypeErased) (h : v.type = α) : α :=
+  cast h v.get
+
+instance : Inhabited TypeErased := ⟨mk ()⟩
+
+@[simp] theorem type_mk (a : α) : (mk a).type = α := Impl.type_inj _
+theorem get_mk {a : α} : (mk a).get = cast (type_mk a).symm a := Impl.proj_inj _
+@[simp] theorem cast_mk (a : α) (h : (mk a).type = β) : (mk a).cast h = cast (Eq.trans (type_mk a).symm h) a := by
+  unfold TypeErased.cast; rw [get_mk]
+  cases h
+  congr
+
+@[simp] theorem cast_cast (v : TypeErased) (h : v.type = α) (h' : α = β) : cast h' (v.cast h) = v.cast (h.trans h') := by
+  cases h'; cases h
+  simp [TypeErased.cast, cast]
+
+theorem cast_rw {v v' : TypeErased} (h : v.type = α) (h' : v = v') : v.cast h = v'.cast (h' ▸ h) := by
+  cases h'; cases h; simp


### PR DESCRIPTION
Dependent array -- the types of each element can depend on the index.

This is a very minimal proof of concept implementation, but a `DepArray` would fit nicely in a hierarchy of array primitives "lower" than the built-in `Array`. It is a generalization of [`SciLean.Data.ArrayN`](https://github.com/lecopivo/SciLean/blob/master/SciLean/Data/ArrayN.lean) and [`LeanColls.ArrayUninit`](https://github.com/JamesGallicchio/LeanColls/blob/main/LeanColls/Array/ArrayUninit.lean).

It is also useful for caching dependent functions over `FinEnum` domains, which is my use case.