### PR TITLE
feat: more order lemmas for `Nat`

### DIFF
--- a/Std/Data/Array/Init/Lemmas.lean
+++ b/Std/Data/Array/Init/Lemmas.lean
@@ -235,7 +235,7 @@ theorem anyM_eq_anyM_loop [Monad m] (p : α → m Bool) (as : Array α) (start s
 
 theorem anyM_stop_le_start [Monad m] (p : α → m Bool) (as : Array α) (start stop)
     (h : min stop as.size ≤ start) : anyM p as start stop = pure false := by
-  rw [anyM_eq_anyM_loop, anyM.loop, dif_neg (Nat.not_lt_of_le h)]
+  rw [anyM_eq_anyM_loop, anyM.loop, dif_neg (Nat.not_lt.2 h)]
 
 theorem SatisfiesM_anyM [Monad m] [LawfulMonad m] (p : α → m Bool) (as : Array α) (start stop)
     (hstart : start ≤ min stop as.size) (tru : Prop) (fal : Nat → Prop) (h0 : fal start)
@@ -285,7 +285,7 @@ theorem SatisfiesM_anyM_iff_exists [Monad m] [LawfulMonad m]
   | inr hstart =>
     rw [anyM_stop_le_start (h := hstart)]
     refine .pure ?_; simp; intro j h₁ h₂
-    cases Nat.not_lt_of_le (Nat.le_trans hstart h₁) (Nat.lt_min.2 ⟨h₂, j.2⟩)
+    cases Nat.not_lt.2 (Nat.le_trans hstart h₁) (Nat.lt_min.2 ⟨h₂, j.2⟩)
 
 theorem any_iff_exists (p : α → Bool) (as : Array α) (start stop) :
     any as p start stop ↔ ∃ i : Fin as.size, start ≤ i.1 ∧ i.1 < stop ∧ p as[i] := by

--- a/Std/Data/Nat/Init/Lemmas.lean
+++ b/Std/Data/Nat/Init/Lemmas.lean
@@ -60,10 +60,6 @@ protected theorem pow_two_pos (w : Nat) : 0 < 2^w := Nat.pos_pow_of_pos _ (by de
 @[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
   ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
 
---protected theorem not_lt_of_le {n m : Nat} (h₁ : m ≤ n) : ¬ n < m := (Nat.not_le_of_gt · h₁)
-
---protected theorem le_of_not_le {a b : Nat} : ¬ a ≤ b → b ≤ a := (Nat.le_total a b).resolve_left
-
 protected theorem le_min_of_le_of_le {a b c : Nat} : a ≤ b → a ≤ c → a ≤ min b c := by
   intros; cases Nat.le_total b c with
   | inl h => rw [Nat.min_eq_left h]; assumption

--- a/Std/Data/Nat/Init/Lemmas.lean
+++ b/Std/Data/Nat/Init/Lemmas.lean
@@ -54,9 +54,15 @@ protected theorem le_max_right (a b : Nat) : b ≤ max a b := Nat.max_comm .. �
 
 protected theorem pow_two_pos (w : Nat) : 0 < 2^w := Nat.pos_pow_of_pos _ (by decide)
 
-protected theorem not_lt_of_le {n m : Nat} (h₁ : m ≤ n) : ¬ n < m := (Nat.not_le_of_gt · h₁)
+@[simp] protected theorem not_le {a b : Nat} : ¬ a ≤ b ↔ b < a :=
+  ⟨Nat.gt_of_not_le, Nat.not_le_of_gt⟩
 
-protected theorem le_of_not_le {a b : Nat} : ¬ a ≤ b → b ≤ a := (Nat.le_total a b).resolve_left
+@[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
+  ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
+
+--protected theorem not_lt_of_le {n m : Nat} (h₁ : m ≤ n) : ¬ n < m := (Nat.not_le_of_gt · h₁)
+
+--protected theorem le_of_not_le {a b : Nat} : ¬ a ≤ b → b ≤ a := (Nat.le_total a b).resolve_left
 
 protected theorem le_min_of_le_of_le {a b c : Nat} : a ≤ b → a ≤ c → a ≤ min b c := by
   intros; cases Nat.le_total b c with

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -335,8 +335,6 @@ theorem le_pred_of_lt (h : n < m) : n ≤ pred m := (le_pred_iff_lt (Nat.zero_lt
 
 /-! ### add -/
 
-theorem add_one_ne_zero (n) : n + 1 ≠ 0 := Nat.succ_ne_zero _
-
 protected theorem eq_zero_of_add_eq_zero_right : ∀ {n m : Nat}, n + m = 0 → n = 0
   | 0,   m => by simp [Nat.zero_add]
   | n+1, m => fun h => by

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -148,13 +148,13 @@ protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :
   ⟨Nat.gt_of_not_le, Nat.not_le_of_gt⟩
 protected alias ⟨lt_of_not_ge, _⟩ := Nat.not_le
 protected alias ⟨lt_of_not_le, not_le_of_lt⟩ := Nat.not_le
-protected alias ⟨_, lt_le_antisymm⟩ := Nat.not_le
+protected alias ⟨_, lt_le_asymm⟩ := Nat.not_le
 
 @[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
   ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
 protected alias ⟨le_of_not_gt, not_lt_of_ge⟩ := Nat.not_lt
 protected alias ⟨le_of_not_lt, not_lt_of_le⟩ := Nat.not_lt
-protected alias ⟨_, le_lt_antisymm⟩ := Nat.not_lt
+protected alias ⟨_, le_lt_asymm⟩ := Nat.not_lt
 
 protected theorem le_of_not_le {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_lt (Nat.not_le.1 h)
 protected alias le_of_not_ge := Nat.le_of_not_le

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -150,29 +150,28 @@ protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :
 @[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
   ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
 
-protected theorem lt_of_not_ge {a b : Nat} : ¬ b ≤ a → a < b := Nat.not_le.1
-protected theorem lt_of_not_le {a b : Nat} : ¬ a ≤ b → b < a := Nat.not_le.1
+protected alias ⟨lt_of_not_ge, _⟩ := Nat.not_le
+protected alias ⟨lt_of_not_le, _⟩ := Nat.not_le
+protected alias ⟨_, not_le_of_lt⟩ := Nat.not_le
+protected alias ⟨_, lt_le_antisymm⟩ := Nat.not_le
 
-protected theorem le_of_not_gt {a b : Nat} : ¬ a < b → b ≤ a := Nat.not_lt.1
-protected theorem le_of_not_lt {a b : Nat} : ¬ a < b → b ≤ a := Nat.not_lt.1
-
-protected theorem not_le_of_lt {a b : Nat} : a < b → ¬ b ≤ a := Nat.not_le.2
-
-protected theorem not_lt_of_ge {a b : Nat} : a ≤ b → ¬ b < a := Nat.not_lt.2
-protected theorem not_lt_of_le {a b : Nat} : a ≤ b → ¬ b < a := Nat.not_lt.2
+protected alias ⟨le_of_not_gt, _⟩ := Nat.not_lt
+protected alias ⟨le_of_not_lt, _⟩ := Nat.not_lt
+protected alias ⟨_, not_lt_of_ge⟩ := Nat.not_lt
+protected alias ⟨_, not_lt_of_le⟩ := Nat.not_lt
+protected alias ⟨_, le_lt_antisymm⟩ := Nat.not_lt
 
 protected theorem le_of_not_ge {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_lt (Nat.not_le.1 h)
-protected theorem le_of_not_le {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_not_ge h
+protected alias le_of_not_le := Nat.le_of_not_ge
 
 protected theorem lt_asymm {a b : Nat} (h : a < b) : ¬ b < a := Nat.not_lt.2 (Nat.le_of_lt h)
-protected theorem not_lt_of_gt {a b : Nat} : a < b → ¬ b < a := Nat.lt_asymm
-protected theorem not_lt_of_lt {a b : Nat} : a < b → ¬ b < a := Nat.lt_asymm
+protected alias not_lt_of_gt := Nat.lt_asymm
+protected alias not_lt_of_lt := Nat.lt_asymm
 
 protected theorem lt_iff_le_and_not_ge {a b : Nat} : a < b ↔ a ≤ b ∧ ¬ b ≤ a :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun ⟨_, h⟩ => Nat.lt_of_not_ge h⟩
 
-protected theorem lt_iff_le_not_le {a b : Nat} : a < b ↔ a ≤ b ∧ ¬ b ≤ a :=
-  Nat.lt_iff_le_and_not_ge
+protected alias lt_iff_le_not_le := Nat.lt_iff_le_and_not_ge
 
 protected theorem lt_iff_le_and_ne {a b : Nat} : a < b ↔ a ≤ b ∧ a ≠ b :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.ne_of_lt h⟩, fun h => Nat.lt_of_le_of_ne h.1 h.2⟩
@@ -180,22 +179,22 @@ protected theorem lt_iff_le_and_ne {a b : Nat} : a < b ↔ a ≤ b ∧ a ≠ b :
 protected theorem le_antisymm_iff {a b : Nat} : a = b ↔ a ≤ b ∧ b ≤ a :=
   ⟨fun | rfl => ⟨Nat.le_refl _, Nat.le_refl _⟩, fun ⟨hle, hge⟩ => Nat.le_antisymm hle hge⟩
 
-protected theorem eq_iff_le_and_ge {a b : Nat} : a = b ↔ a ≤ b ∧ b ≤ a := Nat.le_antisymm_iff
+protected alias eq_iff_le_and_ge := Nat.le_antisymm_iff
 
 protected theorem lt_connex {a b : Nat} : a ≠ b → a < b ∨ b < a := by
   rw [←Nat.not_le, ←Nat.not_le, ←Decidable.not_and, and_comm]
   exact mt Nat.le_antisymm_iff.2
 
-protected theorem lt_or_gt_of_ne {a b : Nat} : a ≠ b → a < b ∨ b < a := Nat.lt_connex
-protected theorem lt_or_lt_of_ne {a b : Nat} : a ≠ b → a < b ∨ b < a := Nat.lt_connex
+protected alias lt_or_gt_of_ne := Nat.lt_connex
+protected alias lt_or_lt_of_ne := Nat.lt_connex
 
 protected theorem lt_connex_iff {a b : Nat} : a ≠ b ↔ a < b ∨ b < a :=
   ⟨Nat.lt_connex, fun | .inl h => Nat.ne_of_lt h | .inr h => Nat.ne_of_gt h⟩
 
-protected theorem ne_iff_lt_or_gt {a b : Nat} : a ≠ b ↔ a < b ∨ b < a := Nat.lt_connex_iff
+protected alias ne_iff_lt_or_gt := Nat.lt_connex_iff
 
-protected theorem le_or_ge (a b : Nat) : a ≤ b ∨ b ≤ a := Nat.le_total ..
-protected theorem le_or_le (a b : Nat) : a ≤ b ∨ b ≤ a := Nat.le_total ..
+protected alias le_or_ge := Nat.le_total
+protected alias le_or_le := Nat.le_total
 
 protected theorem lt_trichotomy (a b : Nat) : a < b ∨ a = b ∨ b < a :=
   if h : a = b then .inr (.inl h) else
@@ -211,9 +210,6 @@ protected theorem lt_or_eq_of_le {n m : Nat} (h : n ≤ m) : n < m ∨ n = m :=
 
 protected theorem le_iff_lt_or_eq {n m : Nat} : n ≤ m ↔ n < m ∨ n = m :=
   ⟨Nat.lt_or_eq_of_le, fun | .inl h => Nat.le_of_lt h | .inr rfl => Nat.le_refl _⟩
-
-theorem le_lt_antisymm {n m : Nat} : n ≤ m → m < n → False := Nat.not_lt.2
-theorem lt_le_antisymm {n m : Nat} : n < m → m ≤ n → False := Nat.not_le.2
 
 /-! ## compare -/
 

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -135,6 +135,7 @@ theorem recDiagOn_succ_succ {motive : Nat → Nat → Sort _} (zero_zero : motiv
 /-! ### le/lt -/
 
 theorem ne_of_gt {a b : Nat} (h : b < a) : a ≠ b := (ne_of_lt h).symm
+theorem ne_of_lt' {a b : Nat} (h : b < a) : a ≠ b := Nat.ne_of_gt h
 
 protected theorem lt_iff_le_not_le {m n : Nat} : m < n ↔ m ≤ n ∧ ¬ n ≤ m :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun h => Nat.gt_of_not_le h.2⟩
@@ -149,14 +150,137 @@ protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :
 @[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
   ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
 
-theorem le_lt_antisymm {n m : Nat} (h₁ : n ≤ m) (h₂ : m < n) : False :=
-  Nat.lt_irrefl n (Nat.lt_of_le_of_lt h₁ h₂)
+protected theorem lt_of_not_ge {a b : Nat} : ¬ b ≤ a → a < b := Nat.not_le.1
+protected theorem lt_of_not_le {a b : Nat} : ¬ a ≤ b → b < a := Nat.not_le.1
 
-theorem lt_le_antisymm {n m : Nat} (h₁ : n < m) (h₂ : m ≤ n) : False :=
-  le_lt_antisymm h₂ h₁
+protected theorem le_of_not_gt {a b : Nat} : ¬ a < b → b ≤ a := Nat.not_lt.1
+protected theorem le_of_not_lt {a b : Nat} : ¬ a < b → b ≤ a := Nat.not_lt.1
 
-protected theorem lt_asymm {n m : Nat} (h₁ : n < m) : ¬ m < n :=
-  le_lt_antisymm (Nat.le_of_lt h₁)
+protected theorem not_le_of_lt {a b : Nat} : a < b → ¬ b ≤ a := Nat.not_le.2
+
+protected theorem not_lt_of_ge {a b : Nat} : a ≤ b → ¬ b < a := Nat.not_lt.2
+protected theorem not_lt_of_le {a b : Nat} : a ≤ b → ¬ b < a := Nat.not_lt.2
+
+protected theorem le_of_not_ge {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_lt (Nat.not_le.1 h)
+protected theorem le_of_not_le {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_not_ge h
+
+protected theorem lt_asymm {a b : Nat} (h : a < b) : ¬ b < a := Nat.not_lt.2 (Nat.le_of_lt h)
+protected theorem not_lt_of_gt {a b : Nat} : a < b → ¬ b < a := Nat.lt_asymm
+protected theorem not_lt_of_lt {a b : Nat} : a < b → ¬ b < a := Nat.lt_asymm
+
+protected theorem lt_iff_le_and_not_ge {a b : Nat} : a < b ↔ a ≤ b ∧ ¬ b ≤ a :=
+  ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun ⟨_, h⟩ => Nat.lt_of_not_ge h⟩
+
+protected theorem lt_iff_le_not_le {a b : Nat} : a < b ↔ a ≤ b ∧ ¬ b ≤ a :=
+  Nat.lt_iff_le_and_not_ge
+
+protected theorem lt_iff_le_and_ne {a b : Nat} : a < b ↔ a ≤ b ∧ a ≠ b :=
+  ⟨fun h => ⟨Nat.le_of_lt h, Nat.ne_of_lt h⟩, fun h => Nat.lt_of_le_of_ne h.1 h.2⟩
+
+protected theorem le_antisymm_iff {a b : Nat} : a = b ↔ a ≤ b ∧ b ≤ a :=
+  ⟨fun | rfl => ⟨Nat.le_refl _, Nat.le_refl _⟩, fun ⟨hle, hge⟩ => Nat.le_antisymm hle hge⟩
+
+protected theorem eq_iff_le_and_ge {a b : Nat} : a = b ↔ a ≤ b ∧ b ≤ a := Nat.le_antisymm_iff
+
+protected theorem lt_connex {a b : Nat} : a ≠ b → a < b ∨ b < a := by
+  rw [←Nat.not_le, ←Nat.not_le, ←Decidable.not_and, and_comm]
+  exact mt Nat.le_antisymm_iff.2
+
+protected theorem lt_or_gt_of_ne {a b : Nat} : a ≠ b → a < b ∨ b < a := Nat.lt_connex
+protected theorem lt_or_lt_of_ne {a b : Nat} : a ≠ b → a < b ∨ b < a := Nat.lt_connex
+
+protected theorem lt_connex_iff {a b : Nat} : a ≠ b ↔ a < b ∨ b < a :=
+  ⟨Nat.lt_connex, fun | .inl h => Nat.ne_of_lt h | .inr h => Nat.ne_of_gt h⟩
+
+protected theorem ne_iff_lt_or_gt {a b : Nat} : a ≠ b ↔ a < b ∨ b < a := Nat.lt_connex_iff
+
+protected theorem le_or_ge (a b : Nat) : a ≤ b ∨ b ≤ a := Nat.le_total ..
+protected theorem le_or_le (a b : Nat) : a ≤ b ∨ b ≤ a := Nat.le_total ..
+
+protected theorem lt_trichotomy (a b : Nat) : a < b ∨ a = b ∨ b < a :=
+  if h : a = b then .inr (.inl h) else
+    match Nat.lt_connex h with
+    | .inl h => .inl h
+    | .inr h => .inr (.inr h)
+
+protected theorem eq_or_lt_of_not_lt {a b : Nat} (hnlt : ¬ a < b) : a = b ∨ b < a :=
+  (Nat.lt_trichotomy ..).resolve_left hnlt
+
+protected theorem lt_or_eq_of_le {n m : Nat} (h : n ≤ m) : n < m ∨ n = m :=
+  (Nat.lt_or_ge ..).imp_right (Nat.le_antisymm h)
+
+protected theorem le_iff_lt_or_eq {n m : Nat} : n ≤ m ↔ n < m ∨ n = m :=
+  ⟨Nat.lt_or_eq_of_le, fun | .inl h => Nat.le_of_lt h | .inr rfl => Nat.le_refl _⟩
+
+theorem le_lt_antisymm {n m : Nat} : n ≤ m → m < n → False := Nat.not_lt.2
+theorem lt_le_antisymm {n m : Nat} : n < m → m ≤ n → False := Nat.not_le.2
+
+/-! ## compare -/
+
+theorem compare_def_lt (a b : Nat) :
+    compare a b = if a < b then .lt else if b < a then .gt else .eq := by
+  simp only [compare, compareOfLessAndEq]
+  split
+  next => rfl
+  next h =>
+    match Nat.lt_or_eq_of_le (Nat.not_lt.1 h) with
+    | .inl h => simp [h, Nat.ne_of_gt h]
+    | .inr rfl => simp
+
+theorem compare_def_le (a b : Nat) :
+    compare a b = if a ≤ b then if b ≤ a then .eq else .lt else .gt := by
+  rw [compare_def_lt]
+  split
+  next hlt => simp [Nat.le_of_lt hlt, Nat.not_le.2 hlt]
+  next hge =>
+    split
+    next hgt => simp [Nat.le_of_lt hgt, Nat.not_le.2 hgt]
+    next hle => simp [Nat.not_lt.1 hge, Nat.not_lt.1 hle]
+
+protected theorem compare_swap_symm (a b : Nat) : (compare a b).swap = compare b a := by
+  simp only [compare_def_le]
+  split
+  next h => split <;> next h' => simp [h, h']
+  next h =>
+    split
+    next h' => simp [h, h']
+    next h' => cases Nat.le_total a b <;> contradiction
+
+protected theorem eq_iff_compare_eq_eq {a b : Nat} : a = b ↔ compare a b = .eq := by
+  rw [compare_def_lt]
+  constructor
+  · intro | rfl => simp
+  · intro h
+    split at h
+    next => contradiction
+    next hlt =>
+      split at h
+      next => contradiction
+      next hgt => exact Nat.le_antisymm (Nat.not_lt.1 hgt) (Nat.not_lt.1 hlt)
+
+protected theorem lt_iff_compare_eq_lt {a b : Nat} : a < b ↔ compare a b = .lt := by
+  rw [compare_def_lt]
+  split
+  next h => simp [h]
+  next h => split <;> simp [h]
+
+protected theorem gt_iff_compare_eq_gt {a b : Nat} : b < a ↔ compare a b = .gt := by
+  rw [compare_def_lt]
+  split
+  next h => simp [Nat.le_of_lt h]
+  next h => split <;> next h' => simp [h, h']
+
+protected theorem le_iff_compare_ne_gt {a b : Nat} : a ≤ b ↔ compare a b ≠ .gt := by
+  rw [compare_def_le]
+  split
+  next h => split <;> simp [h]
+  next h => simp [h]
+
+protected theorem ge_iff_compare_ne_lt {a b : Nat} : b ≤ a ↔ compare a b ≠ .lt := by
+  rw [compare_def_le]
+  split
+  next h => split <;> next h' => simp [h, h']
+  next h => simp [Nat.le_of_lt (Nat.not_le.1 h)]
 
 /-- Strong case analysis on `a < b ∨ b ≤ a` -/
 protected def lt_sum_ge (a b : Nat) : a < b ⊕' b ≤ a :=
@@ -164,53 +288,29 @@ protected def lt_sum_ge (a b : Nat) : a < b ⊕' b ≤ a :=
 
 /-- Strong case analysis on `a < b ∨ a = b ∨ b < a` -/
 protected def sum_trichotomy (a b : Nat) : a < b ⊕' a = b ⊕' b < a :=
-  match a.lt_sum_ge b with
-  | .inl h => .inl h
-  | .inr h₂ => match b.lt_sum_ge a with
-    | .inl h => .inr <| .inr h
-    | .inr h₁ => .inr <| .inl <| Nat.le_antisymm h₁ h₂
-
-protected theorem lt_trichotomy (a b : Nat) : a < b ∨ a = b ∨ b < a :=
-  match a.sum_trichotomy b with
-  | .inl h => .inl h
-  | .inr (.inl h) => .inr (.inl h)
-  | .inr (.inr h) => .inr (.inr h)
-
-protected theorem eq_or_lt_of_not_lt {a b : Nat} (hnlt : ¬ a < b) : a = b ∨ b < a :=
-  (Nat.lt_trichotomy a b).resolve_left hnlt
-
-protected theorem not_le_of_lt {n m : Nat} : m < n → ¬ n ≤ m := Nat.not_le_of_gt
-
-protected theorem lt_of_not_le {a b : Nat} : ¬ a ≤ b → b < a := (Nat.lt_or_ge b a).resolve_right
-
-protected theorem le_of_not_lt {a b : Nat} : ¬ a < b → b ≤ a := (Nat.lt_or_ge a b).resolve_left
-
-protected theorem le_or_le (a b : Nat) : a ≤ b ∨ b ≤ a := (Nat.lt_or_ge _ _).imp_left Nat.le_of_lt
-
-protected theorem lt_or_eq_of_le {n m : Nat} (h : n ≤ m) : n < m ∨ n = m :=
-  (Nat.lt_or_ge _ _).imp_right (Nat.le_antisymm h)
-
-protected theorem le_iff_lt_or_eq {n m : Nat} : n ≤ m ↔ n < m ∨ n = m :=
-  ⟨Nat.lt_or_eq_of_le, (·.elim Nat.le_of_lt Nat.le_of_eq)⟩
-
-protected theorem le_antisymm_iff {n m : Nat} : n = m ↔ n ≤ m ∧ m ≤ n :=
-  ⟨fun h => ⟨Nat.le_of_eq h, Nat.le_of_eq h.symm⟩, fun ⟨h₁, h₂⟩ => Nat.le_antisymm h₁ h₂⟩
+  match h : compare a b with
+  | .lt => .inl (Nat.lt_iff_compare_eq_lt.2 h)
+  | .eq => .inr (.inl (Nat.eq_iff_compare_eq_eq.2 h))
+  | .gt => .inr (.inr (Nat.gt_iff_compare_eq_gt.2 h))
 
 /-! ## zero/one/two -/
 
-protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 := ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
+protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 :=
+  ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
+
+theorem le_zero : i ≤ 0 ↔ i = 0 := ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
+
+protected theorem one_pos : 0 < 1 := Nat.zero_lt_one
+
+protected theorem two_pos : 0 < 2 := Nat.zero_lt_succ _
+
+theorem add_one_ne_zero (n) : n + 1 ≠ 0 := succ_ne_zero _
 
 protected theorem ne_zero_iff_zero_lt : n ≠ 0 ↔ 0 < n := Nat.pos_iff_ne_zero.symm
-
-protected theorem le_zero : i ≤ 0 ↔ i = 0 := ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
 
 protected theorem zero_lt_two : 0 < 2 := Nat.zero_lt_succ _
 
 protected theorem one_lt_two : 1 < 2 := Nat.succ_lt_succ Nat.zero_lt_one
-
-protected theorem one_pos : 0 < 1 := Nat.zero_lt_one
-
-protected theorem two_pos : 0 < 2 := Nat.zero_lt_two
 
 protected theorem eq_zero_of_not_pos (h : ¬0 < n) : n = 0 :=
   Nat.eq_zero_of_le_zero (Nat.not_lt.1 h)

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -135,7 +135,7 @@ theorem recDiagOn_succ_succ {motive : Nat → Nat → Sort _} (zero_zero : motiv
 /-! ### le/lt -/
 
 theorem ne_of_gt {a b : Nat} (h : b < a) : a ≠ b := (ne_of_lt h).symm
-theorem ne_of_lt' {a b : Nat} (h : b < a) : a ≠ b := Nat.ne_of_gt h
+alias ne_of_lt' := ne_of_gt
 
 protected theorem lt_iff_le_not_le {m n : Nat} : m < n ↔ m ≤ n ∧ ¬ n ≤ m :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun h => Nat.gt_of_not_le h.2⟩
@@ -224,29 +224,24 @@ theorem compare_def_le (a b : Nat) :
     · next hgt => simp [Nat.le_of_lt hgt, Nat.not_le.2 hgt]
     · next hle => simp [Nat.not_lt.1 hge, Nat.not_lt.1 hle]
 
-protected theorem compare_swap_symm (a b : Nat) : (compare a b).swap = compare b a := by
-  simp only [compare_def_le]
-  (repeat' split) <;> try rfl
+protected theorem compare_swap (a b : Nat) : (compare a b).swap = compare b a := by
+  simp only [compare_def_le]; (repeat' split) <;> try rfl
   next h1 h2 => cases h1 (Nat.le_of_not_le h2)
 
-protected theorem eq_iff_compare_eq_eq {a b : Nat} : a = b ↔ compare a b = .eq := by
-  rw [compare_def_lt]
-  constructor
-  · intro | rfl => simp
-  · intro h
-    (repeat' split at h) <;> try contradiction
-    next hlt hgt => exact Nat.le_antisymm (Nat.not_lt.1 hgt) (Nat.not_lt.1 hlt)
+protected theorem compare_eq_eq {a b : Nat} : compare a b = .eq ↔ a = b := by
+  rw [compare_def_lt]; (repeat' split) <;> simp [Nat.ne_of_lt, Nat.ne_of_gt, *]
+  next hlt hgt => exact Nat.le_antisymm (Nat.not_lt.1 hgt) (Nat.not_lt.1 hlt)
 
-protected theorem lt_iff_compare_eq_lt {a b : Nat} : a < b ↔ compare a b = .lt := by
+protected theorem compare_eq_lt {a b : Nat} : compare a b = .lt ↔ a < b := by
   rw [compare_def_lt]; (repeat' split) <;> simp [*]
 
-protected theorem gt_iff_compare_eq_gt {a b : Nat} : b < a ↔ compare a b = .gt := by
+protected theorem compare_eq_gt {a b : Nat} : compare a b = .gt ↔ b < a := by
   rw [compare_def_lt]; (repeat' split) <;> simp [Nat.le_of_lt, *]
 
-protected theorem le_iff_compare_ne_gt {a b : Nat} : a ≤ b ↔ compare a b ≠ .gt := by
+protected theorem compare_ne_gt {a b : Nat} : compare a b ≠ .gt ↔ a ≤ b := by
   rw [compare_def_le]; (repeat' split) <;> simp [*]
 
-protected theorem ge_iff_compare_ne_lt {a b : Nat} : b ≤ a ↔ compare a b ≠ .lt := by
+protected theorem compare_ne_lt {a b : Nat} : compare a b ≠ .lt ↔ b ≤ a := by
   rw [compare_def_le]; (repeat' split) <;> simp [Nat.le_of_not_le, *]
 
 /-- Strong case analysis on `a < b ∨ b ≤ a` -/
@@ -256,9 +251,9 @@ protected def lt_sum_ge (a b : Nat) : a < b ⊕' b ≤ a :=
 /-- Strong case analysis on `a < b ∨ a = b ∨ b < a` -/
 protected def sum_trichotomy (a b : Nat) : a < b ⊕' a = b ⊕' b < a :=
   match h : compare a b with
-  | .lt => .inl (Nat.lt_iff_compare_eq_lt.2 h)
-  | .eq => .inr (.inl (Nat.eq_iff_compare_eq_eq.2 h))
-  | .gt => .inr (.inr (Nat.gt_iff_compare_eq_gt.2 h))
+  | .lt => .inl (Nat.compare_eq_lt.1 h)
+  | .eq => .inr (.inl (Nat.compare_eq_eq.1 h))
+  | .gt => .inr (.inr (Nat.compare_eq_gt.1 h))
 
 /-! ## zero/one/two -/
 

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -146,23 +146,18 @@ protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :
 
 @[simp] protected theorem not_le {a b : Nat} : ¬ a ≤ b ↔ b < a :=
   ⟨Nat.gt_of_not_le, Nat.not_le_of_gt⟩
+protected alias ⟨lt_of_not_ge, _⟩ := Nat.not_le
+protected alias ⟨lt_of_not_le, not_le_of_lt⟩ := Nat.not_le
+protected alias ⟨_, lt_le_antisymm⟩ := Nat.not_le
 
 @[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
   ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
-
-protected alias ⟨lt_of_not_ge, _⟩ := Nat.not_le
-protected alias ⟨lt_of_not_le, _⟩ := Nat.not_le
-protected alias ⟨_, not_le_of_lt⟩ := Nat.not_le
-protected alias ⟨_, lt_le_antisymm⟩ := Nat.not_le
-
-protected alias ⟨le_of_not_gt, _⟩ := Nat.not_lt
-protected alias ⟨le_of_not_lt, _⟩ := Nat.not_lt
-protected alias ⟨_, not_lt_of_ge⟩ := Nat.not_lt
-protected alias ⟨_, not_lt_of_le⟩ := Nat.not_lt
+protected alias ⟨le_of_not_gt, not_lt_of_ge⟩ := Nat.not_lt
+protected alias ⟨le_of_not_lt, not_lt_of_le⟩ := Nat.not_lt
 protected alias ⟨_, le_lt_antisymm⟩ := Nat.not_lt
 
-protected theorem le_of_not_ge {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_lt (Nat.not_le.1 h)
-protected alias le_of_not_le := Nat.le_of_not_ge
+protected theorem le_of_not_le {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_lt (Nat.not_le.1 h)
+protected alias le_of_not_ge := Nat.le_of_not_le
 
 protected theorem lt_asymm {a b : Nat} (h : a < b) : ¬ b < a := Nat.not_lt.2 (Nat.le_of_lt h)
 protected alias not_lt_of_gt := Nat.lt_asymm

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -181,24 +181,21 @@ protected theorem le_antisymm_iff {a b : Nat} : a = b ↔ a ≤ b ∧ b ≤ a :=
 
 protected alias eq_iff_le_and_ge := Nat.le_antisymm_iff
 
-protected theorem lt_connex {a b : Nat} : a ≠ b → a < b ∨ b < a := by
+protected theorem lt_or_gt_of_ne {a b : Nat} : a ≠ b → a < b ∨ b < a := by
   rw [←Nat.not_le, ←Nat.not_le, ←Decidable.not_and, and_comm]
   exact mt Nat.le_antisymm_iff.2
 
-protected alias lt_or_gt_of_ne := Nat.lt_connex
-protected alias lt_or_lt_of_ne := Nat.lt_connex
+protected theorem lt_or_gt_iff_ne {a b : Nat} : a ≠ b ↔ a < b ∨ b < a :=
+  ⟨Nat.lt_or_gt_of_ne, fun | .inl h => Nat.ne_of_lt h | .inr h => Nat.ne_of_gt h⟩
 
-protected theorem lt_connex_iff {a b : Nat} : a ≠ b ↔ a < b ∨ b < a :=
-  ⟨Nat.lt_connex, fun | .inl h => Nat.ne_of_lt h | .inr h => Nat.ne_of_gt h⟩
-
-protected alias ne_iff_lt_or_gt := Nat.lt_connex_iff
+protected alias ne_iff_lt_or_gt := Nat.lt_or_gt_iff_ne
 
 protected alias le_or_ge := Nat.le_total
 protected alias le_or_le := Nat.le_total
 
 protected theorem lt_trichotomy (a b : Nat) : a < b ∨ a = b ∨ b < a :=
   if h : a = b then .inr (.inl h) else
-    match Nat.lt_connex h with
+    match Nat.lt_or_gt_of_ne h with
     | .inl h => .inl h
     | .inr h => .inr (.inr h)
 
@@ -1237,3 +1234,9 @@ theorem shiftRight_eq_div_pow (m : Nat) : ∀ n, m >>> n = m / 2 ^ n
   | k + 1 => by
     rw [shiftRight_add, shiftRight_eq_div_pow m k]
     simp [Nat.div_div_eq_div_mul, ← Nat.pow_succ]
+
+/-! ## deprecated -/
+
+@[deprecated] protected alias lt_or_lt_of_ne := Nat.lt_or_gt_of_ne
+
+@[deprecated] protected alias lt_connex := Nat.lt_or_gt_of_ne

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -8,6 +8,7 @@ import Std.Tactic.Basic
 import Std.Tactic.Alias
 import Std.Data.Nat.Init.Lemmas
 import Std.Data.Nat.Basic
+import Std.Data.Ord
 
 namespace Nat
 
@@ -137,21 +138,10 @@ theorem recDiagOn_succ_succ {motive : Nat → Nat → Sort _} (zero_zero : motiv
 theorem ne_of_gt {a b : Nat} (h : b < a) : a ≠ b := (ne_of_lt h).symm
 alias ne_of_lt' := ne_of_gt
 
-protected theorem lt_iff_le_not_le {m n : Nat} : m < n ↔ m ≤ n ∧ ¬ n ≤ m :=
-  ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun h => Nat.gt_of_not_le h.2⟩
-
-protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :=
-  Nat.lt_iff_le_not_le.trans (and_congr_right fun h =>
-    not_congr ⟨Nat.le_antisymm h, fun e => e ▸ Nat.le_refl _⟩)
-
-@[simp] protected theorem not_le {a b : Nat} : ¬ a ≤ b ↔ b < a :=
-  ⟨Nat.gt_of_not_le, Nat.not_le_of_gt⟩
 protected alias ⟨lt_of_not_ge, _⟩ := Nat.not_le
 protected alias ⟨lt_of_not_le, not_le_of_lt⟩ := Nat.not_le
 protected alias ⟨_, lt_le_asymm⟩ := Nat.not_le
 
-@[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
-  ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
 protected alias ⟨le_of_not_gt, not_lt_of_ge⟩ := Nat.not_lt
 protected alias ⟨le_of_not_lt, not_lt_of_le⟩ := Nat.not_lt
 protected alias ⟨_, le_lt_asymm⟩ := Nat.not_lt
@@ -163,11 +153,11 @@ protected theorem lt_asymm {a b : Nat} (h : a < b) : ¬ b < a := Nat.not_lt.2 (N
 protected alias not_lt_of_gt := Nat.lt_asymm
 protected alias not_lt_of_lt := Nat.lt_asymm
 
-protected theorem lt_iff_le_not_le {a b : Nat} : a < b ↔ a ≤ b ∧ ¬ b ≤ a :=
+protected theorem lt_iff_le_not_le {m n : Nat} : m < n ↔ m ≤ n ∧ ¬ n ≤ m :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.not_le_of_gt h⟩, fun ⟨_, h⟩ => Nat.lt_of_not_ge h⟩
 protected alias lt_iff_le_and_not_ge := Nat.lt_iff_le_not_le
 
-protected theorem lt_iff_le_and_ne {a b : Nat} : a < b ↔ a ≤ b ∧ a ≠ b :=
+protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.ne_of_lt h⟩, fun h => Nat.lt_of_le_of_ne h.1 h.2⟩
 
 protected theorem le_antisymm_iff {a b : Nat} : a = b ↔ a ≤ b ∧ b ≤ a :=


### PR DESCRIPTION
- [x] Mathlib patch: https://github.com/leanprover-community/mathlib4/pull/8077

There are lots and lots of synonyms here! I didn't remove any but I did try to group them together.