### PR TITLE
chore: lower simp priority for List.mem_map

### DIFF
--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -156,7 +156,7 @@ theorem mem_iff_append {a : α} {l : List α} : a ∈ l ↔ ∃ s t : List α, l
 
 theorem map_singleton (f : α → β) (a : α) : map f [a] = [f a] := rfl
 
-@[simp] theorem mem_map {f : α → β} : ∀ {l : List α}, b ∈ l.map f ↔ ∃ a, a ∈ l ∧ f a = b
+@[simp 900] theorem mem_map {f : α → β} : ∀ {l : List α}, b ∈ l.map f ↔ ∃ a, a ∈ l ∧ f a = b
   | [] => by simp
   | _ :: l => by simp [mem_map (l := l), eq_comm (a := b)]
 


### PR DESCRIPTION
This is a slightly ugly simplification, and lowering its priority allows nicer lemmas like 
```
theorem mem_map_of_injective {f : α → β} (H : Injective f) {a : α} {l : List α} :
    f a ∈ map f l ↔ a ∈ l
```
to fire first, when `Injective f` is available to the simplifier.