### PR TITLE
feat: ignore sorries in unused argument linter

### DIFF
--- a/Std/Tactic/Lint/Misc.lean
+++ b/Std/Tactic/Lint/Misc.lean
@@ -41,6 +41,7 @@ We skip all declarations that contain `sorry` in their value. -/
     let info ← getConstInfo declName
     let ty := info.type
     let some val := info.value? | return none
+    if val.hasSorry || ty.hasSorry then return none
     forallTelescope ty fun args ty => do
       let mut e := (mkAppN val args).headBeta
       e := mkApp e ty

--- a/test/lintunused.lean
+++ b/test/lintunused.lean
@@ -1,0 +1,7 @@
+import Std.Tactic.Lint
+
+-- should be ignored as the proof contains sorry
+theorem Foo (h : 1 = 1) : True :=
+  sorry
+
+#lint- only unusedArguments


### PR DESCRIPTION
as it states in the docstring