### PR TITLE
chore: union_def and inter_def lemmas

### DIFF
--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -424,6 +424,8 @@ will be retained (but order will otherwise be preserved).
 
 instance [DecidableEq α] : Union (List α) := ⟨List.union⟩
 
+theorem union_def [DecidableEq α] (l₁ l₂ : List α)  : l₁ ∪ l₂ = foldr .insert l₂ l₁ := rfl
+
 /--
 Constructs the intersection of two lists, by filtering the elements of `l₁` that are in `l₂`.
 Unlike `bagInter` this does not preserve multiplicity: `[1, 1].inter [1]` is `[1, 1]`.
@@ -431,6 +433,8 @@ Unlike `bagInter` this does not preserve multiplicity: `[1, 1].inter [1]` is `[1
 @[inline] protected def inter [DecidableEq α] (l₁ l₂ : List α) : List α := filter (· ∈ l₂) l₁
 
 instance [DecidableEq α] : Inter (List α) := ⟨List.inter⟩
+
+theorem inter_def [DecidableEq α] (l₁ l₂ : List α)  : l₁ ∩ l₂ = filter (· ∈ l₂) l₁ := rfl
 
 /-- `l₁ <+ l₂`, or `Sublist l₁ l₂`, says that `l₁` is a (non-contiguous) subsequence of `l₂`. -/
 inductive Sublist {α} : List α → List α → Prop

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -424,8 +424,6 @@ will be retained (but order will otherwise be preserved).
 
 instance [DecidableEq α] : Union (List α) := ⟨List.union⟩
 
-theorem union_def [DecidableEq α] (l₁ l₂ : List α)  : l₁ ∪ l₂ = foldr .insert l₂ l₁ := rfl
-
 /--
 Constructs the intersection of two lists, by filtering the elements of `l₁` that are in `l₂`.
 Unlike `bagInter` this does not preserve multiplicity: `[1, 1].inter [1]` is `[1, 1]`.
@@ -433,8 +431,6 @@ Unlike `bagInter` this does not preserve multiplicity: `[1, 1].inter [1]` is `[1
 @[inline] protected def inter [DecidableEq α] (l₁ l₂ : List α) : List α := filter (· ∈ l₂) l₁
 
 instance [DecidableEq α] : Inter (List α) := ⟨List.inter⟩
-
-theorem inter_def [DecidableEq α] (l₁ l₂ : List α)  : l₁ ∩ l₂ = filter (· ∈ l₂) l₁ := rfl
 
 /-- `l₁ <+ l₂`, or `Sublist l₁ l₂`, says that `l₁` is a (non-contiguous) subsequence of `l₂`. -/
 inductive Sublist {α} : List α → List α → Prop

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1461,21 +1461,21 @@ section union
 
 variable [DecidableEq α]
 
-@[simp] theorem nil_union (l : List α) : nil.union l = l := by simp [List.union, foldr]
+@[simp] theorem nil_union (l : List α) : nil ∪ l = l := by simp [List.union_def, foldr]
 
 @[simp] theorem cons_union (a : α) (l₁ l₂ : List α) :
-    (a :: l₁).union l₂ = (l₁.union l₂).insert a := by simp [List.union, foldr]
+    (a :: l₁) ∪ l₂ = (l₁ ∪ l₂).insert a := by simp [List.union_def, foldr]
 
 @[simp] theorem mem_union_iff [DecidableEq α] {x : α} {l₁ l₂ : List α} :
-    x ∈ l₁.union l₂ ↔ x ∈ l₁ ∨ x ∈ l₂ := by induction l₁ <;> simp [*, or_assoc]
+    x ∈ l₁ ∪ l₂ ↔ x ∈ l₁ ∨ x ∈ l₂ := by induction l₁ <;> simp [*, or_assoc]
 
 end union
 
 /-! ### inter -/
 
 @[simp] theorem mem_inter_iff [DecidableEq α] {x : α} {l₁ l₂ : List α} :
-    x ∈ l₁.inter l₂ ↔ x ∈ l₁ ∧ x ∈ l₂ := by
-  cases l₁ <;> simp [List.inter, mem_filter]
+    x ∈ l₁ ∩ l₂ ↔ x ∈ l₁ ∧ x ∈ l₂ := by
+  cases l₁ <;> simp [List.inter_def, mem_filter]
 
 /-! ### product -/
 

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1461,6 +1461,8 @@ section union
 
 variable [DecidableEq α]
 
+theorem union_def [DecidableEq α] (l₁ l₂ : List α)  : l₁ ∪ l₂ = foldr .insert l₂ l₁ := rfl
+
 @[simp] theorem nil_union (l : List α) : nil ∪ l = l := by simp [List.union_def, foldr]
 
 @[simp] theorem cons_union (a : α) (l₁ l₂ : List α) :
@@ -1472,6 +1474,8 @@ variable [DecidableEq α]
 end union
 
 /-! ### inter -/
+
+theorem inter_def [DecidableEq α] (l₁ l₂ : List α)  : l₁ ∩ l₂ = filter (· ∈ l₂) l₁ := rfl
 
 @[simp] theorem mem_inter_iff [DecidableEq α] {x : α} {l₁ l₂ : List α} :
     x ∈ l₁ ∩ l₂ ↔ x ∈ l₁ ∧ x ∈ l₂ := by


### PR DESCRIPTION
The main purpose here is to provide `union_def` and `inter_def`, so no one has to call simp with the auto-generated instance name. (Supporting https://github.com/leanprover/lean4/issues/2343.)

I've also restated the lemmas about inter and union in terms of the notation, but I'm happy to roll that part back if preferred.