### PR TITLE
New conv tactic: equals

### DIFF
--- a/Std/Tactic/Basic.lean
+++ b/Std/Tactic/Basic.lean
@@ -146,11 +146,11 @@ macro (name := Conv.exact) "exact " t:term : conv => `(conv| tactic => exact $t)
  to the given expression, and proves this claim using the given tactic.
 ```
 example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
-  conv in (_ - _) => equals 0 by
+  conv in (_ - _) => equals 0 =>
     -- current goal: ⊢ n - n = 0
     apply Nat.sub_self
   -- current goal: P (fun n => 0)
 ```
 -/
-macro (name := Conv.equals) "equals " t:term " by " tac:tacticSeq : conv =>
-  `(conv| tactic => next => show (_ = $t); ($tac))
+macro (name := Conv.equals) "equals " t:term " => " tac:tacticSeq : conv =>
+  `(conv| tactic => show (_ = $t); next => $tac)

--- a/Std/Tactic/Basic.lean
+++ b/Std/Tactic/Basic.lean
@@ -153,4 +153,4 @@ example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
 ```
 -/
 macro (name := Conv.equals) "equals " t:term " by " tac:tacticSeq : conv =>
- `(conv|tactic => show (_ = $t); ($tac) )
+  `(conv| tactic => next => show (_ = $t); ($tac))

--- a/Std/Tactic/Basic.lean
+++ b/Std/Tactic/Basic.lean
@@ -141,3 +141,16 @@ macro (name := triv) "triv" : tactic =>
 
 /-- `conv` tactic to close a goal using an equality theorem. -/
 macro (name := Conv.exact) "exact " t:term : conv => `(conv| tactic => exact $t)
+
+/-- The `conv` tactic `equals` claims that the currently focused subexpression is equal
+ to the given expression, and proves this claim using the given tactic.
+```
+example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
+  conv in (_ - _) => equals 0 by
+    -- current goal: ⊢ n - n = 0
+    apply Nat.sub_self
+  -- current goal: P (fun n => 0)
+```
+-/
+macro (name := Conv.equals) "equals " t:term " by " tac:tacticSeq : conv =>
+ `(conv|tactic => show (_ = $t); ($tac) )

--- a/test/conv_equals.lean
+++ b/test/conv_equals.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2023 Joachim Breitner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joachim Breitner
+-/
+
+import Std.Tactic.Basic
+
+
+-- The example from the doc string
+
+/-- warning: declaration uses 'sorry' -/
+example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
+  conv in (_ - _) => equals 0 =>
+    -- current goal: ⊢ n - n = 0
+    apply Nat.sub_self
+  -- current goal: P (fun n => 0)
+  sorry
+
+-- This tests that the goal created by equals must be closed
+
+/-- error: unsolved goals -/
+example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
+  conv in (_ - _) =>
+    equals 0 => skip -- this should complain
+    -- and at this point, there should be no goal left
+    tactic => sorry
+  sorry

--- a/test/conv_equals.lean
+++ b/test/conv_equals.lean
@@ -6,16 +6,20 @@ Authors: Joachim Breitner
 
 import Std.Tactic.Basic
 import Std.Tactic.GuardMsgs
+import Std.Tactic.GuardExpr
 
-
--- The example from the doc string
+-- The example from the doc string, for quick comparision
+-- and keeping the doc up-to-date
+-- (only `guard_target` added)
 
 /-- warning: declaration uses 'sorry' -/
 #guard_msgs in
 example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
   conv in (_ - _) => equals 0 =>
     -- current goal: ⊢ n - n = 0
+    guard_target =ₛ n - n = 0
     apply Nat.sub_self
+  guard_target =ₛ P (fun n => 0)
   -- current goal: P (fun n => 0)
   sorry
 

--- a/test/conv_equals.lean
+++ b/test/conv_equals.lean
@@ -5,11 +5,13 @@ Authors: Joachim Breitner
 -/
 
 import Std.Tactic.Basic
+import Std.Tactic.GuardMsgs
 
 
 -- The example from the doc string
 
 /-- warning: declaration uses 'sorry' -/
+#guard_msgs in
 example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
   conv in (_ - _) => equals 0 =>
     -- current goal: ⊢ n - n = 0
@@ -19,7 +21,18 @@ example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
 
 -- This tests that the goal created by equals must be closed
 
-/-- error: unsolved goals -/
+-- Using #guard_msgs below triggers this linter
+set_option linter.unreachableTactic false
+
+/--
+error: unsolved goals
+P : (Nat → Nat) → Prop
+n : Nat
+⊢ n - n = 0
+---
+error: no goals to be solved
+-/
+#guard_msgs in
 example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
   conv in (_ - _) =>
     equals 0 => skip -- this should complain


### PR DESCRIPTION
Given a goal `a * b`, I find myself wanting for a concise way of specifying the position of `b` (without repeating it), saying that I want to prove it to be equal to `c`, then doing the proof of `b = c`, and end up with `a = c`. Of course the terms can be larger and more deeply nested, possibly in binders.

So here is a tactic that does that.

I think it is a very natural way of interactive proving. Stare at the goal, notice a subexpression where you can make progress, focus, say what you want to rewrite it to, prove the rewriting, all with DRY.
It’s basically the less pretty; less verbose style version of a nice `calc` proof, without the repetition and the `:= by congr 3; …` before the actual proof steps.
Or the equivalent of the pen-and-paper style of putting curly braces under some subexpression to state that it’s equal to something else.

I also found it useful in a lemma dealing with series. If I try to do it with `calc` and `∑' _ = _,` then I have all the `Summable` side conditions, and have to show some transformations twice. But if I state the result using `HasSum _ _` the summability is part of the goal, and I can use this tactic to freely shuffle things under the sum, or in the value of the sum, without dealing with side conditions.

I went back and forth between `by` and `=>` (like with `tactic =>`) half a dozen times. Right now it’s using `=>`.

See discussion in https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Define.20RHS.20in.20conv.20mode/near/379304747