### PR TITLE
chore: bump to nightly-2023-08-19

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-08-17
+leanprover/lean4:nightly-2023-08-19


### PR DESCRIPTION
I know we don't plan to always bump `Std`, but `nightly-2023-08-19` is special, as a tentative release candidate for Lean 4, and we'd like to check everything against it.