### PR TITLE
fix: merge conflicts bot on forks

### DIFF
--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           dirtyLabel: "merge-conflict"
           repoToken: "${{ secrets.MERGE_CONFLICTS_TOKEN }}"
+          continueOnMissingPermissions: true


### PR DESCRIPTION
Since forks have a read-only token, the bot fails every time it is run on a fork. Setting `continueOnMissingPermissions` makes that failure quiet.