### PR TITLE
feat: code action for alias + deprecated

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -8,6 +8,7 @@ import Std.Classes.SetNotation
 import Std.CodeAction
 import Std.CodeAction.Attr
 import Std.CodeAction.Basic
+import Std.CodeAction.Deprecated
 import Std.CodeAction.Misc
 import Std.Control.ForInStep
 import Std.Control.ForInStep.Basic

--- a/Std/CodeAction/Deprecated.lean
+++ b/Std/CodeAction/Deprecated.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean.Server.CodeActions
+import Std.CodeAction.Basic
+import Std.Lean.Position
+
+/-!
+# Code action for @[deprecated] replacements
+
+This is an opt-in mechanism for making machine-applicable `@[deprecated]` definitions. When enabled
+(by setting the `machineApplicableDeprecated` tag attribute), a code action will be triggered
+whenever the deprecation lint also fires, allowing the user to replace the usage of the deprecated
+constant.
+-/
+namespace Std
+open Lean Elab Server Lsp RequestM
+
+/-- An environment extension for identifying `@[deprecated]` definitions which can be auto-fixed -/
+initialize machineApplicableDeprecated : TagDeclarationExtension ← mkTagDeclarationExtension
+
+namespace CodeAction
+
+/-- A code action which applies replacements for `@[deprecated]` definitions. -/
+@[code_action_provider]
+def deprecatedCodeActionProvider : CodeActionProvider := fun params snap => do
+  let mut i := 0
+  let doc ← readDoc
+  let mut msgs := #[]
+  for diag in snap.interactiveDiags do
+    if let some #[.deprecated] := diag.tags? then
+      if h : _ then
+        msgs := msgs.push (snap.cmdState.messages.msgs[i]'h)
+    i := i + 1
+  if msgs.isEmpty then return #[]
+  let start := doc.meta.text.lspPosToUtf8Pos params.range.start
+  let stop := doc.meta.text.lspPosToUtf8Pos params.range.end
+  for msg in msgs do
+    let some endPos := msg.endPos | continue
+    let pos := doc.meta.text.ofPosition msg.pos
+    let endPos' := doc.meta.text.ofPosition endPos
+    unless start ≤ endPos' && pos ≤ stop do continue
+    let some (ctx, .node (.ofTermInfo info@{ expr := .const c .., ..}) _) :=
+      findInfoTree? identKind ⟨pos, endPos'⟩ none snap.infoTree fun _ i =>
+        (i matches .ofTermInfo { elaborator := .anonymous, expr := .const .., ..})
+      | continue
+    unless machineApplicableDeprecated.isTagged snap.cmdState.env c do continue
+    let some c' := Linter.getDeprecatedNewName snap.cmdState.env c | continue
+    let eager : CodeAction := {
+      title := s!"Replace {c} with {c'}"
+      kind? := "quickfix"
+      isPreferred? := true
+    }
+    return #[{
+      eager
+      lazy? := some do
+        let c' ← info.runMetaM ctx (unresolveNameGlobal c')
+        let pos := doc.meta.text.leanPosToLspPos msg.pos
+        let endPos' := doc.meta.text.leanPosToLspPos endPos
+        pure { eager with
+          edit? := some <| .ofTextEdit params.textDocument.uri {
+            range := ⟨pos, endPos'⟩
+            newText := toString c'
+          }
+        }
+    }]
+  return #[]

--- a/Std/Lean/Position.lean
+++ b/Std/Lean/Position.lean
@@ -14,6 +14,17 @@ def Lean.FileMap.utf8RangeToLspRange (text : FileMap) (range : String.Range) : L
 def Lean.FileMap.rangeOfStx? (text : FileMap) (stx : Syntax) : Option Lsp.Range :=
   text.utf8RangeToLspRange <$> stx.getRange?
 
+/-- Convert a `Lean.Position` to a `String.Pos`. -/
+def Lean.FileMap.ofPosition (text : FileMap) (pos : Position) : String.Pos :=
+  let colPos :=
+    if h : pos.line - 1 < text.positions.size then
+      text.positions.get ⟨pos.line - 1, h⟩
+    else if text.positions.isEmpty then
+      0
+    else
+      text.positions.back
+  String.Iterator.nextn ⟨text.source, colPos⟩ pos.column |>.pos
+
 /-- Return the beginning of the line contatining character `pos`. -/
 def Lean.findLineStart (s : String) (pos : String.Pos) : String.Pos :=
   match s.revFindAux (· = '\n') pos with


### PR DESCRIPTION
Now, when you declare a deprecated alias such as `@[deprecated] alias foo := bar`, occurrences of `foo` (which will be marked with a deprecation warning) will also have an auto-fix command to replace `foo` with `bar`.