### PR TITLE
feat: add sublist decidability

### DIFF
--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -452,12 +452,6 @@ def isSublist [DecidableEq α] : List α → List α → Bool
     then tl₁.isSublist tl₂
     else l₁.isSublist tl₂
 
-instance instDecidableIsSublist [DecidableEq α] (l₁ l₂ : List α) : Decidable (l₁.isSublist l₂) :=
-  if h : l₁.isSublist l₂ then
-    isTrue h
-  else
-    isFalse h
-
 
 /--
 Split a list at an index.

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -443,6 +443,22 @@ inductive Sublist {α} : List α → List α → Prop
 
 @[inherit_doc] scoped infixl:50 " <+ " => Sublist
 
+/-- True if the first list is a potentially non-contiguous sub-sequence of the second list. -/
+def isSublist [DecidableEq α] : List α → List α → Bool
+  | [], _ => true
+  | _, [] => false
+  | l₁@(hd₁::tl₁), hd₂::tl₂ =>
+    if hd₁ = hd₂
+    then tl₁.isSublist tl₂
+    else l₁.isSublist tl₂
+
+instance instDecidableIsSublist [DecidableEq α] (l₁ l₂ : List α) : Decidable (l₁.isSublist l₂) :=
+  if h : l₁.isSublist l₂ then
+    isTrue h
+  else
+    isFalse h
+
+
 /--
 Split a list at an index.
 ```

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -452,7 +452,6 @@ def isSublist [DecidableEq α] : List α → List α → Bool
     then tl₁.isSublist tl₂
     else l₁.isSublist tl₂
 
-
 /--
 Split a list at an index.
 ```

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -469,7 +469,7 @@ theorem isSublist_iff_sublist [DecidableEq α] {l₁ l₂ : List α} : l₁.isSu
         case cons₂ =>
           contradiction
 
-instance instDecidableSublist [DecidableEq α] : DecidableRel (@Sublist α) := fun l₁ l₂ =>
+instance [DecidableEq α] (l₁ l₂ : List α) : Decidable (l₁ <+ l₂) :=
   decidable_of_iff (l₁.isSublist l₂) isSublist_iff_sublist
 
 /-! ### head -/

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -471,9 +471,12 @@ theorem isSublist_iff_sublist [DecidableEq α] {l₁ l₂ : List α} : l₁.isSu
           case cons₂ =>
             contradiction⟩
 
-instance instDecidableSublist [DecidableEq α] : DecidableRel (@Sublist α) := fun l l' => by
+instance instDecidableSublist [DecidableEq α] : DecidableRel (@Sublist α) := fun l₁ l₂ => by
   rw [← isSublist_iff_sublist]
-  exact instDecidableIsSublist l l'
+  if h : l₁.isSublist l₂ then
+    exact isTrue h
+  else
+    exact isFalse h
 
 /-! ### head -/
 

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -458,18 +458,16 @@ theorem isSublist_iff_sublist [DecidableEq α] {l₁ l₂ : List α} : l₁.isSu
       simp [h_eq, cons_sublist_cons, isSublist_iff_sublist]
     else
       simp only [h_eq]
-      exact ⟨
-        by
-          intro h_sub
-          apply Sublist.cons
-          exact isSublist_iff_sublist.mp h_sub,
-        by
-          intro h_sub
-          cases h_sub
-          case cons h_sub =>
-            exact isSublist_iff_sublist.mpr h_sub
-          case cons₂ =>
-            contradiction⟩
+      constructor
+      · intro h_sub
+        apply Sublist.cons
+        exact isSublist_iff_sublist.mp h_sub
+      · intro h_sub
+        cases h_sub
+        case cons h_sub =>
+          exact isSublist_iff_sublist.mpr h_sub
+        case cons₂ =>
+          contradiction
 
 instance instDecidableSublist [DecidableEq α] : DecidableRel (@Sublist α) := fun l₁ l₂ => by
   rw [← isSublist_iff_sublist]

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -451,6 +451,30 @@ theorem Sublist.eq_of_length_le (s : l₁ <+ l₂) (h : length l₂ ≤ length l
     | refl => apply Sublist.refl
     | step => simp [*, replicate, Sublist.cons]
 
+theorem isSublist_iff_sublist [DecidableEq α] {l₁ l₂ : List α} : l₁.isSublist l₂ ↔ l₁ <+ l₂ := by
+  cases l₁ <;> cases l₂ <;> simp [isSublist]
+  case cons.cons hd₁ tl₁ hd₂ tl₂ =>
+    if h_eq : hd₁ = hd₂ then
+      simp [h_eq, cons_sublist_cons, isSublist_iff_sublist]
+    else
+      simp only [h_eq]
+      exact ⟨
+        by
+          intro h_sub
+          apply Sublist.cons
+          exact isSublist_iff_sublist.mp h_sub,
+        by
+          intro h_sub
+          cases h_sub
+          case cons h_sub =>
+            exact isSublist_iff_sublist.mpr h_sub
+          case cons₂ =>
+            contradiction⟩
+
+instance instDecidableSublist [DecidableEq α] : DecidableRel (@Sublist α) := fun l l' => by
+  rw [← isSublist_iff_sublist]
+  exact instDecidableIsSublist l l'
+
 /-! ### head -/
 
 theorem head!_of_head? [Inhabited α] : ∀ {l : List α}, head? l = some a → head! l = a

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -469,12 +469,8 @@ theorem isSublist_iff_sublist [DecidableEq α] {l₁ l₂ : List α} : l₁.isSu
         case cons₂ =>
           contradiction
 
-instance instDecidableSublist [DecidableEq α] : DecidableRel (@Sublist α) := fun l₁ l₂ => by
-  rw [← isSublist_iff_sublist]
-  if h : l₁.isSublist l₂ then
-    exact isTrue h
-  else
-    exact isFalse h
+instance instDecidableSublist [DecidableEq α] : DecidableRel (@Sublist α) := fun l₁ l₂ =>
+  decidable_of_iff (l₁.isSublist l₂) isSublist_iff_sublist
 
 /-! ### head -/
 


### PR DESCRIPTION
Migrates `List.Sublist` decidability from Mathlib

There are efficiency concerns on the operation, so this version relies on a (tailrec) `List.isSublist` function unlike the Mathlib version.