### PR TITLE
feat: cleanup some Nat lemmas

### DIFF
--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -312,7 +312,7 @@ theorem castLE_of_eq {m n : Nat} (h : m = n) {h' : m ≤ n} : castLE h' = Fin.ca
 theorem castAdd_lt {m : Nat} (n : Nat) (i : Fin m) : (castAdd n i : Nat) < m := by simp
 
 @[simp] theorem castAdd_mk (m : Nat) (i : Nat) (h : i < n) :
-    castAdd m ⟨i, h⟩ = ⟨i, Nat.lt_add_right i n m h⟩ := rfl
+    castAdd m ⟨i, h⟩ = ⟨i, Nat.lt_add_right m h⟩ := rfl
 
 @[simp] theorem castAdd_castLT (m : Nat) (i : Fin (n + m)) (hi : i.val < n) :
     castAdd m (castLT i hi) = i := rfl

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -198,7 +198,7 @@ theorem add_one_pos (i : Fin (n + 1)) (h : i < Fin.last n) : (0 : Fin (n + 1)) <
   match n with
   | 0 => cases h
   | n+1 =>
-    rw [Fin.lt_def, val_last, ← Nat.add_lt_add_iff_right 1] at h
+    rw [Fin.lt_def, val_last, ← Nat.add_lt_add_iff_right] at h
     rw [Fin.lt_def, val_add, val_zero, val_one, Nat.mod_eq_of_lt h]
     exact Nat.zero_lt_succ _
 

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -174,7 +174,7 @@ theorem forall_mem_map_iff {f : α → β} {l : List α} {P : β → Prop} :
 @[simp] theorem length_zipWith (f : α → β → γ) (l₁ l₂) :
     length (zipWith f l₁ l₂) = min (length l₁) (length l₂) := by
   induction l₁ generalizing l₂ <;> cases l₂ <;>
-    simp_all [add_one, min_succ_succ, Nat.zero_min, Nat.min_zero]
+    simp_all [add_one, Nat.min_succ_succ, Nat.min_zero_left, Nat.min_zero_right]
 
 /-! ### join -/
 
@@ -708,8 +708,8 @@ theorem getD_eq_get? : ∀ l n (a : α), getD l n a = (get? l n).getD a
 /-! ### take and drop -/
 
 @[simp] theorem length_take : ∀ (i : Nat) (l : List α), length (take i l) = min i (length l)
-  | 0, l => by simp [Nat.zero_min]
-  | succ n, [] => by simp [Nat.min_zero]
+  | 0, l => by simp [Nat.min_zero_left]
+  | succ n, [] => by simp [Nat.min_zero_right]
   | succ n, _ :: l => by simp [Nat.min_succ_succ, add_one, length_take]
 
 theorem length_take_le (n) (l : List α) : length (take n l) ≤ n := by simp [Nat.min_le_left]

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -606,7 +606,7 @@ theorem get_zero : ∀ {l : List α} (h : 0 < l.length), l.get ⟨0, h⟩ = l.he
   | _::_, _ => rfl
 
 theorem get_append : ∀ {l₁ l₂ : List α} (n : Nat) (h : n < l₁.length),
-    (l₁ ++ l₂).get ⟨n, length_append .. ▸ Nat.lt_add_right _ _ _ h⟩ = l₁.get ⟨n, h⟩
+    (l₁ ++ l₂).get ⟨n, length_append .. ▸ Nat.lt_add_right _ h⟩ = l₁.get ⟨n, h⟩
 | a :: l, _, 0, h => rfl
 | a :: l, _, n+1, h => by simp only [get, cons_append]; apply get_append
 

--- a/Std/Data/Nat/Basic.lean
+++ b/Std/Data/Nat/Basic.lean
@@ -8,6 +8,86 @@ import Std.Classes.Dvd
 namespace Nat
 
 /--
+  Recursor identical to `Nat.rec` but uses notations `0` for `Nat.zero` and `·+1` for `Nat.succ`
+-/
+@[elab_as_elim]
+protected def recAux {motive : Nat → Sort _} (zero : motive 0) (succ : ∀ n, motive n → motive (n+1)) :
+    (t : Nat) → motive t
+  | 0 => zero
+  | _+1 => succ _ (Nat.recAux zero succ _)
+
+/--
+  Recursor identical to `Nat.recOn` but uses notations `0` for `Nat.zero` and `·+1` for `Nat.succ`
+-/
+@[elab_as_elim]
+protected def recAuxOn {motive : Nat → Sort _} (t : Nat) (zero : motive 0)
+  (succ : ∀ n, motive n → motive (n+1)) : motive t := Nat.recAux zero succ t
+
+/--
+  Recursor identical to `Nat.casesOn` but uses notations `0` for `Nat.zero` and `·+1` for `Nat.succ`
+-/
+@[elab_as_elim]
+protected def casesAuxOn {motive : Nat → Sort _} (t : Nat) (zero : motive 0)
+  (succ : ∀ n, motive (n+1)) : motive t := Nat.recAux zero (fun n _ => succ n) t
+
+/--
+  Simple diagonal recursor for `Nat`
+-/
+@[elab_as_elim]
+protected def recDiagAux {motive : Nat → Nat → Sort _}
+  (zero_left : ∀ n, motive 0 n)
+  (zero_right : ∀ m, motive m 0)
+  (succ_succ : ∀ m n, motive m n → motive (m+1) (n+1)) :
+    (m n : Nat) → motive m n
+  | 0, _ => zero_left _
+  | _, 0 => zero_right _
+  | _+1, _+1 => succ_succ _ _ (Nat.recDiagAux zero_left zero_right succ_succ _ _)
+
+/--
+  Diagonal recursor for `Nat`
+-/
+@[elab_as_elim]
+protected def recDiag {motive : Nat → Nat → Sort _}
+  (zero_zero : motive 0 0)
+  (zero_succ : ∀ n, motive 0 n → motive 0 (n+1))
+  (succ_zero : ∀ m, motive m 0 → motive (m+1) 0)
+  (succ_succ : ∀ m n, motive m n → motive (m+1) (n+1)) :
+    (m n : Nat) → motive m n := Nat.recDiagAux left right succ_succ
+where
+  /-- Left leg for `Nat.recDiag` -/
+  left : ∀ n, motive 0 n
+  | 0 => zero_zero
+  | _+1 => zero_succ _ (left _)
+  /-- Right leg for `Nat.recDiag` -/
+  right : ∀ m, motive m 0
+  | 0 => zero_zero
+  | _+1 => succ_zero _ (right _)
+
+/--
+  Diagonal recursor for `Nat`
+-/
+@[elab_as_elim]
+protected def recDiagOn {motive : Nat → Nat → Sort _} (m n : Nat)
+  (zero_zero : motive 0 0)
+  (zero_succ : ∀ n, motive 0 n → motive 0 (n+1))
+  (succ_zero : ∀ m, motive m 0 → motive (m+1) 0)
+  (succ_succ : ∀ m n, motive m n → motive (m+1) (n+1)) :
+    motive m n := Nat.recDiag zero_zero zero_succ succ_zero succ_succ m n
+
+/--
+  Diagonal recursor for `Nat`
+-/
+@[elab_as_elim]
+protected def casesDiagOn {motive : Nat → Nat → Sort _} (m n : Nat)
+  (zero_zero : motive 0 0)
+  (zero_succ : ∀ n, motive 0 (n+1))
+  (succ_zero : ∀ m, motive (m+1) 0)
+  (succ_succ : ∀ m n, motive (m+1) (n+1)) :
+    motive m n :=
+  Nat.recDiag zero_zero (fun _ _ => zero_succ _) (fun _ _ => succ_zero _)
+    (fun _ _ _ => succ_succ _ _) m n
+
+/--
 Divisibility of natural numbers. `a ∣ b` (typed as `\|`) says that
 there is some `c` such that `b = a * c`.
 -/

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -106,33 +106,28 @@ theorem lt_succ : m < succ n ↔ m ≤ n :=
 theorem lt_succ_of_lt (h : a < b) : a < succ b := le_succ_of_le h
 
 theorem succ_ne_self : ∀ n, succ n ≠ n
-  | 0,   h => absurd h (succ_ne_zero 0)
-  | n+1, h => succ_ne_self n (Nat.noConfusion h id)
+  | _+1, h => succ_ne_self _ (succ.inj h)
 
 theorem succ_pred_eq_of_pos : ∀ {n}, 0 < n → succ (pred n) = n
-  | succ _, _ => rfl
+  | _+1, _ => rfl
 
-theorem eq_zero_or_eq_succ_pred (n) : n = 0 ∨ n = succ (pred n) := by
-  cases n <;> simp
+theorem eq_zero_or_eq_succ_pred : ∀ n, n = 0 ∨ n = succ (pred n)
+  | 0 => .inl rfl
+  | _+1 => .inr rfl
 
-theorem exists_eq_succ_of_ne_zero (H : n ≠ 0) : ∃ k, n = succ k :=
-  ⟨_, (eq_zero_or_eq_succ_pred _).resolve_left H⟩
+theorem exists_eq_succ_of_ne_zero : ∀ {n}, n ≠ 0 → ∃ k, n = succ k
+  | _+1, _ => ⟨_, rfl⟩
 
-theorem succ_eq_one_add (n) : succ n = 1 + n := by
-  rw [Nat.succ_eq_add_one, Nat.add_comm]
+theorem succ_eq_one_add (n) : succ n = 1 + n := Nat.add_comm _ 1
 
 theorem succ_inj' : succ n = succ m ↔ n = m :=
   ⟨succ.inj, congrArg _⟩
 
 theorem pred_inj : ∀ {a b}, 0 < a → 0 < b → pred a = pred b → a = b
-| a+1, b+1, _,  _, h => by rw [show a = b from h]
-| a+1, 0,   _, hb, _ => absurd hb (Nat.lt_irrefl _)
-| 0,   b+1, ha, _, _ => absurd ha (Nat.lt_irrefl _)
-| 0,   0,   _,  _, _ => rfl
+  | _+1, _+1, _, _ => congrArg _
 
 theorem pred_lt_pred : ∀ {n m}, n ≠ 0 → n < m → pred n < pred m
-| 0,   _,   h, _ => (h rfl).elim
-| _+1, _+1, _, h => lt_of_succ_lt_succ h
+  | _+1, _+1, _, h => lt_of_succ_lt_succ h
 
 theorem succ_le_succ_iff : succ a ≤ succ b ↔ a ≤ b :=
   ⟨le_of_succ_le_succ, succ_le_succ⟩
@@ -140,10 +135,9 @@ theorem succ_le_succ_iff : succ a ≤ succ b ↔ a ≤ b :=
 theorem succ_lt_succ_iff : succ a < succ b ↔ a < b :=
   ⟨lt_of_succ_lt_succ, succ_lt_succ⟩
 
-theorem le_succ_of_pred_le : pred n ≤ m → n ≤ succ m :=
-  match n with
-  | 0 => fun _ => zero_le _
-  | _+1 => succ_le_succ
+theorem le_succ_of_pred_le : ∀ {n m}, pred n ≤ m → n ≤ succ m
+  | 0, _, _ => Nat.zero_le ..
+  | _+1, _, h => Nat.succ_le_succ h
 
 theorem le_pred_of_lt (h : m < n) : m ≤ n - 1 :=
   Nat.sub_le_sub_right h 1

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -375,6 +375,12 @@ protected theorem mul_ne_zero_iff : n * m ≠ 0 ↔ n ≠ 0 ∧ m ≠ 0 := by rw
 
 protected theorem mul_ne_zero : n ≠ 0 → m ≠ 0 → n * m ≠ 0 := (Nat.mul_ne_zero_iff.2 ⟨·,·⟩)
 
+protected theorem le_mul_of_pos_left (n) (h : 0 < m) : n ≤ n * m :=
+  Nat.le_trans (Nat.le_of_eq (Nat.mul_one _).symm) (Nat.mul_le_mul_left _ h)
+
+protected theorem le_mul_of_pos_right (m) (h : 0 < n) : m ≤ n * m :=
+  Nat.le_trans (Nat.le_of_eq (Nat.one_mul _).symm) (Nat.mul_le_mul_right _ h)
+
 protected theorem mul_le_mul_of_nonneg_left {a b c : Nat} : a ≤ b → c * a ≤ c * b :=
   Nat.mul_le_mul_left c
 
@@ -711,61 +717,49 @@ theorem lt_log2_self (h : n ≠ 0) : n < 2 ^ (n.log2 + 1) := (log2_lt h).1 (Nat.
 
 /-! ### dvd -/
 
-protected theorem dvd_refl (a : Nat) : a ∣ a := ⟨1, by simp⟩
+protected theorem dvd_refl (a : Nat) : a ∣ a := ⟨_, Nat.mul_one .. |>.symm⟩
 
-protected theorem dvd_zero (a) : a ∣ 0 := ⟨0, by simp⟩
+protected theorem dvd_zero (a) : a ∣ 0 := ⟨0, rfl⟩
 
-protected theorem dvd_mul_left (a b : Nat) : a ∣ b * a := ⟨b, Nat.mul_comm b a⟩
+protected theorem one_dvd (a) : 1 ∣ a := ⟨_, Nat.one_mul _ |>.symm⟩
 
-protected theorem dvd_mul_right (a b : Nat) : a ∣ a * b := ⟨b, rfl⟩
+protected theorem dvd_mul_left (a b : Nat) : a ∣ b * a := ⟨_, Nat.mul_comm ..⟩
 
-protected theorem dvd_trans {a b c : Nat} (h₁ : a ∣ b) (h₂ : b ∣ c) : a ∣ c :=
-  match h₁, h₂ with
-  | ⟨d, (h₃ : b = a * d)⟩, ⟨e, (h₄ : c = b * e)⟩ =>
-    ⟨d * e, show c = a * (d * e) by simp[h₃,h₄, Nat.mul_assoc]⟩
+protected theorem dvd_mul_right (a b : Nat) : a ∣ a * b := ⟨_, rfl⟩
 
-protected theorem eq_zero_of_zero_dvd (h : 0 ∣ a) : a = 0 :=
-  let ⟨c, H'⟩ := h; H'.trans c.zero_mul
+protected theorem dvd_trans : ∀ {a b c : Nat}, a ∣ b → b ∣ c → a ∣ c
+  | _, _, _, ⟨_, rfl⟩, ⟨_, rfl⟩ => ⟨_, Nat.mul_assoc ..⟩
 
-protected theorem dvd_add {a b c : Nat} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
-  let ⟨d, hd⟩ := h₁; let ⟨e, he⟩ := h₂; ⟨d + e, by simp [Nat.left_distrib, hd, he]⟩
+protected theorem eq_zero_of_zero_dvd : ∀ {a}, 0 ∣ a → a = 0
+  | _, ⟨_, rfl⟩ => Nat.zero_mul ..
 
-protected theorem dvd_add_iff_right {k m n : Nat} (h : k ∣ m) : k ∣ n ↔ k ∣ m + n :=
-  ⟨Nat.dvd_add h,
-    match m, h with
-    | _, ⟨d, rfl⟩ => fun ⟨e, he⟩ =>
-      ⟨e - d, by rw [Nat.mul_sub_left_distrib, ← he, Nat.add_sub_cancel_left]⟩⟩
+protected theorem dvd_add : ∀ {a b c : Nat}, a ∣ b → a ∣ c → a ∣ b + c
+  | _, _, _, ⟨_, rfl⟩, ⟨_, rfl⟩ => ⟨_, Nat.mul_add .. |>.symm⟩
 
-protected theorem dvd_add_iff_left {k m n : Nat} (h : k ∣ n) : k ∣ m ↔ k ∣ m + n := by
-  rw [Nat.add_comm]; exact Nat.dvd_add_iff_right h
+protected theorem dvd_sub : ∀ {a b c : Nat}, a ∣ b → a ∣ c → a ∣ b - c
+  | _, _, _, ⟨_, rfl⟩, ⟨_, rfl⟩ => ⟨_, Nat.mul_sub_left_distrib .. |>.symm⟩
 
-theorem dvd_sub {k m n : Nat} (H : n ≤ m) (h₁ : k ∣ m) (h₂ : k ∣ n) : k ∣ m - n :=
-  (Nat.dvd_add_iff_left h₂).2 <| by rwa [Nat.sub_add_cancel H]
+protected theorem dvd_add_iff_left {k m n : Nat} (h : k ∣ n) : k ∣ m ↔ k ∣ m + n :=
+  ⟨fun h' => Nat.dvd_add h' h, fun h' => Nat.add_sub_cancel m n ▸ Nat.dvd_sub h' h⟩
 
-protected theorem mul_dvd_mul {a b c d : Nat} : a ∣ b → c ∣ d → a * c ∣ b * d
-  | ⟨e, he⟩, ⟨f, hf⟩ =>
-    ⟨e * f, by simp [he, hf, Nat.mul_assoc, Nat.mul_left_comm, Nat.mul_comm]⟩
+protected theorem dvd_add_iff_right {k m n : Nat} (h : k ∣ m) : k ∣ n ↔ k ∣ m + n := by
+  rw [Nat.add_comm]; exact Nat.dvd_add_iff_left h
+
+protected theorem mul_dvd_mul : ∀ {a b c d : Nat}, a ∣ b → c ∣ d → a * c ∣ b * d
+  | _, _, _, _, ⟨_, rfl⟩, ⟨_, rfl⟩ => ⟨_, Nat.mul_mul_mul_comm ..⟩
 
 protected theorem mul_dvd_mul_left (a : Nat) (h : b ∣ c) : a * b ∣ a * c :=
-  Nat.mul_dvd_mul (Nat.dvd_refl a) h
+  Nat.mul_dvd_mul (Nat.dvd_refl _) h
 
 protected theorem mul_dvd_mul_right (h: a ∣ b) (c : Nat) : a * c ∣ b * c :=
-  Nat.mul_dvd_mul h (Nat.dvd_refl c)
+  Nat.mul_dvd_mul h (Nat.dvd_refl _)
 
 theorem dvd_mod_iff {k m n : Nat} (h: k ∣ n) : k ∣ m % n ↔ k ∣ m :=
   have := Nat.dvd_add_iff_left <| Nat.dvd_trans h <| Nat.dvd_mul_right n (m / n)
   by rwa [mod_add_div] at this
 
-theorem le_of_dvd (h : 0 < n) : m ∣ n → m ≤ n
-  | ⟨k, e⟩ => by
-    revert h
-    rw [e]
-    match k with
-    | 0 => intro hn; simp at hn
-    | pk+1 =>
-      intro
-      have := Nat.mul_le_mul_left m (succ_pos pk)
-      rwa [Nat.mul_one] at this
+theorem le_of_dvd : ∀ {n m}, 0 < n → m ∣ n → m ≤ n
+  | _, _, _, ⟨_+1, rfl⟩ => Nat.le_mul_of_pos_left _ (Nat.succ_pos _)
 
 protected theorem dvd_antisymm : ∀ {m n : Nat}, m ∣ n → n ∣ m → m = n
   | _, 0, _, h₂ => Nat.eq_zero_of_zero_dvd h₂
@@ -776,15 +770,13 @@ theorem pos_of_dvd_of_pos (H1 : m ∣ n) (H2 : 0 < n) : 0 < m :=
   Nat.pos_of_ne_zero fun m0 => Nat.ne_of_gt H2 <| Nat.eq_zero_of_zero_dvd (m0 ▸ H1)
 
 theorem eq_one_of_dvd_one (H : n ∣ 1) : n = 1 :=
-  Nat.le_antisymm (le_of_dvd (by decide) H) (pos_of_dvd_of_pos H (by decide))
+  Nat.dvd_antisymm H (Nat.one_dvd _)
 
-theorem dvd_of_mod_eq_zero (H : n % m = 0) : m ∣ n := by
-  exists n / m
-  have := (mod_add_div n m).symm
-  rwa [H, Nat.zero_add] at this
+theorem dvd_of_mod_eq_zero (H : n % m = 0) : m ∣ n :=
+  ⟨n / m, (mod_add_div n m).symm.trans (H ▸ Nat.zero_add ..)⟩
 
-theorem mod_eq_zero_of_dvd (H : m ∣ n) : n % m = 0 := by
-  let ⟨z, H⟩ := H; rw [H, mul_mod_right]
+theorem mod_eq_zero_of_dvd : ∀ {n}, m ∣ n → n % m = 0
+  | _, ⟨_, rfl⟩ => Nat.mul_mod_right ..
 
 theorem dvd_iff_mod_eq_zero (m n) : m ∣ n ↔ n % m = 0 :=
   ⟨mod_eq_zero_of_dvd, dvd_of_mod_eq_zero⟩
@@ -792,28 +784,23 @@ theorem dvd_iff_mod_eq_zero (m n) : m ∣ n ↔ n % m = 0 :=
 instance decidable_dvd : @DecidableRel Nat (·∣·) :=
   fun _ _ => decidable_of_decidable_of_iff (dvd_iff_mod_eq_zero _ _).symm
 
-protected theorem mul_div_cancel' {n m : Nat} (H : n ∣ m) : n * (m / n) = m := by
-  have := mod_add_div m n
-  rwa [mod_eq_zero_of_dvd H, Nat.zero_add] at this
+protected theorem mul_div_cancel' : ∀ {n m : Nat}, n ∣ m →  n * (m / n) = m
+  | 0, _, h => by rw [Nat.zero_mul, Nat.eq_zero_of_zero_dvd h]
+  | _+1, _, ⟨_, rfl⟩ => by rw [Nat.mul_div_right]; exact Nat.succ_pos ..
 
 protected theorem div_mul_cancel {n m : Nat} (H : n ∣ m) : m / n * n = m := by
   rw [Nat.mul_comm, Nat.mul_div_cancel' H]
 
-protected theorem mul_div_assoc (m : Nat) (H : k ∣ n) : m * n / k = m * (n / k) := by
-  match Nat.eq_zero_or_pos k with
-  | .inl h0 => rw [h0, Nat.div_zero, Nat.div_zero, Nat.mul_zero]
-  | .inr hpos =>
-    have h1 : m * n / k = m * (n / k * k) / k := by rw [Nat.div_mul_cancel H]
-    rw [h1, ← Nat.mul_assoc, Nat.mul_div_cancel _ hpos]
+protected theorem mul_div_assoc (m : Nat) : ∀ {k n}, k ∣ n → m * n / k = m * (n / k)
+  | 0, _, _ => by rw [Nat.div_zero, Nat.div_zero]; rfl
+  | _+1, _, ⟨_, rfl⟩ => by
+    rw [Nat.mul_left_comm, Nat.mul_div_right, Nat.mul_div_right] <;> exact Nat.succ_pos ..
 
-protected theorem dvd_of_mul_dvd_mul_left
-    (kpos : 0 < k) (H : k * m ∣ k * n) : m ∣ n := by
-  let ⟨l, H⟩ := H
-  rw [Nat.mul_assoc] at H
-  exact ⟨_, Nat.eq_of_mul_eq_mul_left kpos H⟩
+protected theorem dvd_of_mul_dvd_mul_left (kpos : 0 < k) : k * m ∣ k * n → m ∣ n
+  | ⟨_, h⟩ => ⟨_, Nat.eq_of_mul_eq_mul_left kpos (Nat.mul_assoc .. ▸ h)⟩
 
-protected theorem dvd_of_mul_dvd_mul_right (kpos : 0 < k) (H : m * k ∣ n * k) : m ∣ n := by
-  rw [Nat.mul_comm m k, Nat.mul_comm n k] at H; exact Nat.dvd_of_mul_dvd_mul_left kpos H
+protected theorem dvd_of_mul_dvd_mul_right : 0 < k → m * k ∣ n * k → m ∣ n := by
+  rw [Nat.mul_comm m, Nat.mul_comm n]; exact Nat.dvd_of_mul_dvd_mul_left
 
 /-! ### sum -/
 

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -273,10 +273,10 @@ protected theorem add_left_cancel_iff {n m k : Nat} : n + m = n + k ↔ m = k :=
 protected theorem add_right_cancel_iff {n m k : Nat} : n + m = k + m ↔ n = k :=
   ⟨Nat.add_right_cancel, fun | rfl => rfl⟩
 
-protected theorem add_le_add_iff_left (k n m : Nat) : k + n ≤ k + m ↔ n ≤ m :=
+protected theorem add_le_add_iff_left {k n m : Nat} : k + n ≤ k + m ↔ n ≤ m :=
   ⟨Nat.le_of_add_le_add_left, fun h => Nat.add_le_add_left h _⟩
 
-protected theorem add_le_add_iff_right (k n m : Nat) : n + k ≤ m + k ↔ n ≤ m :=
+protected theorem add_le_add_iff_right {k n m : Nat} : n + k ≤ m + k ↔ n ≤ m :=
   ⟨Nat.le_of_add_le_add_right, fun h => Nat.add_le_add_right h _⟩
 
 protected theorem lt_of_add_lt_add_right : ∀ {m : Nat}, k + m < n + m → k < n
@@ -287,10 +287,10 @@ protected theorem lt_of_add_lt_add_left {k n m : Nat} : k + n < k + m → n < m 
   repeat rw [Nat.add_comm k]
   exact Nat.lt_of_add_lt_add_right
 
-protected theorem add_lt_add_iff_left (k n m : Nat) : k + n < k + m ↔ n < m :=
+protected theorem add_lt_add_iff_left {k n m : Nat} : k + n < k + m ↔ n < m :=
   ⟨Nat.lt_of_add_lt_add_left, fun h => Nat.add_lt_add_left h _⟩
 
-protected theorem add_lt_add_iff_right (k n m : Nat) : n + k < m + k ↔ n < m :=
+protected theorem add_lt_add_iff_right {k n m : Nat} : n + k < m + k ↔ n < m :=
   ⟨Nat.lt_of_add_lt_add_right, fun h => Nat.add_lt_add_right h _⟩
 
 protected theorem lt_add_right (k : Nat) (h : n < m) : n < m + k :=
@@ -1024,11 +1024,11 @@ theorem dvd_of_mod_eq_zero (H : n % m = 0) : m ∣ n :=
 theorem mod_eq_zero_of_dvd : ∀ {n}, m ∣ n → n % m = 0
   | _, ⟨_, rfl⟩ => Nat.mul_mod_right ..
 
-theorem dvd_iff_mod_eq_zero (m n) : m ∣ n ↔ n % m = 0 :=
+theorem dvd_iff_mod_eq_zero {m n} : m ∣ n ↔ n % m = 0 :=
   ⟨mod_eq_zero_of_dvd, dvd_of_mod_eq_zero⟩
 
 instance decidable_dvd : @DecidableRel Nat (·∣·) :=
-  fun _ _ => decidable_of_decidable_of_iff (dvd_iff_mod_eq_zero _ _).symm
+  fun _ _ => decidable_of_decidable_of_iff dvd_iff_mod_eq_zero.symm
 
 protected theorem mul_div_cancel' : ∀ {n m : Nat}, n ∣ m →  n * (m / n) = m
   | 0, _, h => by rw [Nat.zero_mul, Nat.eq_zero_of_zero_dvd h]

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -178,12 +178,12 @@ protected theorem le_antisymm_iff {n m : Nat} : n = m ↔ n ≤ m ∧ m ≤ n :=
 protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=
   ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
 
-theorem le_zero : i ≤ 0 ↔ i = 0 :=
+protected theorem le_zero : i ≤ 0 ↔ i = 0 :=
   ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
 
-theorem one_pos : 0 < 1 := Nat.zero_lt_one
+protected theorem one_pos : 0 < 1 := Nat.zero_lt_one
 
-theorem two_pos : 0 < 2 := Nat.zero_lt_succ _
+protected theorem two_pos : 0 < 2 := Nat.zero_lt_succ _
 
 theorem add_one_ne_zero (n) : n + 1 ≠ 0 := succ_ne_zero _
 
@@ -945,14 +945,14 @@ theorem le_log2 (h : n ≠ 0) : ∀ {k}, k ≤ n.log2 ↔ 2 ^ k ≤ n
   | k+1 => by
     unfold log2; split
     next h =>
-      have h : 0 < n / 2 := (Nat.le_div_iff_mul_le two_pos).2 h
-      rw [Nat.add_le_add_iff_right, le_log2 (Nat.ne_of_gt h), le_div_iff_mul_le two_pos, Nat.pow_succ]
+      have h : 0 < n / 2 := (Nat.le_div_iff_mul_le Nat.two_pos).2 h
+      rw [Nat.add_le_add_iff_right, le_log2 (Nat.ne_of_gt h), le_div_iff_mul_le Nat.two_pos, Nat.pow_succ]
     next h =>
       have h : n < 2 := Nat.lt_of_not_le h
       simp only [le_zero_eq, false_iff, Nat.succ_ne_zero, Nat.not_le]
       apply Nat.lt_of_lt_of_le h
       apply Nat.le_mul_of_pos_right
-      exact Nat.pos_pow_of_pos _ two_pos
+      exact Nat.pos_pow_of_pos _ Nat.two_pos
 
 theorem log2_lt (h : n ≠ 0) : n.log2 < k ↔ n < 2 ^ k := by
   rw [← Nat.not_le, ← Nat.not_le, le_log2 h]

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -10,6 +10,101 @@ import Std.Data.Nat.Basic
 
 namespace Nat
 
+/-! ### rec/cases -/
+
+section recAux
+variable {motive : Nat → Sort _} (zero : motive 0) (succ : ∀ n, motive n → motive (n+1))
+
+@[simp] theorem recAux_zero : Nat.recAux zero succ 0 = zero := rfl
+
+theorem recAux_succ (n) : Nat.recAux zero succ (n+1) = succ n (Nat.recAux zero succ n) := rfl
+
+@[simp] theorem recAuxOn_zero : Nat.recAuxOn 0 zero succ = zero := rfl
+
+theorem recAuxOn_succ (n) : Nat.recAuxOn (n+1) zero succ = succ n (Nat.recAuxOn n zero succ) := rfl
+
+variable (succ : ∀ n, motive (n+1))
+
+@[simp] theorem casesAuxOn_zero : Nat.casesAuxOn 0 zero succ = zero := rfl
+
+@[simp] theorem casesAuxOn_succ (n) : Nat.casesAuxOn (n+1) zero succ = succ n := rfl
+
+end recAux
+
+section recDiagAux
+variable {motive : Nat → Nat → Sort _}
+  (zero_left : ∀ n, motive 0 n) (zero_right : ∀ m, motive m 0)
+  (succ_succ : ∀ m n, motive m n → motive (m+1) (n+1))
+
+@[simp] theorem recDiagAux_zero_left (n) :
+  Nat.recDiagAux zero_left zero_right succ_succ 0 n = zero_left n := by cases n <;> rfl
+
+@[simp] theorem recDiagAux_zero_right (m)
+  (h : zero_left 0 = zero_right 0 := by first | assumption | trivial) :
+  Nat.recDiagAux zero_left zero_right succ_succ m 0 = zero_right m := by cases m; exact h; rfl
+
+theorem recDiagAux_succ_succ (m n) :
+  Nat.recDiagAux zero_left zero_right succ_succ (m+1) (n+1)
+    = succ_succ m n (Nat.recDiagAux zero_left zero_right succ_succ m n) := rfl
+
+end recDiagAux
+
+section recDiag
+variable {motive : Nat → Nat → Sort _} (zero_zero : motive 0 0)
+  (zero_succ : ∀ n, motive 0 n → motive 0 (n+1)) (succ_zero : ∀ m, motive m 0 → motive (m+1) 0)
+  (succ_succ : ∀ m n, motive m n → motive (m+1) (n+1))
+
+@[simp] theorem recDiag_zero_zero :
+  Nat.recDiag (motive:=motive) zero_zero zero_succ succ_zero succ_succ 0 0 = zero_zero := rfl
+
+theorem recDiag_zero_succ (n) :
+  Nat.recDiag zero_zero zero_succ succ_zero succ_succ 0 (n+1)
+    = zero_succ n (Nat.recDiag zero_zero zero_succ succ_zero succ_succ 0 n) := by
+  simp [Nat.recDiag]; rfl
+
+theorem recDiag_succ_zero (m) :
+  Nat.recDiag zero_zero zero_succ succ_zero succ_succ (m+1) 0
+    = succ_zero m (Nat.recDiag zero_zero zero_succ succ_zero succ_succ m 0) := by
+  simp [Nat.recDiag]; cases m <;> rfl
+
+theorem recDiag_succ_succ (m n) :
+  Nat.recDiag zero_zero zero_succ succ_zero succ_succ (m+1) (n+1)
+    = succ_succ m n (Nat.recDiag zero_zero zero_succ succ_zero succ_succ m n) := rfl
+
+@[simp] theorem recDiagOn_zero_zero :
+  Nat.recDiagOn 0 0 (motive:=motive) zero_zero zero_succ succ_zero succ_succ = zero_zero := rfl
+
+theorem recDiagOn_zero_succ (n) :
+  Nat.recDiagOn 0 (n+1) zero_zero zero_succ succ_zero succ_succ
+    = zero_succ n (Nat.recDiagOn 0 n zero_zero zero_succ succ_zero succ_succ) :=
+  Nat.recDiag_zero_succ ..
+
+theorem recDiagOn_succ_zero (m) :
+  Nat.recDiagOn (m+1) 0 zero_zero zero_succ succ_zero succ_succ
+    = succ_zero m (Nat.recDiagOn m 0 zero_zero zero_succ succ_zero succ_succ) :=
+  Nat.recDiag_succ_zero ..
+
+theorem recDiagOn_succ_succ (m n) :
+  Nat.recDiagOn (m+1) (n+1) zero_zero zero_succ succ_zero succ_succ
+    = succ_succ m n (Nat.recDiagOn m n zero_zero zero_succ succ_zero succ_succ) := rfl
+
+variable (zero_succ : ∀ n, motive 0 (n+1)) (succ_zero : ∀ m, motive (m+1) 0)
+  (succ_succ : ∀ m n, motive (m+1) (n+1))
+
+@[simp] theorem casesDiagOn_zero_zero :
+  Nat.casesDiagOn 0 0 (motive:=motive) zero_zero zero_succ succ_zero succ_succ = zero_zero := rfl
+
+@[simp] theorem casesDiagOn_zero_succ (n) :
+  Nat.casesDiagOn 0 (n+1) zero_zero zero_succ succ_zero succ_succ = zero_succ n := rfl
+
+@[simp] theorem casesDiagOn_succ_zero (m) :
+  Nat.casesDiagOn (m+1) 0 zero_zero zero_succ succ_zero succ_succ = succ_zero m := rfl
+
+@[simp] theorem casesDiagOn_succ_succ (m n) :
+  Nat.casesDiagOn (m+1) (n+1) zero_zero zero_succ succ_zero succ_succ = succ_succ m n := rfl
+
+end recDiag
+
 /-! ### le/lt -/
 
 theorem ne_of_gt {a b : Nat} (h : b < a) : a ≠ b := (ne_of_lt h).symm

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -636,32 +636,32 @@ theorem add_mod (a b n : Nat) : (a + b) % n = ((a % n) + (b % n)) % n := by
 
 /-! ### pow -/
 
+attribute [simp] Nat.pow_zero
+
 theorem pow_succ' {m : Nat} : m ^ n.succ = m * m ^ n := by
   rw [Nat.pow_succ, Nat.mul_comm]
 
 @[simp] theorem pow_eq : Nat.pow m n = m ^ n := rfl
 
-@[simp] theorem shiftLeft_eq (a b : Nat) : a <<< b = a * 2 ^ b :=
-  match b with
-  | 0 => (Nat.mul_one _).symm
-  | b+1 => (shiftLeft_eq _ b).trans <| by
-    simp [pow_succ, Nat.mul_assoc, Nat.mul_left_comm, Nat.mul_comm]
+theorem shiftLeft_eq' (a b : Nat) : a <<< b = 2 ^ b * a := by
+  induction b generalizing a with
+  | zero => rw [Nat.pow_zero, Nat.one_mul]; rfl
+  | succ _ ih => rw [Nat.pow_succ, Nat.mul_assoc, ←ih]; rfl
+
+@[simp] theorem shiftLeft_eq (a b : Nat) : a <<< b = a * 2 ^ b := by
+  rw [Nat.mul_comm, Nat.shiftLeft_eq']
 
 theorem one_shiftLeft (n) : 1 <<< n = 2 ^ n := by rw [shiftLeft_eq, Nat.one_mul]
 
-attribute [simp] Nat.pow_zero
+protected theorem zero_pow : ∀ n, 0 < n → 0 ^ n = 0
+  | _+1, _ => rfl
 
-protected theorem zero_pow (H : 0 < n) : 0 ^ n = 0 := by
-  match n with
-  | 0 => contradiction
-  | n+1 => rw [Nat.pow_succ, Nat.mul_zero]
+@[simp] protected theorem one_pow : ∀ (n : Nat), 1 ^ n = 1
+  | 0 => rfl
+  | _+1 => by rw [Nat.pow_succ, Nat.mul_one]; exact Nat.one_pow ..
 
-@[simp] protected theorem one_pow (n : Nat) : 1 ^ n = 1 := by
-  induction n with
-  | zero => rfl
-  | succ _ ih => rw [Nat.pow_succ, Nat.mul_one, ih]
-
-@[simp] protected theorem pow_one (a : Nat) : a ^ 1 = a := by rw [Nat.pow_succ, Nat.pow_zero, Nat.one_mul]
+@[simp] protected theorem pow_one (a : Nat) : a ^ 1 = a := by
+  rw [Nat.pow_succ, Nat.pow_zero, Nat.one_mul]
 
 protected theorem pow_two (a : Nat) : a ^ 2 = a * a := by rw [Nat.pow_succ, Nat.pow_one]
 
@@ -670,16 +670,19 @@ protected theorem pow_add (a m n : Nat) : a ^ (m + n) = a ^ m * a ^ n := by
   | zero => rw [Nat.add_zero, Nat.pow_zero, Nat.mul_one]
   | succ _ ih => rw [Nat.add_succ, Nat.pow_succ, Nat.pow_succ, ih, Nat.mul_assoc]
 
-protected theorem pow_add' (a m n : Nat) : a ^ (m + n) = a ^ n * a ^ m := by rw [←Nat.pow_add, Nat.add_comm]
+protected theorem pow_add' (a m n : Nat) : a ^ (m + n) = a ^ n * a ^ m := by
+  rw [←Nat.pow_add, Nat.add_comm]
 
 protected theorem pow_mul (a m n : Nat) : a ^ (m * n) = (a ^ m) ^ n := by
   induction n with
   | zero => rw [Nat.mul_zero, Nat.pow_zero, Nat.pow_zero]
   | succ _ ih => rw [Nat.mul_succ, Nat.pow_add, Nat.pow_succ, ih]
 
-protected theorem pow_mul' (a m n : Nat) : a ^ (m * n) = (a ^ n) ^ m := by rw [←Nat.pow_mul, Nat.mul_comm]
+protected theorem pow_mul' (a m n : Nat) : a ^ (m * n) = (a ^ n) ^ m := by
+  rw [←Nat.pow_mul, Nat.mul_comm]
 
-protected theorem pow_right_comm (a m n : Nat) : (a ^ m) ^ n = (a ^ n) ^ m := by rw [←Nat.pow_mul, Nat.pow_mul']
+protected theorem pow_right_comm (a m n : Nat) : (a ^ m) ^ n = (a ^ n) ^ m := by
+  rw [←Nat.pow_mul, Nat.pow_mul']
 
 protected theorem mul_pow (a b n : Nat) : (a * b) ^ n = a ^ n * b ^ n := by
   induction n with

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -333,23 +333,21 @@ protected theorem max_le {a b c : Nat} : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :
   ⟨fun h => ⟨Nat.le_trans (Nat.le_max_left ..) h, Nat.le_trans (Nat.le_max_right ..) h⟩,
    fun ⟨h₁, h₂⟩ => by rw [Nat.max_def]; split <;> assumption⟩
 
-protected theorem max_eq_right {a b : Nat} (h : a ≤ b) : max a b = b := by
-  simp [Nat.max_def, h, Nat.not_lt.2 h]
+protected theorem max_eq_right {a b : Nat} (h : a ≤ b) : max a b = b := if_pos h
 
 protected theorem max_eq_left {a b : Nat} (h : b ≤ a) : max a b = a := by
-  rw [← Nat.max_comm b a]; exact Nat.max_eq_right h
+  rw [Nat.max_comm]; exact Nat.max_eq_right h
 
--- Distribute succ over min
 theorem min_succ_succ (x y) : min (succ x) (succ y) = succ (min x y) := by
   simp [Nat.min_def, succ_le_succ_iff]; split <;> rfl
 
 theorem sub_eq_sub_min (n m : Nat) : n - m = n - min n m := by
   rw [Nat.min_def]; split
-  · rw [Nat.sub_eq_zero_of_le ‹n ≤ m›, Nat.sub_self]
-  · rfl
+  next h => rw [Nat.sub_eq_zero_of_le h, Nat.sub_self]
+  next => rfl
 
 @[simp] protected theorem sub_add_min_cancel (n m : Nat) : n - m + min n m = n := by
-  rw [sub_eq_sub_min, Nat.sub_add_cancel (Nat.min_le_left n m)]
+  rw [sub_eq_sub_min, Nat.sub_add_cancel (Nat.min_le_left ..)]
 
 protected theorem sub_add_eq_max {a b : Nat} : a - b + b = max a b := by
   match a.le_total b with

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -78,7 +78,7 @@ protected theorem le_iff_lt_or_eq {n m : Nat} : n ≤ m ↔ n < m ∨ n = m :=
 protected theorem le_antisymm_iff {n m : Nat} : n = m ↔ n ≤ m ∧ m ≤ n :=
   ⟨fun h => ⟨Nat.le_of_eq h, Nat.le_of_eq h.symm⟩, fun ⟨h₁, h₂⟩ => Nat.le_antisymm h₁ h₂⟩
 
-/-! ### zero/one -/
+/-! ### zero/one/two -/
 
 protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=
   ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
@@ -87,6 +87,8 @@ theorem le_zero : i ≤ 0 ↔ i = 0 :=
   ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
 
 theorem one_pos : 0 < 1 := Nat.zero_lt_one
+
+theorem two_pos : 0 < 2 := Nat.zero_lt_succ _
 
 theorem add_one_ne_zero (n) : n + 1 ≠ 0 := succ_ne_zero _
 
@@ -150,10 +152,9 @@ protected theorem eq_zero_of_add_eq_zero_right : ∀ {n m}, n + m = 0 → n = 0
 protected theorem eq_zero_of_add_eq_zero_left : ∀ {n m}, n + m = 0 → m = 0
   | _, 0, _ => rfl
 
-theorem succ_add_eq_succ_add (n m) : succ n + m = n + succ m := by
-  simp [succ_add, add_succ]
+theorem succ_add_eq_succ_add (n m) : succ n + m = n + succ m := Nat.succ_add ..
 
-theorem one_add (n) : 1 + n = succ n := by simp [Nat.add_comm]
+theorem one_add (n) : 1 + n = succ n := Nat.add_comm ..
 
 theorem eq_zero_of_add_eq_zero (H : n + m = 0) : n = 0 ∧ m = 0 :=
   ⟨Nat.eq_zero_of_add_eq_zero_right H, Nat.eq_zero_of_add_eq_zero_left H⟩
@@ -231,12 +232,6 @@ protected theorem le_of_le_of_sub_le_sub_right : ∀ {n m k : Nat}, k ≤ m → 
 protected theorem sub_le_sub_iff_right {n m k : Nat} (h : k ≤ m) : n - k ≤ m - k ↔ n ≤ m :=
   ⟨Nat.le_of_le_of_sub_le_sub_right h, fun h => Nat.sub_le_sub_right h _⟩
 
-protected theorem add_le_to_le_sub (n : Nat) (h : m ≤ k) : n + m ≤ k ↔ n ≤ k - m := by
-  rw [← Nat.add_sub_cancel n, Nat.sub_le_sub_iff_right h, Nat.add_sub_cancel]
-
-protected theorem sub_lt_of_pos_le (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
-  Nat.sub_lt (Nat.lt_of_lt_of_le h₀ h₁) h₀
-
 protected theorem sub_one (n) : n - 1 = pred n := rfl
 
 theorem succ_sub_one (n) : succ n - 1 = n := rfl
@@ -293,7 +288,7 @@ theorem le_sub_iff_add_le {x y k : Nat} (h : k ≤ y) : x ≤ y - k ↔ x + k �
   rw [← Nat.add_sub_cancel x k, Nat.sub_le_sub_iff_right h, Nat.add_sub_cancel]
 
 protected theorem sub_le_iff_le_add {a b c : Nat} : a - b ≤ c ↔ a ≤ c + b :=
-  ⟨Nat.le_add_of_sub_le, sub_le_of_le_add⟩
+  ⟨le_add_of_sub_le, sub_le_of_le_add⟩
 
 protected theorem sub_le_iff_le_add' {a b c : Nat} : a - b ≤ c ↔ a ≤ b + c := by
   rw [Nat.sub_le_iff_le_add, Nat.add_comm]
@@ -312,6 +307,12 @@ protected theorem sub_add_lt_sub (h₁ : m + k ≤ n) (h₂ : 0 < k) : n - (m + 
       (pred_lt (Nat.ne_of_lt $ Nat.sub_pos_of_lt $ lt_of_succ_le h₁).symm)
       (Nat.sub_le_sub_left _ $ Nat.le_add_right ..)
 
+protected theorem sub_lt_of_pos_le (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
+  Nat.sub_lt_self h₀ h₁
+
+protected theorem add_le_to_le_sub (n : Nat) (h : m ≤ k) : n + m ≤ k ↔ n ≤ k - m :=
+  (Nat.le_sub_iff_add_le h).symm
+
 /-! ## min/max -/
 
 protected theorem le_min {a b c : Nat} : a ≤ min b c ↔ a ≤ b ∧ a ≤ c :=
@@ -320,10 +321,10 @@ protected theorem le_min {a b c : Nat} : a ≤ min b c ↔ a ≤ b ∧ a ≤ c :
 
 protected theorem lt_min {a b c : Nat} : a < min b c ↔ a < b ∧ a < c := Nat.le_min
 
-protected theorem min_eq_left {a b : Nat} (h : a ≤ b) : min a b = a := by simp [Nat.min_def, h]
+protected theorem min_eq_left {a b : Nat} (h : a ≤ b) : min a b = a := if_pos h
 
 protected theorem min_eq_right {a b : Nat} (h : b ≤ a) : min a b = b := by
-  rw [Nat.min_comm a b]; exact Nat.min_eq_left h
+  rw [Nat.min_comm]; exact Nat.min_eq_left h
 
 protected theorem zero_min (a) : min 0 a = 0 := Nat.min_eq_left (zero_le a)
 
@@ -697,16 +698,19 @@ protected theorem mul_pow (a b n : Nat) : (a * b) ^ n = a ^ n * b ^ n := by
 
 /-! ### log2 -/
 
-theorem le_log2 (h : n ≠ 0) : k ≤ n.log2 ↔ 2 ^ k ≤ n := by
-  match k with
-  | 0 => simp [show 1 ≤ n from Nat.pos_of_ne_zero h]
-  | k+1 =>
-    rw [log2]; split
-    · have n0 : 0 < n / 2 := (Nat.le_div_iff_mul_le (by decide)).2 ‹_›
-      simp [Nat.add_le_add_iff_right, le_log2 (Nat.ne_of_gt n0), le_div_iff_mul_le, Nat.pow_succ]
-    · simp only [le_zero_eq, succ_ne_zero, false_iff]
-      refine mt (Nat.le_trans ?_) ‹_›
-      exact Nat.pow_le_pow_of_le_right (Nat.succ_pos 1) (Nat.le_add_left 1 k)
+theorem le_log2 (h : n ≠ 0) : ∀ {k}, k ≤ n.log2 ↔ 2 ^ k ≤ n
+  | 0 => ⟨fun _ => Nat.zero_lt_of_ne_zero h, fun _ => Nat.zero_le _⟩
+  | k+1 => by
+    unfold log2; split
+    next h =>
+      have h : 0 < n / 2 := (Nat.le_div_iff_mul_le two_pos).2 h
+      rw [Nat.add_le_add_iff_right, le_log2 (Nat.ne_of_gt h), le_div_iff_mul_le two_pos, Nat.pow_succ]
+    next h =>
+      have h : n < 2 := Nat.lt_of_not_le h
+      simp only [le_zero_eq, false_iff, Nat.succ_ne_zero, Nat.not_le]
+      apply Nat.lt_of_lt_of_le h
+      apply Nat.le_mul_of_pos_right
+      exact Nat.pos_pow_of_pos _ two_pos
 
 theorem log2_lt (h : n ≠ 0) : n.log2 < k ↔ n < 2 ^ k := by
   rw [← Nat.not_le, ← Nat.not_le, le_log2 h]

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -223,6 +223,9 @@ theorem succ_inj' : succ n = succ m ↔ n = m :=
 theorem pred_inj : ∀ {a b}, 0 < a → 0 < b → pred a = pred b → a = b
   | _+1, _+1, _, _ => congrArg _
 
+theorem pred_inj' (hn : 0 < n) (hm : 0 < m) : pred n = pred m ↔ n = m :=
+  ⟨pred_inj hn hm, congrArg _⟩
+
 theorem pred_lt_pred : ∀ {n m}, n ≠ 0 → n < m → pred n < pred m
   | _+1, _+1, _, h => lt_of_succ_lt_succ h
 
@@ -236,20 +239,30 @@ theorem le_succ_of_pred_le : ∀ {n m}, pred n ≤ m → n ≤ succ m
   | 0, _, _ => Nat.zero_le ..
   | _+1, _, h => Nat.succ_le_succ h
 
+theorem pred_le_of_le_succ : ∀ {n m}, n ≤ succ m → pred n ≤ m
+  | 0, _, _ => Nat.zero_le _
+  | _+1, _, h => Nat.le_of_succ_le_succ h
+
+theorem pred_le_iff_le_succ : pred n ≤ m ↔ n ≤ succ m :=
+  ⟨le_succ_of_pred_le, pred_le_of_le_succ⟩
+
 theorem le_pred_of_lt (h : m < n) : m ≤ n - 1 :=
   Nat.sub_le_sub_right h 1
 
 /-! ### add -/
+
+protected theorem add_add_add_comm (a b c d : Nat) : (a + b) + (c + d) = (a + c) + (b + d) := by
+  rw [Nat.add_assoc, Nat.add_assoc, Nat.add_left_comm b]
+
+theorem succ_add_eq_add_succ (n m) : succ n + m = n + succ m := Nat.succ_add ..
+
+theorem one_add (n) : 1 + n = succ n := Nat.add_comm ..
 
 protected theorem eq_zero_of_add_eq_zero_right : ∀ {n m}, n + m = 0 → n = 0
   | _, 0, h => h
 
 protected theorem eq_zero_of_add_eq_zero_left : ∀ {n m}, n + m = 0 → m = 0
   | _, 0, _ => rfl
-
-theorem succ_add_eq_succ_add (n m) : succ n + m = n + succ m := Nat.succ_add ..
-
-theorem one_add (n) : 1 + n = succ n := Nat.add_comm ..
 
 theorem eq_zero_of_add_eq_zero (H : n + m = 0) : n = 0 ∧ m = 0 :=
   ⟨Nat.eq_zero_of_add_eq_zero_right H, Nat.eq_zero_of_add_eq_zero_left H⟩
@@ -280,7 +293,7 @@ protected theorem add_lt_add_iff_left (k n m : Nat) : k + n < k + m ↔ n < m :=
 protected theorem add_lt_add_iff_right (k n m : Nat) : n + k < m + k ↔ n < m :=
   ⟨Nat.lt_of_add_lt_add_right, fun h => Nat.add_lt_add_right h _⟩
 
-protected theorem lt_add_right (a b c : Nat) (h : a < b) : a < b + c :=
+protected theorem lt_add_right (k : Nat) (h : n < m) : n < m + k :=
   Nat.lt_of_lt_of_le h (Nat.le_add_right ..)
 
 protected theorem lt_add_of_pos_right (h : 0 < k) : n < n + k :=
@@ -346,7 +359,7 @@ protected theorem lt_of_sub_eq_succ (H : m - n = succ l) : n < m :=
 
 protected theorem sub_le_sub_left (k : Nat) (h : n ≤ m) : k - m ≤ k - n :=
   match m, le.dest h with
-  | _, ⟨a, rfl⟩ => by rw [← Nat.sub_sub]; apply sub_le
+  | _, ⟨a, rfl⟩ => by rw [← Nat.sub_sub]; exact sub_le ..
 
 theorem succ_sub_sub_succ (n m k) : succ n - m - succ k = n - m - k := by
   rw [Nat.sub_sub, Nat.sub_sub, add_succ, succ_sub_succ]
@@ -404,9 +417,6 @@ protected theorem sub_add_lt_sub (h₁ : m + k ≤ n) (h₂ : 0 < k) : n - (m + 
 
 protected theorem sub_lt_of_pos_le (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
   Nat.sub_lt_self h₀ h₁
-
-protected theorem add_le_to_le_sub (n : Nat) (h : m ≤ k) : n + m ≤ k ↔ n ≤ k - m :=
-  (Nat.le_sub_iff_add_le h).symm
 
 /-! ## min/max -/
 
@@ -909,3 +919,13 @@ protected theorem dvd_of_mul_dvd_mul_right : 0 < k → m * k ∣ n * k → m ∣
 
 @[simp] theorem sum_append : Nat.sum (l₁ ++ l₂) = Nat.sum l₁ + Nat.sum l₂ := by
   induction l₁ <;> simp [*, Nat.add_assoc]
+
+/-! ### deprecated -/
+
+@[deprecated Nat.le_sub_iff_add_le]
+theorem add_le_to_le_sub (x : Nat) {y k : Nat} (h : k ≤ y) : x + k ≤ y ↔ x ≤ y - k :=
+  (Nat.le_sub_iff_add_le h).symm
+
+@[deprecated Nat.succ_add_eq_add_succ]
+theorem succ_add_eq_succ_add (n m : Nat) : succ n + m = n + succ m :=
+  Nat.succ_add_eq_add_succ ..

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -80,10 +80,11 @@ protected theorem le_antisymm_iff {n m : Nat} : n = m ↔ n ≤ m ∧ m ≤ n :=
 
 /-! ### zero/one -/
 
-protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 := ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
+protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=
+  ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
 
 theorem le_zero : i ≤ 0 ↔ i = 0 :=
-  ⟨Nat.eq_zero_of_le_zero, fun h => h ▸ Nat.le_refl i⟩
+  ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
 
 theorem one_pos : 0 < 1 := Nat.zero_lt_one
 
@@ -91,7 +92,7 @@ theorem add_one_ne_zero (n) : n + 1 ≠ 0 := succ_ne_zero _
 
 protected theorem eq_zero_of_nonpos : ∀ n, ¬0 < n → n = 0
   | 0 => fun _ => rfl
-  | n+1 => fun h => absurd (Nat.zero_lt_succ n) h
+  | _+1 => absurd (Nat.zero_lt_succ _)
 
 /-! ### succ/pred -/
 

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -10,7 +10,7 @@ import Std.Data.Nat.Basic
 
 namespace Nat
 
-/-! ## le/lt -/
+/-! ### le/lt -/
 
 theorem ne_of_gt {a b : Nat} (h : b < a) : a ≠ b := (ne_of_lt h).symm
 
@@ -80,16 +80,16 @@ protected theorem le_antisymm_iff {n m : Nat} : n = m ↔ n ≤ m ∧ m ≤ n :=
 
 /-! ### zero/one -/
 
-protected theorem pos_iff_ne_zero {n : Nat} : 0 < n ↔ n ≠ 0 := ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
+protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 := ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
 
-theorem le_zero {i : Nat} : i ≤ 0 ↔ i = 0 :=
+theorem le_zero : i ≤ 0 ↔ i = 0 :=
   ⟨Nat.eq_zero_of_le_zero, fun h => h ▸ Nat.le_refl i⟩
 
 theorem one_pos : 0 < 1 := Nat.zero_lt_one
 
-theorem add_one_ne_zero (n : Nat) : n + 1 ≠ 0 := succ_ne_zero _
+theorem add_one_ne_zero (n) : n + 1 ≠ 0 := succ_ne_zero _
 
-protected theorem eq_zero_of_nonpos : ∀ (n : Nat), ¬0 < n → n = 0
+protected theorem eq_zero_of_nonpos : ∀ n, ¬0 < n → n = 0
   | 0 => fun _ => rfl
   | n+1 => fun h => absurd (Nat.zero_lt_succ n) h
 
@@ -97,73 +97,73 @@ protected theorem eq_zero_of_nonpos : ∀ (n : Nat), ¬0 < n → n = 0
 
 attribute [simp] succ_ne_zero lt_succ_self Nat.pred_zero Nat.pred_succ
 
-theorem succ_le {n m : Nat} : succ n ≤ m ↔ n < m := .rfl
+theorem succ_le : succ n ≤ m ↔ n < m := .rfl
 
-theorem lt_succ {m n : Nat} : m < succ n ↔ m ≤ n :=
+theorem lt_succ : m < succ n ↔ m ≤ n :=
   ⟨le_of_lt_succ, lt_succ_of_le⟩
 
 theorem lt_succ_of_lt (h : a < b) : a < succ b := le_succ_of_le h
 
-theorem succ_ne_self : ∀ n : Nat, succ n ≠ n
+theorem succ_ne_self : ∀ n, succ n ≠ n
   | 0,   h => absurd h (succ_ne_zero 0)
   | n+1, h => succ_ne_self n (Nat.noConfusion h id)
 
-theorem succ_pred_eq_of_pos : ∀ {n : Nat}, 0 < n → succ (pred n) = n
+theorem succ_pred_eq_of_pos : ∀ {n}, 0 < n → succ (pred n) = n
   | succ _, _ => rfl
 
-theorem eq_zero_or_eq_succ_pred (n : Nat) : n = 0 ∨ n = succ (pred n) := by
+theorem eq_zero_or_eq_succ_pred (n) : n = 0 ∨ n = succ (pred n) := by
   cases n <;> simp
 
-theorem exists_eq_succ_of_ne_zero {n : Nat} (H : n ≠ 0) : ∃ k, n = succ k :=
+theorem exists_eq_succ_of_ne_zero (H : n ≠ 0) : ∃ k, n = succ k :=
   ⟨_, (eq_zero_or_eq_succ_pred _).resolve_left H⟩
 
-theorem succ_eq_one_add (n : Nat) : n.succ = 1 + n := by
+theorem succ_eq_one_add (n) : succ n = 1 + n := by
   rw [Nat.succ_eq_add_one, Nat.add_comm]
 
 theorem succ_inj' : succ n = succ m ↔ n = m :=
   ⟨succ.inj, congrArg _⟩
 
-theorem pred_inj : ∀ {a b : Nat}, 0 < a → 0 < b → Nat.pred a = Nat.pred b → a = b
+theorem pred_inj : ∀ {a b}, 0 < a → 0 < b → pred a = pred b → a = b
 | a+1, b+1, _,  _, h => by rw [show a = b from h]
 | a+1, 0,   _, hb, _ => absurd hb (Nat.lt_irrefl _)
 | 0,   b+1, ha, _, _ => absurd ha (Nat.lt_irrefl _)
 | 0,   0,   _,  _, _ => rfl
 
-theorem pred_lt_pred : ∀ {n m : Nat}, n ≠ 0 → n < m → pred n < pred m
+theorem pred_lt_pred : ∀ {n m}, n ≠ 0 → n < m → pred n < pred m
 | 0,   _,   h, _ => (h rfl).elim
 | _+1, _+1, _, h => lt_of_succ_lt_succ h
 
-theorem succ_le_succ_iff {a b : Nat} : succ a ≤ succ b ↔ a ≤ b :=
+theorem succ_le_succ_iff : succ a ≤ succ b ↔ a ≤ b :=
   ⟨le_of_succ_le_succ, succ_le_succ⟩
 
-theorem succ_lt_succ_iff {a b : Nat} : succ a < succ b ↔ a < b :=
+theorem succ_lt_succ_iff : succ a < succ b ↔ a < b :=
   ⟨lt_of_succ_lt_succ, succ_lt_succ⟩
 
-theorem le_succ_of_pred_le {n m : Nat} : pred n ≤ m → n ≤ succ m :=
+theorem le_succ_of_pred_le : pred n ≤ m → n ≤ succ m :=
   match n with
   | 0 => fun _ => zero_le _
   | _+1 => succ_le_succ
 
-theorem le_pred_of_lt {m n : Nat} (h : m < n) : m ≤ n - 1 :=
+theorem le_pred_of_lt (h : m < n) : m ≤ n - 1 :=
   Nat.sub_le_sub_right h 1
 
 /-! ### add -/
 
-protected theorem eq_zero_of_add_eq_zero_right : ∀ {n m : Nat}, n + m = 0 → n = 0
+protected theorem eq_zero_of_add_eq_zero_right : ∀ {n m}, n + m = 0 → n = 0
 | 0,   m => by simp [Nat.zero_add]
 | n+1, m => fun h => by
   rw [add_one, succ_add] at h
   cases succ_ne_zero _ h
 
-protected theorem eq_zero_of_add_eq_zero_left {n m : Nat} (h : n + m = 0) : m = 0 :=
+protected theorem eq_zero_of_add_eq_zero_left (h : n + m = 0) : m = 0 :=
   @Nat.eq_zero_of_add_eq_zero_right m n (Nat.add_comm n m ▸ h)
 
-theorem succ_add_eq_succ_add (n m : Nat) : succ n + m = n + succ m := by
+theorem succ_add_eq_succ_add (n m) : succ n + m = n + succ m := by
   simp [succ_add, add_succ]
 
-theorem one_add (n : Nat) : 1 + n = succ n := by simp [Nat.add_comm]
+theorem one_add (n) : 1 + n = succ n := by simp [Nat.add_comm]
 
-theorem eq_zero_of_add_eq_zero {n m : Nat} (H : n + m = 0) : n = 0 ∧ m = 0 :=
+theorem eq_zero_of_add_eq_zero (H : n + m = 0) : n = 0 ∧ m = 0 :=
   ⟨Nat.eq_zero_of_add_eq_zero_right H, Nat.eq_zero_of_add_eq_zero_left H⟩
 
 protected theorem add_left_cancel_iff {n m k : Nat} : n + m = n + k ↔ m = k :=
@@ -194,32 +194,32 @@ protected theorem add_lt_add_iff_right (k n m : Nat) : n + k < m + k ↔ n < m :
 protected theorem lt_add_right (a b c : Nat) (h : a < b) : a < b + c :=
   Nat.lt_of_lt_of_le h (Nat.le_add_right _ _)
 
-protected theorem lt_add_of_pos_right {n k : Nat} (h : 0 < k) : n < n + k :=
+protected theorem lt_add_of_pos_right (h : 0 < k) : n < n + k :=
   Nat.add_lt_add_left h n
 
-protected theorem lt_add_of_pos_left {n k : Nat} (h : 0 < k) : n < k + n := by
+protected theorem lt_add_of_pos_left (h : 0 < k) : n < k + n := by
   rw [Nat.add_comm]; exact Nat.lt_add_of_pos_right h
 
-protected theorem pos_of_lt_add_right {n k : Nat} (h : n < n + k) : 0 < k :=
+protected theorem pos_of_lt_add_right (h : n < n + k) : 0 < k :=
   Nat.lt_of_add_lt_add_left h
 
-protected theorem pos_of_lt_add_left {n k : Nat} (h : n < k + n) : 0 < k :=
+protected theorem pos_of_lt_add_left (h : n < k + n) : 0 < k :=
   Nat.lt_of_add_lt_add_right (by rw [Nat.zero_add]; exact h)
 
-protected theorem lt_add_right_iff_pos {n k : Nat} : n < n + k ↔ 0 < k :=
+protected theorem lt_add_right_iff_pos : n < n + k ↔ 0 < k :=
   ⟨Nat.pos_of_lt_add_right, Nat.lt_add_of_pos_right⟩
 
-protected theorem lt_add_left_iff_pos {n k : Nat} : n < k + n ↔ 0 < k :=
+protected theorem lt_add_left_iff_pos : n < k + n ↔ 0 < k :=
   ⟨Nat.pos_of_lt_add_left, Nat.lt_add_of_pos_left⟩
 
-theorem add_pos_left (h : 0 < m) (n : Nat) : 0 < m + n :=
+theorem add_pos_left (h : 0 < m) (n) : 0 < m + n :=
   Nat.lt_of_le_of_lt (zero_le n) (Nat.lt_add_of_pos_left h)
 
-theorem add_pos_right (m : Nat) (h : 0 < n) : 0 < m + n := by
+theorem add_pos_right (m) (h : 0 < n) : 0 < m + n := by
   rw [Nat.add_comm]
   exact add_pos_left h m
 
-protected theorem add_self_ne_one : ∀ (n : Nat), n + n ≠ 1
+protected theorem add_self_ne_one : ∀ n, n + n ≠ 1
   | n+1, h =>
     have h1 : succ (succ (n + n)) = 1 := succ_add n n ▸ h
     Nat.noConfusion h1 fun.
@@ -228,7 +228,7 @@ protected theorem add_self_ne_one : ∀ (n : Nat), n + n ≠ 1
 
 attribute [simp] Nat.zero_sub Nat.add_sub_cancel succ_sub_succ_eq_sub
 
-theorem sub_lt_succ (a b : Nat) : a - b < succ a :=
+theorem sub_lt_succ (a b) : a - b < succ a :=
   lt_succ_of_le (sub_le a b)
 
 protected theorem le_of_le_of_sub_le_sub_right :
@@ -243,18 +243,17 @@ protected theorem le_of_le_of_sub_le_sub_right :
 protected theorem sub_le_sub_iff_right {n m k : Nat} (h : k ≤ m) : n - k ≤ m - k ↔ n ≤ m :=
   ⟨Nat.le_of_le_of_sub_le_sub_right h, fun h => Nat.sub_le_sub_right h k⟩
 
-protected theorem add_le_to_le_sub (x : Nat) {y k : Nat} (h : k ≤ y) :
-    x + k ≤ y ↔ x ≤ y - k := by
-  rw [← Nat.add_sub_cancel x k, Nat.sub_le_sub_iff_right h, Nat.add_sub_cancel]
+protected theorem add_le_to_le_sub (n : Nat) (h : m ≤ k) : n + m ≤ k ↔ n ≤ k - m := by
+  rw [← Nat.add_sub_cancel n, Nat.sub_le_sub_iff_right h, Nat.add_sub_cancel]
 
-protected theorem sub_lt_of_pos_le {a b : Nat} (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
+protected theorem sub_lt_of_pos_le (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
   Nat.sub_lt (Nat.lt_of_lt_of_le h₀ h₁) h₀
 
-protected theorem sub_one (n : Nat) : n - 1 = pred n := rfl
+protected theorem sub_one (n) : n - 1 = pred n := rfl
 
-theorem succ_sub_one (n : Nat) : succ n - 1 = n := rfl
+theorem succ_sub_one (n) : succ n - 1 = n := rfl
 
-protected theorem le_of_sub_eq_zero : ∀ {n m : Nat}, n - m = 0 → n ≤ m
+protected theorem le_of_sub_eq_zero : ∀ {n m}, n - m = 0 → n ≤ m
   | n, 0, H => by rw [Nat.sub_zero] at H; simp [H]
   | 0, m+1, _ => Nat.zero_le (m + 1)
   | n+1, m+1, H => Nat.add_le_add_right
@@ -274,7 +273,7 @@ protected theorem sub_le_sub_left (k : Nat) (h : n ≤ m) : k - m ≤ k - n :=
   match m, le.dest h with
   | _, ⟨a, rfl⟩ => by rw [← Nat.sub_sub]; apply sub_le
 
-theorem succ_sub_sub_succ (n m k : Nat) : succ n - m - succ k = n - m - k := by
+theorem succ_sub_sub_succ (n m k) : succ n - m - succ k = n - m - k := by
   rw [Nat.sub_sub, Nat.sub_sub, add_succ, succ_sub_succ]
 
 protected theorem sub_right_comm (m n k : Nat) : m - n - k = m - k - n := by
@@ -296,7 +295,7 @@ theorem sub_one_sub_lt (h : i < n) : n - 1 - i < n := by
   apply Nat.sub_lt (Nat.lt_of_lt_of_le (Nat.zero_lt_succ _) h)
   rw [Nat.add_comm]; apply Nat.zero_lt_succ
 
-theorem sub_lt_self {a b : Nat} (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b := by
+theorem sub_lt_self (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b := by
   apply sub_lt _ h₀
   apply Nat.lt_of_lt_of_le h₀ h₁
 
@@ -321,8 +320,7 @@ protected theorem sub_le_sub_iff_left {n m k : Nat} (hn : n ≤ k) : k - m ≤ k
     le_sub_iff_add_le (Nat.le_trans hn (Nat.le_add_left ..)),
     Nat.add_comm, Nat.add_le_add_iff_right] at h
 
-protected theorem sub_add_lt_sub {n m k : Nat} (h₁ : m + k ≤ n) (h₂ : 0 < k) :
-    n - (m + k) < n - m :=
+protected theorem sub_add_lt_sub (h₁ : m + k ≤ n) (h₂ : 0 < k) : n - (m + k) < n - m :=
   match k with
   | zero => Nat.lt_irrefl _ h₂ |>.elim
   | succ _ =>
@@ -343,9 +341,9 @@ protected theorem min_eq_left {a b : Nat} (h : a ≤ b) : min a b = a := by simp
 protected theorem min_eq_right {a b : Nat} (h : b ≤ a) : min a b = b := by
   rw [Nat.min_comm a b]; exact Nat.min_eq_left h
 
-protected theorem zero_min (a : Nat) : min 0 a = 0 := Nat.min_eq_left (zero_le a)
+protected theorem zero_min (a) : min 0 a = 0 := Nat.min_eq_left (zero_le a)
 
-protected theorem min_zero (a : Nat) : min a 0 = 0 := Nat.min_eq_right (zero_le a)
+protected theorem min_zero (a) : min a 0 = 0 := Nat.min_eq_right (zero_le a)
 
 protected theorem max_le {a b c : Nat} : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
   ⟨fun h => ⟨Nat.le_trans (Nat.le_max_left ..) h, Nat.le_trans (Nat.le_max_right ..) h⟩,
@@ -358,7 +356,7 @@ protected theorem max_eq_left {a b : Nat} (h : b ≤ a) : max a b = a := by
   rw [← Nat.max_comm b a]; exact Nat.max_eq_right h
 
 -- Distribute succ over min
-theorem min_succ_succ (x y : Nat) : min (succ x) (succ y) = succ (min x y) := by
+theorem min_succ_succ (x y) : min (succ x) (succ y) = succ (min x y) := by
   simp [Nat.min_def, succ_le_succ_iff]; split <;> rfl
 
 theorem sub_eq_sub_min (n m : Nat) : n - m = n - min n m := by
@@ -382,11 +380,11 @@ protected theorem mul_right_comm (n m k : Nat) : n * m * k = n * k * m := by
 protected theorem mul_mul_mul_comm (a b c d : Nat) : (a * b) * (c * d) = (a * c) * (b * d) := by
   rw [Nat.mul_assoc, Nat.mul_assoc, Nat.mul_left_comm b]
 
-protected theorem mul_two (n : Nat) : n * 2 = n + n := by simp [Nat.mul_succ]
+protected theorem mul_two (n) : n * 2 = n + n := by simp [Nat.mul_succ]
 
-protected theorem two_mul (n : Nat) : 2 * n = n + n := by simp [Nat.succ_mul]
+protected theorem two_mul (n) : 2 * n = n + n := by simp [Nat.succ_mul]
 
-theorem mul_eq_zero {n m : Nat} : n * m = 0 ↔ n = 0 ∨ m = 0 :=
+theorem mul_eq_zero : n * m = 0 ↔ n = 0 ∨ m = 0 :=
   ⟨fun h => match n, m, h with
     | 0,   m, _ => .inl rfl
     | n+1, m, h => by rw [succ_mul] at h; exact .inr (Nat.eq_zero_of_add_eq_zero_left h),
@@ -413,7 +411,7 @@ protected theorem mul_lt_mul (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) : a *
 protected theorem mul_lt_mul' (h1 : a ≤ c) (h2 : b < d) (h3 : 0 < c) : a * b < c * d :=
   Nat.lt_of_le_of_lt (Nat.mul_le_mul_of_nonneg_right h1) (Nat.mul_lt_mul_of_pos_left h2 h3)
 
-theorem succ_mul_succ_eq (a b : Nat) : succ a * succ b = a * b + a + b + 1 := by
+theorem succ_mul_succ_eq (a b) : succ a * succ b = a * b + a + b + 1 := by
   rw [mul_succ, succ_mul, Nat.add_right_comm _ a]; rfl
 
 protected theorem mul_self_sub_mul_self_eq (a b : Nat) : a * a - b * b = (a + b) * (a - b) := by
@@ -431,15 +429,15 @@ theorem mod_add_div (m k : Nat) : m % k + k * (m / k) = m := by
   | base x y h => simp [h]
   | ind x y h IH => simp [h]; rw [Nat.mul_succ, ← Nat.add_assoc, IH, Nat.sub_add_cancel h.2]
 
-@[simp] protected theorem div_one (n : Nat) : n / 1 = n := by
+@[simp] protected theorem div_one (n) : n / 1 = n := by
   have := mod_add_div n 1
   rwa [mod_one, Nat.zero_add, Nat.one_mul] at this
 
-@[simp] protected theorem div_zero (n : Nat) : n / 0 = 0 := by
+@[simp] protected theorem div_zero (n) : n / 0 = 0 := by
   rw [div_eq]; simp [Nat.lt_irrefl]
 
-@[simp] protected theorem zero_div (b : Nat) : 0 / b = 0 :=
-  (div_eq 0 b).trans <| if_neg <| And.rec Nat.not_le_of_gt
+@[simp] protected theorem zero_div (n) : 0 / n = 0 :=
+  (div_eq 0 _).trans <| if_neg <| And.rec Nat.not_le_of_gt
 
 theorem le_div_iff_mul_le (k0 : 0 < k) : x ≤ y / k ↔ x * k ≤ y := by
   induction y, k using mod.inductionOn generalizing x with
@@ -452,7 +450,7 @@ theorem le_div_iff_mul_le (k0 : 0 < k) : x ≤ y / k ↔ x * k ≤ y := by
     rw [← add_one, Nat.add_le_add_iff_right, IH k0, succ_mul,
         ← Nat.add_sub_cancel (x*k) k, Nat.sub_le_sub_iff_right h.2, Nat.add_sub_cancel]
 
-protected theorem div_le_of_le_mul {m n : Nat} : ∀ {k}, m ≤ k * n → m / k ≤ n
+protected theorem div_le_of_le_mul : ∀ {k : Nat}, m ≤ k * n → m / k ≤ n
   | 0, _ => by simp [Nat.div_zero, n.zero_le]
   | succ k, h => by
     suffices succ k * (m / succ k) ≤ succ k * n from
@@ -493,35 +491,35 @@ theorem div_mul_le_self : ∀ (m n : Nat), m / n * n ≤ m
   | m, 0   => by simp
   | m, n+1 => (le_div_iff_mul_le (Nat.succ_pos _)).1 (Nat.le_refl _)
 
-@[simp] theorem add_div_right (x : Nat) {z : Nat} (H : 0 < z) : (x + z) / z = succ (x / z) := by
+@[simp] theorem add_div_right (x) (H : 0 < z) : (x + z) / z = succ (x / z) := by
   rw [div_eq_sub_div H (Nat.le_add_left _ _), Nat.add_sub_cancel]
 
-@[simp] theorem add_div_left (x : Nat) {z : Nat} (H : 0 < z) : (z + x) / z = succ (x / z) := by
+@[simp] theorem add_div_left (x) (H : 0 < z) : (z + x) / z = succ (x / z) := by
   rw [Nat.add_comm, add_div_right x H]
 
-@[simp] theorem mul_div_right (n : Nat) {m : Nat} (H : 0 < m) : m * n / m = n := by
+@[simp] theorem mul_div_right (n) (H : 0 < m) : m * n / m = n := by
   induction n <;> simp_all [mul_succ]
 
-@[simp] theorem mul_div_left (m : Nat) {n : Nat} (H : 0 < n) : m * n / n = m := by
+@[simp] theorem mul_div_left (m) (H : 0 < n) : m * n / n = m := by
   rw [Nat.mul_comm, mul_div_right _ H]
 
 protected theorem div_self (H : 0 < n) : n / n = 1 := by
   let t := add_div_right 0 H
   rwa [Nat.zero_add, Nat.zero_div] at t
 
-theorem add_mul_div_left (x z : Nat) {y : Nat} (H : 0 < y) : (x + y * z) / y = x / y + z := by
+theorem add_mul_div_left (x z) (H : 0 < y) : (x + y * z) / y = x / y + z := by
   induction z with
   | zero => rw [Nat.mul_zero, Nat.add_zero, Nat.add_zero]
   | succ z ih => rw [mul_succ, ← Nat.add_assoc, add_div_right _ H, ih]; rfl
 
-theorem add_mul_div_right (x y : Nat) {z : Nat} (H : 0 < z) : (x + y * z) / z = x / z + y := by
+theorem add_mul_div_right (x y) (H : 0 < z) : (x + y * z) / z = x / z + y := by
   rw [Nat.mul_comm, add_mul_div_left _ _ H]
 
-protected theorem mul_div_cancel (m : Nat) {n : Nat} (H : 0 < n) : m * n / n = m := by
+protected theorem mul_div_cancel (m) (H : 0 < n) : m * n / n = m := by
   let t := add_mul_div_right 0 m H
   rwa [Nat.zero_add, Nat.zero_div, Nat.zero_add] at t
 
-protected theorem mul_div_cancel_left (m : Nat) {n : Nat} (H : 0 < n) : n * m / n = m :=
+protected theorem mul_div_cancel_left (m) (H : 0 < n) : n * m / n = m :=
 by rw [Nat.mul_comm, Nat.mul_div_cancel _ H]
 
 protected theorem div_eq_of_eq_mul_left (H1 : 0 < n) (H2 : m = k * n) : m / n = k :=
@@ -537,7 +535,7 @@ Nat.le_antisymm
   (le_of_lt_succ ((Nat.div_lt_iff_lt_mul npos).2 hi))
   ((Nat.le_div_iff_mul_le npos).2 lo)
 
-theorem mul_sub_div (x n p : Nat) (h₁ : x < n*p) : (n * p - succ x) / n = p - succ (x / n) := by
+theorem mul_sub_div (x n p) (h₁ : x < n*p) : (n * p - succ x) / n = p - succ (x / n) := by
   have npos : 0 < n := (eq_zero_or_pos _).resolve_left fun n0 => by
     rw [n0, Nat.zero_mul] at h₁; exact not_lt_zero _ h₁
   apply Nat.div_eq_of_lt_le
@@ -567,18 +565,18 @@ protected theorem div_div_eq_div_mul (m n k : Nat) : m / n / k = m / (n * k) := 
     apply (le_div_iff_mul_le (Nat.mul_pos kpos npos)).1
     apply Nat.le_refl
 
-protected theorem mul_div_mul_left {m : Nat} (n k : Nat) (H : 0 < m) :
-    m * n / (m * k) = n / k := by rw [← Nat.div_div_eq_div_mul, Nat.mul_div_cancel_left _ H]
+protected theorem mul_div_mul_left (n k) (H : 0 < m) : m * n / (m * k) = n / k := by
+  rw [← Nat.div_div_eq_div_mul, Nat.mul_div_cancel_left _ H]
 
-protected theorem mul_div_mul_right {m : Nat} (n k : Nat) (H : 0 < m) :
-    n * m / (k * m) = n / k := by rw [Nat.mul_comm, Nat.mul_comm k, Nat.mul_div_mul_left _ _ H]
+protected theorem mul_div_mul_right (n k) (H : 0 < m) : n * m / (k * m) = n / k := by
+  rw [Nat.mul_comm, Nat.mul_comm k, Nat.mul_div_mul_left _ _ H]
 
 theorem mul_div_le (m n : Nat) : n * (m / n) ≤ m := by
   match n, Nat.eq_zero_or_pos n with
   | _, Or.inl rfl => rw [Nat.zero_mul]; exact m.zero_le
   | n, Or.inr h => rw [Nat.mul_comm, ← Nat.le_div_iff_mul_le h]; exact Nat.le_refl _
 
-theorem mod_two_eq_zero_or_one (n : Nat) : n % 2 = 0 ∨ n % 2 = 1 :=
+theorem mod_two_eq_zero_or_one (n) : n % 2 = 0 ∨ n % 2 = 1 :=
   match n % 2, @Nat.mod_lt n 2 (by simp) with
   | 0, _ => .inl rfl
   | 1, _ => .inr rfl
@@ -600,10 +598,10 @@ theorem le_of_mod_lt {a b : Nat} (h : a % b < a) : b ≤ a :=
 @[simp] theorem add_mul_mod_self_right (x y z : Nat) : (x + y * z) % z = x % z := by
   rw [Nat.mul_comm, add_mul_mod_self_left]
 
-@[simp] theorem mul_mod_right (m n : Nat) : (m * n) % m = 0 := by
+@[simp] theorem mul_mod_right (m n) : (m * n) % m = 0 := by
   rw [← Nat.zero_add (m * n), add_mul_mod_self_left, zero_mod]
 
-@[simp] theorem mul_mod_left (m n : Nat) : (m * n) % n = 0 := by
+@[simp] theorem mul_mod_left (m n) : (m * n) % n = 0 := by
   rw [Nat.mul_comm, mul_mod_right]
 
 theorem mul_mod_mul_left (z x y : Nat) : (z * x) % (z * y) = z * (x % y) :=
@@ -662,10 +660,10 @@ theorem add_mod (a b n : Nat) : (a + b) % n = ((a % n) + (b % n)) % n := by
 
 /-! ### pow -/
 
-theorem pow_succ' {m n : Nat} : m ^ n.succ = m * m ^ n := by
+theorem pow_succ' {m : Nat} : m ^ n.succ = m * m ^ n := by
   rw [Nat.pow_succ, Nat.mul_comm]
 
-@[simp] theorem pow_eq {m n : Nat} : m.pow n = m ^ n := rfl
+@[simp] theorem pow_eq : Nat.pow m n = m ^ n := rfl
 
 @[simp] theorem shiftLeft_eq (a b : Nat) : a <<< b = a * 2 ^ b :=
   match b with
@@ -673,11 +671,11 @@ theorem pow_succ' {m n : Nat} : m ^ n.succ = m * m ^ n := by
   | b+1 => (shiftLeft_eq _ b).trans <| by
     simp [pow_succ, Nat.mul_assoc, Nat.mul_left_comm, Nat.mul_comm]
 
-theorem one_shiftLeft (n : Nat) : 1 <<< n = 2 ^ n := by rw [shiftLeft_eq, Nat.one_mul]
+theorem one_shiftLeft (n) : 1 <<< n = 2 ^ n := by rw [shiftLeft_eq, Nat.one_mul]
 
 attribute [simp] Nat.pow_zero
 
-protected theorem zero_pow {n : Nat} (H : 0 < n) : 0 ^ n = 0 := by
+protected theorem zero_pow (H : 0 < n) : 0 ^ n = 0 := by
   match n with
   | 0 => contradiction
   | n+1 => rw [Nat.pow_succ, Nat.mul_zero]
@@ -736,7 +734,7 @@ theorem lt_log2_self (h : n ≠ 0) : n < 2 ^ (n.log2 + 1) := (log2_lt h).1 (Nat.
 
 protected theorem dvd_refl (a : Nat) : a ∣ a := ⟨1, by simp⟩
 
-protected theorem dvd_zero (a : Nat) : a ∣ 0 := ⟨0, by simp⟩
+protected theorem dvd_zero (a) : a ∣ 0 := ⟨0, by simp⟩
 
 protected theorem dvd_mul_left (a b : Nat) : a ∣ b * a := ⟨b, Nat.mul_comm b a⟩
 
@@ -747,7 +745,7 @@ protected theorem dvd_trans {a b c : Nat} (h₁ : a ∣ b) (h₂ : b ∣ c) : a 
   | ⟨d, (h₃ : b = a * d)⟩, ⟨e, (h₄ : c = b * e)⟩ =>
     ⟨d * e, show c = a * (d * e) by simp[h₃,h₄, Nat.mul_assoc]⟩
 
-protected theorem eq_zero_of_zero_dvd {a : Nat} (h : 0 ∣ a) : a = 0 :=
+protected theorem eq_zero_of_zero_dvd (h : 0 ∣ a) : a = 0 :=
   let ⟨c, H'⟩ := h; H'.trans c.zero_mul
 
 protected theorem dvd_add {a b c : Nat} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
@@ -779,7 +777,7 @@ theorem dvd_mod_iff {k m n : Nat} (h: k ∣ n) : k ∣ m % n ↔ k ∣ m :=
   have := Nat.dvd_add_iff_left <| Nat.dvd_trans h <| Nat.dvd_mul_right n (m / n)
   by rwa [mod_add_div] at this
 
-theorem le_of_dvd {m n : Nat} (h : 0 < n) : m ∣ n → m ≤ n
+theorem le_of_dvd (h : 0 < n) : m ∣ n → m ≤ n
   | ⟨k, e⟩ => by
     revert h
     rw [e]
@@ -795,21 +793,21 @@ protected theorem dvd_antisymm : ∀ {m n : Nat}, m ∣ n → n ∣ m → m = n
   | 0, _, h₁, _ => (Nat.eq_zero_of_zero_dvd h₁).symm
   | _+1, _+1, h₁, h₂ => Nat.le_antisymm (le_of_dvd (succ_pos _) h₁) (le_of_dvd (succ_pos _) h₂)
 
-theorem pos_of_dvd_of_pos {m n : Nat} (H1 : m ∣ n) (H2 : 0 < n) : 0 < m :=
+theorem pos_of_dvd_of_pos (H1 : m ∣ n) (H2 : 0 < n) : 0 < m :=
   Nat.pos_of_ne_zero fun m0 => Nat.ne_of_gt H2 <| Nat.eq_zero_of_zero_dvd (m0 ▸ H1)
 
-theorem eq_one_of_dvd_one {n : Nat} (H : n ∣ 1) : n = 1 :=
+theorem eq_one_of_dvd_one (H : n ∣ 1) : n = 1 :=
   Nat.le_antisymm (le_of_dvd (by decide) H) (pos_of_dvd_of_pos H (by decide))
 
-theorem dvd_of_mod_eq_zero {m n : Nat} (H : n % m = 0) : m ∣ n := by
+theorem dvd_of_mod_eq_zero (H : n % m = 0) : m ∣ n := by
   exists n / m
   have := (mod_add_div n m).symm
   rwa [H, Nat.zero_add] at this
 
-theorem mod_eq_zero_of_dvd {m n : Nat} (H : m ∣ n) : n % m = 0 := by
+theorem mod_eq_zero_of_dvd (H : m ∣ n) : n % m = 0 := by
   let ⟨z, H⟩ := H; rw [H, mul_mod_right]
 
-theorem dvd_iff_mod_eq_zero (m n : Nat) : m ∣ n ↔ n % m = 0 :=
+theorem dvd_iff_mod_eq_zero (m n) : m ∣ n ↔ n % m = 0 :=
   ⟨mod_eq_zero_of_dvd, dvd_of_mod_eq_zero⟩
 
 instance decidable_dvd : @DecidableRel Nat (·∣·) :=

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -221,17 +221,15 @@ attribute [simp] Nat.zero_sub Nat.add_sub_cancel succ_sub_succ_eq_sub
 theorem sub_lt_succ (a b) : a - b < succ a :=
   lt_succ_of_le (sub_le a b)
 
-protected theorem le_of_le_of_sub_le_sub_right :
-    ∀ {n m k : Nat}, k ≤ m → n - k ≤ m - k → n ≤ m
-  | 0, m, _, _, _ => m.zero_le
-  | succ _, _, 0, _, h₁ => h₁
-  | succ _, 0, succ k, h₀, _ => nomatch not_succ_le_zero k h₀
-  | succ n, succ m, succ k, h₀, h₁ => by
-    simp [succ_sub_succ] at h₁
+protected theorem le_of_le_of_sub_le_sub_right : ∀ {n m k : Nat}, k ≤ m → n - k ≤ m - k → n ≤ m
+  | 0, _, _, _, _ => Nat.zero_le ..
+  | _+1, _, 0, _, h₁ => h₁
+  | _+1, _+1, _+1, h₀, h₁ => by
+    simp only [Nat.succ_sub_succ] at h₁
     exact succ_le_succ <| Nat.le_of_le_of_sub_le_sub_right (le_of_succ_le_succ h₀) h₁
 
 protected theorem sub_le_sub_iff_right {n m k : Nat} (h : k ≤ m) : n - k ≤ m - k ↔ n ≤ m :=
-  ⟨Nat.le_of_le_of_sub_le_sub_right h, fun h => Nat.sub_le_sub_right h k⟩
+  ⟨Nat.le_of_le_of_sub_le_sub_right h, fun h => Nat.sub_le_sub_right h _⟩
 
 protected theorem add_le_to_le_sub (n : Nat) (h : m ≤ k) : n + m ≤ k ↔ n ≤ k - m := by
   rw [← Nat.add_sub_cancel n, Nat.sub_le_sub_iff_right h, Nat.add_sub_cancel]
@@ -244,17 +242,14 @@ protected theorem sub_one (n) : n - 1 = pred n := rfl
 theorem succ_sub_one (n) : succ n - 1 = n := rfl
 
 protected theorem le_of_sub_eq_zero : ∀ {n m}, n - m = 0 → n ≤ m
-  | n, 0, H => by rw [Nat.sub_zero] at H; simp [H]
-  | 0, m+1, _ => Nat.zero_le (m + 1)
-  | n+1, m+1, H => Nat.add_le_add_right
-    (Nat.le_of_sub_eq_zero (by simp [Nat.add_sub_add_right] at H; exact H)) _
+  | 0, _, _ => Nat.zero_le ..
+  | _+1, _+1, h => Nat.succ_le_succ <| Nat.le_of_sub_eq_zero (Nat.succ_sub_succ .. ▸ h)
 
 protected theorem sub_eq_zero_iff_le : n - m = 0 ↔ n ≤ m :=
   ⟨Nat.le_of_sub_eq_zero, Nat.sub_eq_zero_of_le⟩
 
-protected theorem sub_eq_iff_eq_add {a b c : Nat} (ab : b ≤ a) : a - b = c ↔ a = c + b :=
-  ⟨fun c_eq => by rw [c_eq.symm, Nat.sub_add_cancel ab],
-   fun a_eq => by rw [a_eq, Nat.add_sub_cancel]⟩
+protected theorem sub_eq_iff_eq_add {a b c : Nat} (h : b ≤ a) : a - b = c ↔ a = c + b :=
+  ⟨fun | rfl => by rw [Nat.sub_add_cancel h], fun heq => by rw [heq, Nat.add_sub_cancel]⟩
 
 protected theorem lt_of_sub_eq_succ (H : m - n = succ l) : n < m :=
   Nat.not_le.1 fun H' => by simp [Nat.sub_eq_zero_of_le H'] at H
@@ -270,7 +265,7 @@ protected theorem sub_right_comm (m n k : Nat) : m - n - k = m - k - n := by
   rw [Nat.sub_sub, Nat.sub_sub, Nat.add_comm]
 
 protected theorem sub_pos_of_lt (h : m < n) : 0 < n - m := by
-  apply Nat.lt_of_add_lt_add_right (b := m)
+  apply Nat.lt_of_add_lt_add_right
   rwa [Nat.zero_add, Nat.sub_add_cancel (Nat.le_of_lt h)]
 
 protected theorem sub_sub_self {n m : Nat} (h : m ≤ n) : n - (n - m) = m :=
@@ -285,9 +280,8 @@ theorem sub_one_sub_lt (h : i < n) : n - 1 - i < n := by
   apply Nat.sub_lt (Nat.lt_of_lt_of_le (Nat.zero_lt_succ _) h)
   rw [Nat.add_comm]; apply Nat.zero_lt_succ
 
-theorem sub_lt_self (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b := by
-  apply sub_lt _ h₀
-  apply Nat.lt_of_lt_of_le h₀ h₁
+protected theorem sub_lt_self (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :=
+  Nat.sub_lt (Nat.lt_of_lt_of_le h₀ h₁) h₀
 
 protected theorem add_sub_cancel' {n m : Nat} (h : m ≤ n) : m + (n - m) = n := by
   rw [Nat.add_comm, Nat.sub_add_cancel h]

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -362,30 +362,24 @@ protected theorem mul_right_comm (n m k : Nat) : n * m * k = n * k * m := by
 protected theorem mul_mul_mul_comm (a b c d : Nat) : (a * b) * (c * d) = (a * c) * (b * d) := by
   rw [Nat.mul_assoc, Nat.mul_assoc, Nat.mul_left_comm b]
 
-protected theorem mul_two (n) : n * 2 = n + n := by simp [Nat.mul_succ]
+protected theorem mul_two (n) : n * 2 = n + n := by rw [Nat.mul_succ, Nat.mul_one]
 
-protected theorem two_mul (n) : 2 * n = n + n := by simp [Nat.succ_mul]
+protected theorem two_mul (n) : 2 * n = n + n := by rw [Nat.succ_mul, Nat.one_mul]
 
-theorem mul_eq_zero : n * m = 0 ↔ n = 0 ∨ m = 0 :=
-  ⟨fun h => match n, m, h with
-    | 0,   m, _ => .inl rfl
-    | n+1, m, h => by rw [succ_mul] at h; exact .inr (Nat.eq_zero_of_add_eq_zero_left h),
-   fun | .inl h | .inr h => by simp [h]⟩
+theorem mul_eq_zero : ∀ {m n}, n * m = 0 ↔ n = 0 ∨ m = 0
+  | 0, _ => ⟨fun _ => .inr rfl, fun _ => rfl⟩
+  | _, 0 => ⟨fun _ => .inl rfl, fun _ => Nat.zero_mul ..⟩
+  | _+1, _+1 => ⟨fun., fun.⟩
 
-protected theorem mul_ne_zero_iff : n * m ≠ 0 ↔ n ≠ 0 ∧ m ≠ 0 := by simp [mul_eq_zero, not_or]
+protected theorem mul_ne_zero_iff : n * m ≠ 0 ↔ n ≠ 0 ∧ m ≠ 0 := by rw [ne_eq, mul_eq_zero, not_or]
 
-protected theorem mul_ne_zero (n0 : n ≠ 0) (m0 : m ≠ 0) : n * m ≠ 0 :=
-  Nat.mul_ne_zero_iff.2 ⟨n0, m0⟩
+protected theorem mul_ne_zero : n ≠ 0 → m ≠ 0 → n * m ≠ 0 := (Nat.mul_ne_zero_iff.2 ⟨·,·⟩)
 
-protected theorem mul_le_mul_of_nonneg_left {a b c : Nat} (h₁ : a ≤ b) : c * a ≤ c * b := by
-  if hba : b ≤ a then simp [Nat.le_antisymm hba h₁] else
-  if hc0 : c ≤ 0 then simp [Nat.le_antisymm hc0 (zero_le c), Nat.zero_mul] else
-  exact Nat.le_of_lt (Nat.mul_lt_mul_of_pos_left (Nat.not_le.1 hba) (Nat.not_le.1 hc0))
+protected theorem mul_le_mul_of_nonneg_left {a b c : Nat} : a ≤ b → c * a ≤ c * b :=
+  Nat.mul_le_mul_left c
 
-protected theorem mul_le_mul_of_nonneg_right {a b c : Nat} (h₁ : a ≤ b) : a * c ≤ b * c := by
-  if hba : b ≤ a then simp [Nat.le_antisymm hba h₁] else
-  if hc0 : c ≤ 0 then simp [Nat.le_antisymm hc0 (zero_le c), Nat.mul_zero] else
-  exact Nat.le_of_lt (Nat.mul_lt_mul_of_pos_right (Nat.not_le.1 hba) (Nat.not_le.1 hc0))
+protected theorem mul_le_mul_of_nonneg_right {a b c : Nat} : a ≤ b → a * c ≤ b * c :=
+  Nat.mul_le_mul_right c
 
 protected theorem mul_lt_mul (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) : a * b < c * d :=
   Nat.lt_of_lt_of_le (Nat.mul_lt_mul_of_pos_right hac pos_b) (Nat.mul_le_mul_of_nonneg_left hbd)
@@ -394,11 +388,11 @@ protected theorem mul_lt_mul' (h1 : a ≤ c) (h2 : b < d) (h3 : 0 < c) : a * b <
   Nat.lt_of_le_of_lt (Nat.mul_le_mul_of_nonneg_right h1) (Nat.mul_lt_mul_of_pos_left h2 h3)
 
 theorem succ_mul_succ_eq (a b) : succ a * succ b = a * b + a + b + 1 := by
-  rw [mul_succ, succ_mul, Nat.add_right_comm _ a]; rfl
+  rw [succ_mul, mul_succ]; rfl
 
 protected theorem mul_self_sub_mul_self_eq (a b : Nat) : a * a - b * b = (a + b) * (a - b) := by
-  rw [Nat.mul_sub_left_distrib, Nat.right_distrib, Nat.right_distrib,
-      Nat.mul_comm b a, Nat.add_comm (a*a) (a*b), Nat.add_sub_add_left]
+  rw [Nat.mul_sub_left_distrib, Nat.right_distrib, Nat.right_distrib]
+  rw [Nat.mul_comm a b, Nat.sub_add_eq, Nat.add_sub_cancel]
 
 /-! ## div/mod -/
 

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -420,45 +420,185 @@ protected theorem sub_lt_of_pos_le (h₀ : 0 < a) (h₁ : a ≤ b) : b - a < b :
 
 /-! ## min/max -/
 
-protected theorem le_min {a b c : Nat} : a ≤ min b c ↔ a ≤ b ∧ a ≤ c :=
-  ⟨fun h => ⟨Nat.le_trans h (Nat.min_le_left ..), Nat.le_trans h (Nat.min_le_right ..)⟩,
-   fun ⟨h₁, h₂⟩ => by rw [Nat.min_def]; split <;> assumption⟩
+protected theorem min_succ_succ (x y) : min (succ x) (succ y) = succ (min x y) := by
+  simp [Nat.min_def, succ_le_succ_iff]; split <;> rfl
 
-protected theorem lt_min {a b c : Nat} : a < min b c ↔ a < b ∧ a < c := Nat.le_min
+protected theorem le_min {a b c : Nat} (_ : a ≤ b) (_ : a ≤ c) : a ≤ min b c := by
+  rw [Nat.min_def]; split <;> assumption
+
+protected theorem le_min_iff {a b c : Nat} : a ≤ min b c ↔ a ≤ b ∧ a ≤ c :=
+  ⟨fun h => ⟨Nat.le_trans h (Nat.min_le_left ..), Nat.le_trans h (Nat.min_le_right ..)⟩,
+   fun ⟨h₁, h₂⟩ => Nat.le_min h₁ h₂⟩
+
+protected theorem lt_min_iff {a b c : Nat} : a < min b c ↔ a < b ∧ a < c := Nat.le_min_iff
 
 protected theorem min_eq_left {a b : Nat} (h : a ≤ b) : min a b = a := if_pos h
 
 protected theorem min_eq_right {a b : Nat} (h : b ≤ a) : min a b = b := by
   rw [Nat.min_comm]; exact Nat.min_eq_left h
 
-protected theorem zero_min (a) : min 0 a = 0 := Nat.min_eq_left (zero_le a)
+@[simp] protected theorem min_self (a : Nat) : min a a = a := Nat.min_eq_left (Nat.le_refl _)
 
-protected theorem min_zero (a) : min a 0 = 0 := Nat.min_eq_right (zero_le a)
+@[simp] protected theorem min_zero_left (a) : min 0 a = 0 := Nat.min_eq_left (Nat.zero_le _)
 
-protected theorem max_le {a b c : Nat} : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
+@[simp] protected theorem min_zero_right (a) : min a 0 = 0 := Nat.min_eq_right (Nat.zero_le _)
+
+protected theorem min_assoc : ∀ (a b c : Nat), min (min a b) c = min a (min b c)
+| 0, _, _ => by rw [Nat.min_zero_left, Nat.min_zero_left, Nat.min_zero_left]
+| _, 0, _ => by rw [Nat.min_zero_left, Nat.min_zero_right, Nat.min_zero_left]
+| _, _, 0 => by rw [Nat.min_zero_right, Nat.min_zero_right, Nat.min_zero_right]
+| _+1, _+1, _+1 => by simp only [Nat.min_succ_succ]; exact congrArg succ <| Nat.min_assoc ..
+
+protected theorem sub_sub_eq_min : ∀ (a b : Nat), a - (a - b) = min a b
+  | 0, _ => by rw [Nat.zero_sub, Nat.min_zero_left]
+  | _, 0 => by rw [Nat.sub_zero, Nat.sub_self, Nat.min_zero_right]
+  | _+1, _+1 => by
+    rw [Nat.succ_sub_succ, Nat.min_succ_succ, Nat.succ_sub (Nat.sub_le ..)]
+    exact congrArg succ <| Nat.sub_sub_eq_min ..
+
+protected theorem sub_eq_sub_min (n m : Nat) : n - m = n - min n m := by
+  rw [Nat.min_def]; split
+  next h => rw [Nat.sub_eq_zero_of_le h, Nat.sub_self]
+  next => rfl
+
+@[simp] protected theorem sub_add_min_cancel (n m : Nat) : n - m + min n m = n := by
+  rw [Nat.sub_eq_sub_min, Nat.sub_add_cancel (Nat.min_le_left ..)]
+
+protected theorem max_succ_succ (x y) : max (succ x) (succ y) = succ (max x y) := by
+  simp [Nat.max_def, succ_le_succ_iff]; split <;> rfl
+
+protected theorem max_le {a b c : Nat} : a ≤ c → b ≤ c → max a b ≤ c := by
+  intros; rw [Nat.max_def]; split <;> assumption
+
+protected theorem max_le_iff {a b c : Nat} : max a b ≤ c ↔ a ≤ c ∧ b ≤ c :=
   ⟨fun h => ⟨Nat.le_trans (Nat.le_max_left ..) h, Nat.le_trans (Nat.le_max_right ..) h⟩,
-   fun ⟨h₁, h₂⟩ => by rw [Nat.max_def]; split <;> assumption⟩
+   fun ⟨h₁, h₂⟩ => Nat.max_le h₁ h₂⟩
+
+protected theorem max_lt_iff {a b c : Nat} : max a b < c ↔ a < c ∧ b < c := by
+  rw [← Nat.succ_le, ← Nat.max_succ_succ a b]; exact Nat.max_le_iff
 
 protected theorem max_eq_right {a b : Nat} (h : a ≤ b) : max a b = b := if_pos h
 
 protected theorem max_eq_left {a b : Nat} (h : b ≤ a) : max a b = a := by
   rw [Nat.max_comm]; exact Nat.max_eq_right h
 
-theorem min_succ_succ (x y) : min (succ x) (succ y) = succ (min x y) := by
-  simp [Nat.min_def, succ_le_succ_iff]; split <;> rfl
+@[simp] protected theorem max_self (a : Nat) : max a a = a := Nat.max_eq_right (Nat.le_refl _)
 
-theorem sub_eq_sub_min (n m : Nat) : n - m = n - min n m := by
-  rw [Nat.min_def]; split
+@[simp] protected theorem max_zero_left (a) : max 0 a = a := Nat.max_eq_right (Nat.zero_le _)
+
+@[simp] protected theorem max_zero_right (a) : max a 0 = a := Nat.max_eq_left (Nat.zero_le _)
+
+protected theorem max_assoc : ∀ (a b c : Nat), max (max a b) c = max a (max b c)
+| 0, _, _ => by rw [Nat.max_zero_left, Nat.max_zero_left]
+| _, 0, _ => by rw [Nat.max_zero_left, Nat.max_zero_right]
+| _, _, 0 => by rw [Nat.max_zero_right, Nat.max_zero_right]
+| _+1, _+1, _+1 => by simp only [Nat.max_succ_succ]; exact congrArg succ <| Nat.max_assoc ..
+
+protected theorem sub_add_eq_max (a b : Nat) : a - b + b = max a b := by
+  match Nat.le_total a b with
+  | .inl hl => rw [Nat.max_eq_right hl, Nat.sub_eq_zero_iff_le.mpr hl, Nat.zero_add]
+  | .inr hr => rw [Nat.max_eq_left hr, Nat.sub_add_cancel hr]
+
+protected theorem sub_eq_max_sub (n m : Nat) : n - m = max n m - m := by
+  rw [Nat.max_def]; split
   next h => rw [Nat.sub_eq_zero_of_le h, Nat.sub_self]
   next => rfl
 
-@[simp] protected theorem sub_add_min_cancel (n m : Nat) : n - m + min n m = n := by
-  rw [sub_eq_sub_min, Nat.sub_add_cancel (Nat.min_le_left ..)]
+protected theorem max_min_distrib_left : ∀ (a b c : Nat), max a (min b c) = min (max a b) (max a c)
+  | 0, _, _ => by simp only [Nat.max_zero_left]
+  | _, 0, _ => by
+    rw [Nat.min_zero_left, Nat.max_zero_right]
+    exact Nat.min_eq_left (Nat.le_max_left ..) |>.symm
+  | _, _, 0 => by
+    rw [Nat.min_zero_right, Nat.max_zero_right]
+    exact Nat.min_eq_right (Nat.le_max_left ..) |>.symm
+  | _+1, _+1, _+1 => by
+    simp only [Nat.max_succ_succ, Nat.min_succ_succ]
+    exact congrArg succ <| Nat.max_min_distrib_left ..
 
-protected theorem sub_add_eq_max {a b : Nat} : a - b + b = max a b := by
-  match a.le_total b with
-  | .inl hl => rw [Nat.max_eq_right hl, Nat.sub_eq_zero_iff_le.mpr hl, Nat.zero_add]
-  | .inr hr => rw [Nat.max_eq_left hr, Nat.sub_add_cancel hr]
+protected theorem min_max_distrib_left : ∀ (a b c : Nat), min a (max b c) = max (min a b) (min a c)
+  | 0, _, _ => by simp only [Nat.min_zero_left]
+  | _, 0, _ => by simp only [Nat.min_zero_right, Nat.max_zero_left]
+  | _, _, 0 => by simp only [Nat.min_zero_right, Nat.max_zero_right]
+  | _+1, _+1, _+1 => by
+    simp only [Nat.max_succ_succ, Nat.min_succ_succ]
+    exact congrArg succ <| Nat.min_max_distrib_left ..
+
+protected theorem max_min_distrib_right (a b c : Nat) :
+    max (min a b) c = min (max a c) (max b c) := by
+  repeat rw [Nat.max_comm _ c]
+  exact Nat.max_min_distrib_left ..
+
+protected theorem min_max_distrib_right (a b c : Nat) :
+    min (max a b) c = max (min a c) (min b c) := by
+  repeat rw [Nat.min_comm _ c]
+  exact Nat.min_max_distrib_left ..
+
+protected theorem max_add_add_right : ∀ (a b c : Nat), max (a + c) (b + c) = max a b + c
+  | _, _, 0 => rfl
+  | _, _, _+1 => Eq.trans (Nat.max_succ_succ ..) <| congrArg _ (Nat.max_add_add_right ..)
+
+protected theorem min_add_add_right : ∀ (a b c : Nat), min (a + c) (b + c) = min a b + c
+  | _, _, 0 => rfl
+  | _, _, _+1 => Eq.trans (Nat.min_succ_succ ..) <| congrArg _ (Nat.min_add_add_right ..)
+
+protected theorem max_add_add_left (a b c : Nat) : max (a + b) (a + c) = a + max b c := by
+  repeat rw [Nat.add_comm a]
+  exact Nat.max_add_add_right ..
+
+protected theorem min_add_add_left (a b c : Nat) : min (a + b) (a + c) = a + min b c := by
+  repeat rw [Nat.add_comm a]
+  exact Nat.min_add_add_right ..
+
+protected theorem min_pred_pred : ∀ (x y), min (pred x) (pred y) = pred (min x y)
+  | 0, _ => by simp only [Nat.pred_zero, Nat.min_zero_left]
+  | _, 0 => by simp only [Nat.pred_zero, Nat.min_zero_right]
+  | _+1, _+1 => by simp only [Nat.pred_succ, Nat.min_succ_succ]
+
+protected theorem max_pred_pred : ∀ (x y), max (pred x) (pred y) = pred (max x y)
+  | 0, _ => by simp only [Nat.pred_zero, Nat.max_zero_left]
+  | _, 0 => by simp only [Nat.pred_zero, Nat.max_zero_right]
+  | _+1, _+1 => by simp only [Nat.pred_succ, Nat.max_succ_succ]
+
+protected theorem min_sub_sub_right : ∀ (a b c : Nat), min (a - c) (b - c) = min a b - c
+  | _, _, 0 => rfl
+  | _, _, _+1 => Eq.trans (Nat.min_pred_pred ..) <| congrArg _ (Nat.min_sub_sub_right ..)
+
+protected theorem max_sub_sub_right : ∀ (a b c : Nat), max (a - c) (b - c) = max a b - c
+  | _, _, 0 => rfl
+  | _, _, _+1 => Eq.trans (Nat.max_pred_pred ..) <| congrArg _ (Nat.max_sub_sub_right ..)
+
+protected theorem min_sub_sub_left (a b c : Nat) : min (a - b) (a - c) = a - max b c := by
+  induction b, c using Nat.recDiagAux with
+  | zero_left => rw [Nat.sub_zero, Nat.max_zero_left]; exact Nat.min_eq_right (Nat.sub_le ..)
+  | zero_right => rw [Nat.sub_zero, Nat.max_zero_right]; exact Nat.min_eq_left (Nat.sub_le ..)
+  | succ_succ _ _ ih => simp only [Nat.sub_succ, Nat.max_succ_succ, Nat.min_pred_pred, ih]
+
+protected theorem max_sub_sub_left (a b c : Nat) : max (a - b) (a - c) = a - min b c := by
+  induction b, c using Nat.recDiagAux with
+  | zero_left => rw [Nat.sub_zero, Nat.min_zero_left]; exact Nat.max_eq_left (Nat.sub_le ..)
+  | zero_right => rw [Nat.sub_zero, Nat.min_zero_right]; exact Nat.max_eq_right (Nat.sub_le ..)
+  | succ_succ _ _ ih => simp only [Nat.sub_succ, Nat.min_succ_succ, Nat.max_pred_pred, ih]
+
+protected theorem max_mul_mul_right (a b c : Nat) : max (a * c) (b * c) = max a b * c := by
+  induction a, b using Nat.recDiagAux with
+  | zero_left => simp only [Nat.zero_mul, Nat.max_zero_left]
+  | zero_right => simp only [Nat.zero_mul, Nat.max_zero_right]
+  | succ_succ _ _ ih => simp only [Nat.succ_mul, Nat.max_add_add_right, ih]
+
+protected theorem min_mul_mul_right (a b c : Nat) : min (a * c) (b * c) = min a b * c := by
+  induction a, b using Nat.recDiagAux with
+  | zero_left => simp only [Nat.zero_mul, Nat.min_zero_left]
+  | zero_right => simp only [Nat.zero_mul, Nat.min_zero_right]
+  | succ_succ _ _ ih => simp only [Nat.succ_mul, Nat.min_add_add_right, ih]
+
+protected theorem max_mul_mul_left (a b c : Nat) : max (a * b) (a * c) = a * max b c := by
+  repeat rw [Nat.mul_comm a]
+  exact Nat.max_mul_mul_right ..
+
+protected theorem min_mul_mul_left (a b c : Nat) : min (a * b) (a * c) = a * min b c := by
+  repeat rw [Nat.mul_comm a]
+  exact Nat.min_mul_mul_right ..
 
 /-! ## mul -/
 
@@ -938,3 +1078,18 @@ protected theorem mul_le_mul_of_nonneg_right {a b c : Nat} : a ≤ b → a * c �
 @[deprecated Nat.mul_lt_mul_of_le_of_lt]
 protected theorem mul_lt_mul' (hac : a ≤ c) (hbd : b < d) (hc : 0 < c) : a * b < c * d :=
   Nat.mul_lt_mul_of_le_of_lt hac hbd hc
+
+@[deprecated Nat.lt_min_iff]
+protected theorem lt_min {a b c : Nat} : a < min b c ↔ a < b ∧ a < c := Nat.lt_min_iff
+
+@[deprecated Nat.max_zero_left]
+protected theorem zero_max (n) : max 0 n = n := Nat.max_zero_left ..
+
+@[deprecated Nat.max_zero_right]
+protected theorem max_zero (n) : max n 0 = n := Nat.max_zero_right ..
+
+@[deprecated Nat.min_zero_left]
+protected theorem zero_min (n) : min 0 n = 0 := Nat.min_zero_left ..
+
+@[deprecated Nat.max_zero_right]
+protected theorem min_zero (n) : min n 0 = 0 := Nat.min_zero_right ..

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -487,17 +487,14 @@ protected theorem le_mul_of_pos_left (n) (h : 0 < m) : n ≤ n * m :=
 protected theorem le_mul_of_pos_right (m) (h : 0 < n) : m ≤ n * m :=
   Nat.le_trans (Nat.le_of_eq (Nat.one_mul _).symm) (Nat.mul_le_mul_right _ h)
 
-protected theorem mul_le_mul_of_nonneg_left {a b c : Nat} : a ≤ b → c * a ≤ c * b :=
-  Nat.mul_le_mul_left c
+protected theorem mul_lt_mul_of_lt_of_le (hac : a < c) (hbd : b ≤ d) (hd : 0 < d) : a * b < c * d :=
+  Nat.lt_of_le_of_lt (Nat.mul_le_mul_left _ hbd) (Nat.mul_lt_mul_of_pos_right hac hd)
 
-protected theorem mul_le_mul_of_nonneg_right {a b c : Nat} : a ≤ b → a * c ≤ b * c :=
-  Nat.mul_le_mul_right c
+protected theorem mul_lt_mul_of_le_of_lt (hac : a ≤ c) (hbd : b < d) (hc : 0 < c) : a * b < c * d :=
+  Nat.lt_of_le_of_lt (Nat.mul_le_mul_right _ hac) (Nat.mul_lt_mul_of_pos_left hbd hc)
 
-protected theorem mul_lt_mul (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) : a * b < c * d :=
-  Nat.lt_of_lt_of_le (Nat.mul_lt_mul_of_pos_right hac pos_b) (Nat.mul_le_mul_of_nonneg_left hbd)
-
-protected theorem mul_lt_mul' (h1 : a ≤ c) (h2 : b < d) (h3 : 0 < c) : a * b < c * d :=
-  Nat.lt_of_le_of_lt (Nat.mul_le_mul_of_nonneg_right h1) (Nat.mul_lt_mul_of_pos_left h2 h3)
+protected theorem mul_lt_mul {a b c d : Nat} (hac : a < c) (hbd : b < d) : a * b < c * d :=
+  Nat.mul_lt_mul_of_le_of_lt (Nat.le_of_lt hac) hbd (Nat.zero_lt_of_lt hac)
 
 theorem succ_mul_succ_eq (a b) : succ a * succ b = a * b + a + b + 1 := by
   rw [succ_mul, mul_succ]; rfl
@@ -929,3 +926,15 @@ theorem add_le_to_le_sub (x : Nat) {y k : Nat} (h : k ≤ y) : x + k ≤ y ↔ x
 @[deprecated Nat.succ_add_eq_add_succ]
 theorem succ_add_eq_succ_add (n m : Nat) : succ n + m = n + succ m :=
   Nat.succ_add_eq_add_succ ..
+
+@[deprecated Nat.mul_le_mul_left]
+protected theorem mul_le_mul_of_nonneg_left {a b c : Nat} : a ≤ b → c * a ≤ c * b :=
+  Nat.mul_le_mul_left c
+
+@[deprecated Nat.mul_le_mul_right]
+protected theorem mul_le_mul_of_nonneg_right {a b c : Nat} : a ≤ b → a * c ≤ b * c :=
+  Nat.mul_le_mul_right c
+
+@[deprecated Nat.mul_lt_mul_of_le_of_lt]
+protected theorem mul_lt_mul' (hac : a ≤ c) (hbd : b < d) (hc : 0 < c) : a * b < c * d :=
+  Nat.mul_lt_mul_of_le_of_lt hac hbd hc

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -938,6 +938,24 @@ protected theorem mul_pow (a b n : Nat) : (a * b) ^ n = a ^ n * b ^ n := by
   | zero => rw [Nat.pow_zero, Nat.pow_zero, Nat.pow_zero, Nat.mul_one]
   | succ _ ih => rw [Nat.pow_succ, Nat.pow_succ, Nat.pow_succ, Nat.mul_mul_mul_comm, ih]
 
+protected theorem pow_lt_pow_of_lt_left {a b : Nat} : a < b → {n : Nat} → 0 < n → a ^ n < b ^ n
+  | h, n+1, _ => by
+    have hpos : 0 < b ^ n := Nat.pos_pow_of_pos n (Nat.zero_lt_of_lt h)
+    simp [Nat.pow_succ]
+    apply Nat.mul_lt_mul_of_le_of_lt _ h hpos
+    exact Nat.pow_le_pow_of_le_left (Nat.le_of_lt h) n
+
+protected theorem pow_lt_pow_of_lt_right {a : Nat} : 1 < a → m < n → a ^ m < a ^ n := by
+  intro ha h; induction m, n using Nat.recDiag with try contradiction
+  | zero_succ n =>
+    have hpos := Nat.pos_pow_of_pos n (Nat.le_of_lt ha)
+    apply Nat.lt_of_le_of_lt hpos
+    have : a ^ n * 1 < a ^ n * a := Nat.mul_lt_mul_of_pos_left ha hpos
+    rwa [Nat.mul_one] at this
+  | succ_succ m n ih =>
+    apply Nat.mul_lt_mul_of_pos_right _ (Nat.le_of_lt ha)
+    exact ih (Nat.lt_of_succ_lt_succ h)
+
 /-! ### log2 -/
 
 theorem le_log2 (h : n ≠ 0) : ∀ {k}, k ≤ n.log2 ↔ 2 ^ k ≤ n

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -145,13 +145,10 @@ theorem le_pred_of_lt (h : m < n) : m ≤ n - 1 :=
 /-! ### add -/
 
 protected theorem eq_zero_of_add_eq_zero_right : ∀ {n m}, n + m = 0 → n = 0
-| 0,   m => by simp [Nat.zero_add]
-| n+1, m => fun h => by
-  rw [add_one, succ_add] at h
-  cases succ_ne_zero _ h
+  | _, 0, h => h
 
-protected theorem eq_zero_of_add_eq_zero_left (h : n + m = 0) : m = 0 :=
-  @Nat.eq_zero_of_add_eq_zero_right m n (Nat.add_comm n m ▸ h)
+protected theorem eq_zero_of_add_eq_zero_left : ∀ {n m}, n + m = 0 → m = 0
+  | _, 0, _ => rfl
 
 theorem succ_add_eq_succ_add (n m) : succ n + m = n + succ m := by
   simp [succ_add, add_succ]
@@ -173,12 +170,13 @@ protected theorem add_le_add_iff_left (k n m : Nat) : k + n ≤ k + m ↔ n ≤ 
 protected theorem add_le_add_iff_right (k n m : Nat) : n + k ≤ m + k ↔ n ≤ m :=
   ⟨Nat.le_of_add_le_add_right, fun h => Nat.add_le_add_right h _⟩
 
-protected theorem lt_of_add_lt_add_left {k n m : Nat} (h : k + n < k + m) : n < m :=
-  Nat.lt_of_le_of_ne (Nat.le_of_add_le_add_left (Nat.le_of_lt h)) fun heq =>
-    Nat.lt_irrefl (k + m) <| by rwa [heq] at h
+protected theorem lt_of_add_lt_add_right : ∀ {m : Nat}, k + m < n + m → k < n
+  | 0, h => h
+  | _+1, h => Nat.lt_of_add_lt_add_right (Nat.lt_of_succ_lt_succ h)
 
-protected theorem lt_of_add_lt_add_right {a b c : Nat} (h : a + b < c + b) : a < c :=
-  Nat.lt_of_add_lt_add_left ((by rwa [Nat.add_comm b a, Nat.add_comm b c]): b + a < b + c)
+protected theorem lt_of_add_lt_add_left {k n m : Nat} : k + n < k + m → n < m := by
+  repeat rw [Nat.add_comm k]
+  exact Nat.lt_of_add_lt_add_right
 
 protected theorem add_lt_add_iff_left (k n m : Nat) : k + n < k + m ↔ n < m :=
   ⟨Nat.lt_of_add_lt_add_left, fun h => Nat.add_lt_add_left h _⟩
@@ -187,19 +185,19 @@ protected theorem add_lt_add_iff_right (k n m : Nat) : n + k < m + k ↔ n < m :
   ⟨Nat.lt_of_add_lt_add_right, fun h => Nat.add_lt_add_right h _⟩
 
 protected theorem lt_add_right (a b c : Nat) (h : a < b) : a < b + c :=
-  Nat.lt_of_lt_of_le h (Nat.le_add_right _ _)
+  Nat.lt_of_lt_of_le h (Nat.le_add_right ..)
 
 protected theorem lt_add_of_pos_right (h : 0 < k) : n < n + k :=
   Nat.add_lt_add_left h n
 
-protected theorem lt_add_of_pos_left (h : 0 < k) : n < k + n := by
-  rw [Nat.add_comm]; exact Nat.lt_add_of_pos_right h
+protected theorem lt_add_of_pos_left : 0 < k → n < k + n := by
+  rw [Nat.add_comm]; exact Nat.lt_add_of_pos_right
 
 protected theorem pos_of_lt_add_right (h : n < n + k) : 0 < k :=
   Nat.lt_of_add_lt_add_left h
 
-protected theorem pos_of_lt_add_left (h : n < k + n) : 0 < k :=
-  Nat.lt_of_add_lt_add_right (by rw [Nat.zero_add]; exact h)
+protected theorem pos_of_lt_add_left : n < k + n → 0 < k := by
+  rw [Nat.add_comm]; exact Nat.pos_of_lt_add_right
 
 protected theorem lt_add_right_iff_pos : n < n + k ↔ 0 < k :=
   ⟨Nat.pos_of_lt_add_right, Nat.lt_add_of_pos_right⟩
@@ -207,17 +205,14 @@ protected theorem lt_add_right_iff_pos : n < n + k ↔ 0 < k :=
 protected theorem lt_add_left_iff_pos : n < k + n ↔ 0 < k :=
   ⟨Nat.pos_of_lt_add_left, Nat.lt_add_of_pos_left⟩
 
-theorem add_pos_left (h : 0 < m) (n) : 0 < m + n :=
-  Nat.lt_of_le_of_lt (zero_le n) (Nat.lt_add_of_pos_left h)
+protected theorem add_pos_left (h : 0 < m) (n) : 0 < m + n :=
+  Nat.lt_of_lt_of_le h (Nat.le_add_right ..)
 
-theorem add_pos_right (m) (h : 0 < n) : 0 < m + n := by
-  rw [Nat.add_comm]
-  exact add_pos_left h m
+protected theorem add_pos_right (m) (h : 0 < n) : 0 < m + n :=
+  Nat.lt_of_lt_of_le h (Nat.le_add_left ..)
 
 protected theorem add_self_ne_one : ∀ n, n + n ≠ 1
-  | n+1, h =>
-    have h1 : succ (succ (n + n)) = 1 := succ_add n n ▸ h
-    Nat.noConfusion h1 fun.
+  | n+1, h => by rw [Nat.succ_add, Nat.succ_inj'] at h; contradiction
 
 /-! ### sub -/
 

--- a/Std/Data/RBMap/Lemmas.lean
+++ b/Std/Data/RBMap/Lemmas.lean
@@ -66,8 +66,8 @@ theorem depthUB_le_two_depthLB : ∀ c n, depthUB c n ≤ 2 * depthLB c n
 
 theorem Balanced.depth_le : @Balanced α t c n → t.depth ≤ depthUB c n
   | .nil => Nat.le_refl _
-  | .red hl hr => Nat.succ_le_succ <| Nat.max_le.2 ⟨hl.depth_le, hr.depth_le⟩
-  | .black hl hr => Nat.succ_le_succ <| Nat.max_le.2
+  | .red hl hr => Nat.succ_le_succ <| Nat.max_le_iff.2 ⟨hl.depth_le, hr.depth_le⟩
+  | .black hl hr => Nat.succ_le_succ <| Nat.max_le_iff.2
     ⟨Nat.le_trans hl.depth_le (depthUB_le ..), Nat.le_trans hr.depth_le (depthUB_le ..)⟩
 
 theorem Balanced.le_size : @Balanced α t c n → 2 ^ depthLB c n ≤ t.size + 1

--- a/Std/Data/String/Lemmas.lean
+++ b/Std/Data/String/Lemmas.lean
@@ -448,7 +448,7 @@ theorem extract_of_valid (l m r : List Char) :
     extract ⟨l ++ m ++ r⟩ ⟨utf8Len l⟩ ⟨utf8Len l + utf8Len m⟩ = ⟨m⟩ := by
   simp only [extract]
   split
-  · next h => rw [utf8Len_eq_zero.1 <| Nat.le_zero.1 <| (Nat.add_le_add_iff_left _ _ 0).1 h]
+  · next h => rw [utf8Len_eq_zero.1 <| Nat.le_zero.1 <| Nat.add_le_add_iff_left.1 h]
   · congr; rw [List.append_assoc, extract.go₁_append_right _ _ _ _ _ (by rfl)]
     apply extract.go₂_append_left; apply Nat.add_comm
 
@@ -567,7 +567,7 @@ theorem prev_nil : ∀ {it}, ValidFor [] r it → ValidFor [] r it.prev
 theorem atEnd : ∀ {it}, ValidFor l r it → (it.atEnd ↔ r = [])
   | it, h => by
     simp [Iterator.atEnd, h.pos, h.toString]
-    exact (Nat.add_le_add_iff_left _ _ 0).trans <| Nat.le_zero.trans utf8Len_eq_zero
+    exact Nat.add_le_add_iff_left.trans <| Nat.le_zero.trans utf8Len_eq_zero
 
 theorem hasNext : ∀ {it}, ValidFor l r it → (it.hasNext ↔ r ≠ [])
   | it, h => by simp [Iterator.hasNext, ← h.atEnd, Iterator.atEnd]
@@ -911,7 +911,7 @@ theorem extract : ∀ {s}, ValidFor l m r s → ValidFor ml mm mr ⟨⟨m⟩, b,
   | _, ⟨⟩, ⟨⟩ => by
     simp [Substring.extract]; split
     · next h =>
-      rw [utf8Len_eq_zero.1 <| Nat.le_zero.1 <| (Nat.add_le_add_iff_left _ _ 0).1 h]
+      rw [utf8Len_eq_zero.1 <| Nat.le_zero.1 <| Nat.add_le_add_iff_left.1 h]
       exact ⟨[], [], ⟨⟩⟩
     · next h =>
       refine ⟨l ++ ml, mr ++ r, .of_eq _ (by simp) ?_ ?_⟩ <;>

--- a/Std/Data/String/Lemmas.lean
+++ b/Std/Data/String/Lemmas.lean
@@ -365,7 +365,7 @@ theorem firstDiffPos_loop_eq (l₁ l₂ r₁ r₂ stop p)
     rw [
       dif_pos <| by
         rw [hstop, ← hl₁, ← hl₂]
-        refine Nat.lt_min.2 ⟨?_, ?_⟩ <;> exact Nat.lt_add_of_pos_right add_csize_pos,
+        refine Nat.lt_min_iff.2 ⟨?_, ?_⟩ <;> exact Nat.lt_add_of_pos_right add_csize_pos,
       show get ⟨l₁ ++ a :: r₁⟩ ⟨p⟩ = a by simp [hl₁, get_of_valid],
       show get ⟨l₂ ++ b :: r₂⟩ ⟨p⟩ = b by simp [hl₂, get_of_valid]]
     simp [bne]; split <;> simp
@@ -375,7 +375,7 @@ theorem firstDiffPos_loop_eq (l₁ l₂ r₁ r₂ stop p)
       firstDiffPos_loop_eq (l₁ ++ [a]) (l₂ ++ [a]) r₁ r₂ stop (p + csize a)
         (by simp [hl₁]) (by simp [hl₂]) (by simp [hstop, ← Nat.add_assoc, Nat.add_right_comm])
   · next h =>
-    rw [dif_neg] <;> simp [hstop, ← hl₁, ← hl₂, -Nat.not_lt, Nat.lt_min]
+    rw [dif_neg] <;> simp [hstop, ← hl₁, ← hl₂, -Nat.not_lt, Nat.lt_min_iff]
     intro h₁ h₂
     have : ∀ {cs}, p < p + utf8Len cs → cs ≠ [] := by rintro _ h rfl; simp at h
     obtain ⟨a, as, e₁⟩ := List.exists_cons_of_ne_nil (this h₁)


### PR DESCRIPTION
Depends on #182 

Potentially breaking changes:

* Changed `Nat.mul_lt_mul` (1 use in Mathlib). See comments below.
* Made two parameters implicit in `Nat.lt_add_right` (4 uses in Mathlib)
* Made parameters implicit for `Nat.add_le_add_iff_left` (no uses in Mathlib)
* Made parameters implicit for `Nat.add_le_add_iff_right` (no uses in Mathlib)
* Made parameters implicit for `Nat.add_lt_add_iff_left` (no uses in Mathlib)
* Made parameters implicit for `Nat.add_lt_add_iff_right` (no uses in Mathlib)
* Made parameters implicit for `Nat.dvd_iff_mod_eq_zero` (16 uses in Mathlib)
* Renamed `Nat.max_le` (no uses in Mathlib) to `Nat.max_le_iff` and added new `Nat.max_le` (Mathlib conformance)
* Renamed `Nat.le_min` (no uses in Mathlib)  to `Nat.le_min_iff`  and added new `Nat.le_min` (Mathlib conformance)
* Protected `Nat.zero_le` (unknown uses in Mathlib; at least one hiding clause)
* Protected `Nat.one_pos` (unknown uses in Mathlib)
* Protected `Nat.two_pos` (no uses in Mathlib)
* Deprecated `Nat.lt_min` (no uses in Mathlib)
* Deprecated `Nat.add_le_to_le_sub` (no uses in Mathlib)
* Deprecated `Nat.succ_add_eq_succ_add` (4 uses in Mathlib)
* Deprecated `Nat.mul_le_mul_of_nonneg_left` (4 uses in Mathlib)
* Deprecated `Nat.mul_le_mul_of_nonneg_right` (3 uses in Mathlib)
* Deprecated `Nat.mul_lt_mul'` (2 uses in Mathlib)
* Deprecated `Nat.zero_max` (1 use in Mathlib)
* Deprecated `Nat.zero_min` (no uses in Mathlib)
* Deprecated `Nat.max_zero` (no uses in Mathlib)
* Deprecated `Nat.min_zero` (no uses in Mathlib)

Deprecated lemmas all have recommended replacements.
