### PR TITLE
fix: merge conflict bot

### DIFF
--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   main:
+    if: github.repository_owner == 'leanprover'
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are dirty
@@ -13,4 +14,3 @@ jobs:
         with:
           dirtyLabel: "merge-conflict"
           repoToken: "${{ secrets.MERGE_CONFLICTS_TOKEN }}"
-          continueOnMissingPermissions: true


### PR DESCRIPTION
My first attempt to fix this didn't work as expected for this setup. (Since the `MERGE_CONFLICTS_TOKEN` simply doesn't exist on forks, it triggers a missing input error instead of a missing permissions error. So the `continueOnMissingPermissions` flag doesn't end up doing anything.)

I tested this second attempt more carefully on my end. It emits `run skipped` instead of `run failed`. That's still a bit of noise but it's easier to ignore (and it is arguably more accurate than continuing after failure). Assuming it doesn't break anything on your end (it shouldn't) then I'm completely happy with this solution.