### PR TITLE
feat: tailrec pmap

### DIFF
--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -742,7 +742,7 @@ def attach (l : List α) : List { x // x ∈ l } := pmap (⟨·,·⟩) l (fun _ 
 private def pmap.impl {p : α → Prop} (f : ∀ a, p a → β) (l : List α) (h : ∀ a ∈ l, p a) : List β :=
   l.attach.map fun ⟨x,h'⟩ => f x (h _ h')
 
-@[csimp] theorem pmap_eq_pmapTR : @pmap = @pmap.impl := by
+@[csimp] theorem pmap_eq_pmap_impl : @pmap = @pmap.impl := by
   funext α β p f L h
   unfold pmap.impl
   unfold attach

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -732,9 +732,11 @@ def findIdx? (p : α → Bool) : List α → (start : Nat := 0) → Option Nat
 /-- Tail-recursive version of `pmap`. -/
 def pmapTR {p : α → Prop} (f : ∀ a, p a → β) (l : List α) (h : ∀ a ∈ l, p a) : List β :=
   aux f l h []
-where aux {p : α → Prop} (f : ∀ a, p a → β) : ∀ l : List α, (∀ a ∈ l, p a) → List β → List β
-| [], _, acc => acc.reverse
-| x::xs, h, acc => aux f xs (fun a ha => h a (.tail _ ha)) (f x (h x (.head _)) :: acc)
+where
+  /-- aux f l h acc = acc.reverse ++ pmap f l h -/
+  aux {p : α → Prop} (f : ∀ a, p a → β) : ∀ l : List α, (∀ a ∈ l, p a) → List β → List β
+  | [], _, acc => acc.reverse
+  | x::xs, h, acc => aux f xs (fun a ha => h a (.tail _ ha)) (f x (h x (.head _)) :: acc)
 
 @[csimp] theorem pmap_eq_pmapTR : @pmap = @pmapTR := by
   funext α β p f L h

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -743,7 +743,7 @@ def attach (l : List α) : List { x // x ∈ l } :=
 private def pmap.impl {p : α → Prop} (f : ∀ a, p a → β) (l : List α) (h : ∀ a ∈ l, p a) : List β :=
   l.attach.map fun ⟨x,h'⟩ => f x (h _ h')
 
-@[csimp] theorem pmap_eq_pmap_impl : @pmap = @pmap.impl := by
+@[csimp] private theorem pmap_eq_pmap_impl : @pmap = @pmap.impl := by
   funext α β p f L h
   unfold pmap.impl
   unfold attach

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -757,11 +757,10 @@ private def pmap.impl {p : α → Prop} (f : ∀ a, p a → β) (l : List α) (h
     from this L (fun _ hx => hx) h
   intro L hL h
   induction L with
-  | nil => simp
-  | cons x xs ih =>
-    simp
-    rw [ih]
-    exact fun _ hx => hL <| .tail _ hx
+  | nil => rfl
+  | cons _ L' ih =>
+    have : L' ⊆ L := fun _ hx => hL (.tail _ hx)
+    exact congrArg _ (ih this)
 
 /--
 `lookmap` is a combination of `lookup` and `filterMap`.

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -736,7 +736,8 @@ private unsafe def attach.impl (l : List α) : List { x // x ∈ l } :=
 /-- "Attach" the proof that the elements of `l` are in `l` to produce a new list
   with the same elements but in the type `{x // x ∈ l}`. -/
 @[implemented_by attach.impl]
-def attach (l : List α) : List { x // x ∈ l } := pmap (⟨·,·⟩) l (fun _ h => h)
+def attach (l : List α) : List { x // x ∈ l } :=
+  pmap Subtype.mk l (fun _ => id)
 
 /-- Tail-recursive version of `pmap`. -/
 private def pmap.impl {p : α → Prop} (f : ∀ a, p a → β) (l : List α) (h : ∀ a ∈ l, p a) : List β :=


### PR DESCRIPTION
includes csimp lemma to substitute the tailrec version