### PR TITLE
feat: ignore rhs of dischargers when linting for unreachable

### DIFF
--- a/Std/Linter/UnreachableTactic.lean
+++ b/Std/Linter/UnreachableTactic.lean
@@ -44,6 +44,7 @@ initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
     |>.insert ``Lean.Parser.Tactic.tacticStop_
     |>.insert ``Lean.Parser.Command.notation
     |>.insert ``Lean.Parser.Command.mixfix
+    |>.insert ``Lean.Parser.Tactic.discharger
 
 /-- Is this a syntax kind that contains intentionally unevaluated tactic subterms? -/
 def isIgnoreTacticKind (ignoreTacticKinds : NameHashSet) (k : SyntaxNodeKind) : Bool :=
@@ -57,8 +58,6 @@ This should be called from an `initialize` block.
 -/
 def addIgnoreTacticKind (kind : SyntaxNodeKind) : IO Unit :=
   ignoreTacticKindsRef.modify (·.insert kind)
-
-initialize Std.Linter.UnreachableTactic.addIgnoreTacticKind `Lean.Parser.Tactic.discharger
 
 variable (ignoreTacticKinds : NameHashSet) (isTacKind : SyntaxNodeKind → Bool) in
 /-- Accumulates the set of tactic syntaxes that should be evaluated at least once. -/

--- a/Std/Linter/UnreachableTactic.lean
+++ b/Std/Linter/UnreachableTactic.lean
@@ -58,6 +58,8 @@ This should be called from an `initialize` block.
 def addIgnoreTacticKind (kind : SyntaxNodeKind) : IO Unit :=
   ignoreTacticKindsRef.modify (·.insert kind)
 
+initialize Std.Linter.UnreachableTactic.addIgnoreTacticKind `Lean.Parser.Tactic.discharger
+
 variable (ignoreTacticKinds : NameHashSet) (isTacKind : SyntaxNodeKind → Bool) in
 /-- Accumulates the set of tactic syntaxes that should be evaluated at least once. -/
 @[specialize] partial def getTactics (stx : Syntax) : M Unit := do

--- a/Std/Tactic/GuardMsgs.lean
+++ b/Std/Tactic/GuardMsgs.lean
@@ -140,7 +140,7 @@ elab_rules : command
     let expected : String := (← dc?.mapM (getDocStringText ·)).getD "" |>.trim
     let specFn ← parseGuardMsgsSpec spec?
     let initMsgs ← modifyGet fun st => (st.messages, { st with messages := {} })
-    elabCommand cmd
+    elabCommandTopLevel cmd
     let msgs := (← get).messages
     let mut toCheck : MessageLog := .empty
     let mut toPassthrough : MessageLog := .empty

--- a/test/lint_unreachableTactic.lean
+++ b/test/lint_unreachableTactic.lean
@@ -1,0 +1,23 @@
+import Std.Linter.UnreachableTactic
+import Std.Tactic.GuardMsgs
+
+/-- warning: this tactic is never executed [linter.unreachableTactic] -/
+#guard_msgs in
+example : 1 = 1 := by
+  rfl <;> simp
+
+/--
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example : 1 = 1 := by
+  stop
+  rfl
+
+def t : Nat → Nat := sorry
+@[simp]
+theorem a : aa = 0 → t aa = 0 := sorry
+
+#guard_msgs in
+example (ha : aa = 0) : t aa = 0 := by
+  simp (disch := assumption)


### PR DESCRIPTION
Before this change the linter would complain that `assumption` was unused
```lean
def t : ℕ → ℕ := sorry
@[simp]
lemma a : aa = 0 → t aa = 0 := sorry
lemma aaa (ha : aa = 0) : t aa = 0 := by
  simp (disch := assumption)
``` 

Also have `guardMsgs` run linters so that we can test them