### PR TITLE
chore: upstream MLList.whileAtLeastHeartbeatsPercent

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -35,6 +35,7 @@ import Std.Data.List.Basic
 import Std.Data.List.Init.Lemmas
 import Std.Data.List.Lemmas
 import Std.Data.MLList.Basic
+import Std.Data.MLList.Heartbeats
 import Std.Data.Nat.Basic
 import Std.Data.Nat.Gcd
 import Std.Data.Nat.Init.Lemmas
@@ -59,6 +60,7 @@ import Std.Data.String.Basic
 import Std.Data.String.Lemmas
 import Std.Lean.AttributeExtra
 import Std.Lean.Command
+import Std.Lean.CoreM
 import Std.Lean.Delaborator
 import Std.Lean.Expr
 import Std.Lean.Format

--- a/Std/Data/MLList/Heartbeats.lean
+++ b/Std/Data/MLList/Heartbeats.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Std.Data.MLList.Basic
+import Std.Lean.CoreM
+
+/-!
+# Truncate a `MLList` when running out of available heartbeats.
+-/
+
+open Lean.Core (CoreM)
+
+/-- Take an initial segment of a monadic lazy list,
+trying to leave at least `percent` of the remaining allowed heartbeats. -/
+def MLList.whileAtLeastHeartbeatsPercent [Monad m] [MonadLiftT CoreM m]
+    (L : MLList m α) (percent : Nat := 10) : MLList m α :=
+  MLList.squash fun _ => do
+    if (← getMaxHeartbeats) = 0 then do
+      return L
+    let initialHeartbeats ← getRemainingHeartbeats
+    pure <| L.takeWhileM fun _ => do
+      return .up <| (← getRemainingHeartbeats) * 100 / initialHeartbeats > percent

--- a/Std/Lean/CoreM.lean
+++ b/Std/Lean/CoreM.lean
@@ -11,13 +11,17 @@ import Lean.CoreM
 
 open Lean
 
-/-- Count the number of heartbeats used during a monadic function. -/
+/--
+Count the number of heartbeats used during a monadic function.
+
+Remember that user facing heartbeats (e.g. as used in `set_option maxHeartbeats`) differ from the internally tracked heartbeats by a factor of 1000, so you need to divide the results here by 1000 before comparing with user facing numbers.
+-/
 -- See also `Lean.withSeconds`
 def Lean.withHeartbeats [Monad m] [MonadLiftT BaseIO m] (x : m α) : m (α × Nat) := do
   let start ← IO.getNumHeartbeats
   let r ← x
   let finish ← IO.getNumHeartbeats
-  return (r, (finish - start) / 1000)
+  return (r, finish - start)
 
 /-- Return the current `maxHeartbeats`. -/
 def getMaxHeartbeats : CoreM Nat := do pure <| (← read).maxHeartbeats

--- a/Std/Lean/CoreM.lean
+++ b/Std/Lean/CoreM.lean
@@ -11,6 +11,14 @@ import Lean.CoreM
 
 open Lean
 
+/-- Count the number of heartbeats used during a monadic function. -/
+-- See also `Lean.withSeconds`
+def Lean.withHeartbeats [Monad m] [MonadLiftT BaseIO m] (x : m α) : m (α × Nat) := do
+  let start ← IO.getNumHeartbeats
+  let r ← x
+  let finish ← IO.getNumHeartbeats
+  return (r, (finish - start) / 1000)
+
 /-- Return the current `maxHeartbeats`. -/
 def getMaxHeartbeats : CoreM Nat := do pure <| (← read).maxHeartbeats
 

--- a/Std/Lean/CoreM.lean
+++ b/Std/Lean/CoreM.lean
@@ -14,7 +14,9 @@ open Lean
 /--
 Count the number of heartbeats used during a monadic function.
 
-Remember that user facing heartbeats (e.g. as used in `set_option maxHeartbeats`) differ from the internally tracked heartbeats by a factor of 1000, so you need to divide the results here by 1000 before comparing with user facing numbers.
+Remember that user facing heartbeats (e.g. as used in `set_option maxHeartbeats`) 
+differ from the internally tracked heartbeats by a factor of 1000, 
+so you need to divide the results here by 1000 before comparing with user facing numbers.
 -/
 -- See also `Lean.withSeconds`
 def Lean.withHeartbeats [Monad m] [MonadLiftT BaseIO m] (x : m α) : m (α × Nat) := do

--- a/Std/Lean/CoreM.lean
+++ b/Std/Lean/CoreM.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2023 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Lean.CoreM
+
+/-!
+# Additional functions using `CoreM` state.
+-/
+
+open Lean
+
+/-- Return the current `maxHeartbeats`. -/
+def getMaxHeartbeats : CoreM Nat := do pure <| (← read).maxHeartbeats
+
+/-- Return the current `initHeartbeats`. -/
+def getInitHeartbeats : CoreM Nat := do pure <| (← read).initHeartbeats
+
+/-- Return the remaining heartbeats available in this computation. -/
+def getRemainingHeartbeats : CoreM Nat := do
+  pure <| (← getMaxHeartbeats) - ((← IO.getNumHeartbeats) - (← getInitHeartbeats))
+
+/--
+Return the percentage of the max heartbeats allowed
+that have been consumed so far in this computation.
+-/
+def heartbeatsPercent : CoreM Nat := do
+  pure <| ((← IO.getNumHeartbeats) - (← getInitHeartbeats)) * 100 / (← getMaxHeartbeats)
+
+/-- Log a message if it looks like we ran out of time. -/
+def reportOutOfHeartbeats (tac : Name) (stx : Syntax) (threshold : Nat := 90) : CoreM Unit := do
+  if (← heartbeatsPercent) ≥ threshold then
+    logInfoAt stx (s!"`{tac}` stopped because it was running out of time.\n" ++
+      "You may get better results using `set_option maxHeartbeats 0`.")


### PR DESCRIPTION
I appreciate this may seem slightly esoteric, but it is used in `apply?`, to prefer giving a "best available" answer to the user in situations where `apply?` runs for a long time, rather than crashing out with a timeout.
