### PR TITLE
chore: upstream rfl and symm tactics

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -68,6 +68,7 @@ import Std.Lean.AttributeExtra
 import Std.Lean.Command
 import Std.Lean.CoreM
 import Std.Lean.Delaborator
+import Std.Lean.Elab.Tactic
 import Std.Lean.Expr
 import Std.Lean.Format
 import Std.Lean.HashMap
@@ -121,7 +122,7 @@ import Std.Tactic.NormCast.Lemmas
 import Std.Tactic.OpenPrivate
 import Std.Tactic.PrintDependents
 import Std.Tactic.RCases
-import Std.Tactic.Relation.Refl
+import Std.Tactic.Relation.Rfl
 import Std.Tactic.Relation.Symm
 import Std.Tactic.Replace
 import Std.Tactic.SeqFocus

--- a/Std.lean
+++ b/Std.lean
@@ -121,6 +121,8 @@ import Std.Tactic.NormCast.Lemmas
 import Std.Tactic.OpenPrivate
 import Std.Tactic.PrintDependents
 import Std.Tactic.RCases
+import Std.Tactic.Relation.Refl
+import Std.Tactic.Relation.Symm
 import Std.Tactic.Replace
 import Std.Tactic.SeqFocus
 import Std.Tactic.ShowTerm

--- a/Std/Lean/Elab/Tactic.lean
+++ b/Std/Lean/Elab/Tactic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Lean
+import Lean.Elab.Tactic.Basic
 
 /-!
 # Tactic combinators in `TacticM`.

--- a/Std/Lean/Elab/Tactic.lean
+++ b/Std/Lean/Elab/Tactic.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2022 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Lean
+
+/-!
+# Tactic combinators in `TacticM`.
+-/
+
+namespace Lean.Elab.Tactic
+
+/-- Analogue of `liftMetaTactic` for tactics that do not return any goals. -/
+def liftMetaFinishingTactic (tac : MVarId → MetaM Unit) : TacticM Unit :=
+  liftMetaTactic fun g => do tac g; pure []
+
+end Lean.Elab.Tactic

--- a/Std/Lean/Meta/Basic.lean
+++ b/Std/Lean/Meta/Basic.lean
@@ -296,10 +296,10 @@ def replace (g : MVarId) (hyp : FVarId) (proof : Expr) (typeNew : Option Expr :=
 where
   /-- Finds the `LocalDecl` for the FVar in `e` with the highest index. -/
   findMaxFVar (e : Expr) : StateRefT LocalDecl MetaM Unit :=
-    e.forEach' fun e ↦ do
+    e.forEach' fun e => do
       if e.isFVar then
         let ldecl' ← e.fvarId!.getDecl
-        modify fun ldecl ↦ if ldecl'.index > ldecl.index then ldecl' else ldecl
+        modify fun ldecl => if ldecl'.index > ldecl.index then ldecl' else ldecl
         return false
       else
         return e.hasFVar

--- a/Std/Lean/Meta/Basic.lean
+++ b/Std/Lean/Meta/Basic.lean
@@ -274,6 +274,41 @@ where
           modify (·.insert pendingMVarId)
         go pendingMVarId
 
+/--
+Replace hypothesis `hyp` in goal `g` with `proof : typeNew`.
+The new hypothesis is given the same user name as the original,
+it attempts to avoid reordering hypotheses, and the original is cleared if possible.
+-/
+-- adapted from Lean.Meta.replaceLocalDeclCore
+def replace (g : MVarId) (hyp : FVarId) (proof : Expr) (typeNew : Option Expr := none) :
+    MetaM AssertAfterResult :=
+  g.withContext do
+    let typeNew ← match typeNew with
+    | some t => pure t
+    | none => inferType proof
+    let ldecl ← hyp.getDecl
+    -- `typeNew` may contain variables that occur after `hyp`.
+    -- Thus, we use the auxiliary function `findMaxFVar` to ensure `typeNew` is well-formed
+    -- at the position we are inserting it.
+    let (_, ldecl') ← findMaxFVar typeNew |>.run ldecl
+    let result ← g.assertAfter ldecl'.fvarId ldecl.userName typeNew proof
+    (return { result with mvarId := ← result.mvarId.clear hyp }) <|> pure result
+where
+  /-- Finds the `LocalDecl` for the FVar in `e` with the highest index. -/
+  findMaxFVar (e : Expr) : StateRefT LocalDecl MetaM Unit :=
+    e.forEach' fun e ↦ do
+      if e.isFVar then
+        let ldecl' ← e.fvarId!.getDecl
+        modify fun ldecl ↦ if ldecl'.index > ldecl.index then ldecl' else ldecl
+        return false
+      else
+        return e.hasFVar
+
+/-- Get the type the given metavariable after instantiating metavariables and cleaning up
+annotations. -/
+def getTypeCleanup (mvarId : MVarId) : MetaM Expr :=
+  return (← instantiateMVars (← mvarId.getType)).cleanupAnnotations
+
 end MVarId
 
 

--- a/Std/Tactic/Relation/Rfl.lean
+++ b/Std/Tactic/Relation/Rfl.lean
@@ -13,7 +13,7 @@ This extends the `rfl` tactic so that it works on any reflexive relation,
 provided the reflexivity lemma has been marked as `@[refl]`.
 -/
 
-namespace Mathlib.Tactic
+namespace Std.Tactic
 
 open Lean Meta
 

--- a/Std/Tactic/Relation/Rfl.lean
+++ b/Std/Tactic/Relation/Rfl.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Newell Jensen, Thomas Murrills
 -/
 import Std.Lean.Elab.Tactic
+import Lean.Meta.Tactic.Apply
 
 /-!
 # `rfl` tactic extension for reflexive relations

--- a/Std/Tactic/Relation/Rfl.lean
+++ b/Std/Tactic/Relation/Rfl.lean
@@ -21,14 +21,14 @@ open Lean Meta
 initialize reflExt :
     SimpleScopedEnvExtension (Name × Array (DiscrTree.Key true)) (DiscrTree Name true) ←
   registerSimpleScopedEnvExtension {
-    addEntry := fun dt (n, ks) ↦ dt.insertCore ks n
+    addEntry := fun dt (n, ks) => dt.insertCore ks n
     initial := {}
   }
 
 initialize registerBuiltinAttribute {
   name := `refl
   descr := "reflexivity relation"
-  add := fun decl _ kind ↦ MetaM.run' do
+  add := fun decl _ kind => MetaM.run' do
     let declTy := (← getConstInfo decl).type
     let (_, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
     let fail := throwError

--- a/Std/Tactic/Relation/Rfl.lean
+++ b/Std/Tactic/Relation/Rfl.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2022 Newell Jensen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Newell Jensen, Thomas Murrills
+-/
+import Std.Lean.Elab.Tactic
+
+/-!
+# `rfl` tactic extension for reflexive relations
+
+This extends the `rfl` tactic so that it works on any reflexive relation,
+provided the reflexivity lemma has been marked as `@[refl]`.
+-/
+
+namespace Mathlib.Tactic
+
+open Lean Meta
+
+/-- Environment extensions for `refl` lemmas -/
+initialize reflExt :
+    SimpleScopedEnvExtension (Name × Array (DiscrTree.Key true)) (DiscrTree Name true) ←
+  registerSimpleScopedEnvExtension {
+    addEntry := fun dt (n, ks) ↦ dt.insertCore ks n
+    initial := {}
+  }
+
+initialize registerBuiltinAttribute {
+  name := `refl
+  descr := "reflexivity relation"
+  add := fun decl _ kind ↦ MetaM.run' do
+    let declTy := (← getConstInfo decl).type
+    let (_, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
+    let fail := throwError
+      "@[refl] attribute only applies to lemmas proving x ∼ x, got {declTy}"
+    let .app (.app rel lhs) rhs := targetTy | fail
+    unless ← withNewMCtxDepth <| isDefEq lhs rhs do fail
+    let key ← DiscrTree.mkPath rel
+    reflExt.add (decl, key) kind
+}
+
+open Elab Tactic
+
+/-- `MetaM` version of the `rfl` tactic.
+
+This tactic applies to a goal whose target has the form `x ~ x`, where `~` is a reflexive
+relation, that is, a relation which has a reflexive lemma tagged with the attribute [refl].
+-/
+def _root_.Lean.MVarId.rfl (goal : MVarId) : MetaM Unit := do
+  let .app (.app rel _) _ ← whnfR <|← instantiateMVars <|← goal.getType
+    | throwError "reflexivity lemmas only apply to binary relations, not
+      {indentExpr (← goal.getType)}"
+  let s ← saveState
+  let mut ex? := none
+  for lem in ← (reflExt.getState (← getEnv)).getMatch rel do
+    try
+      let gs ← goal.apply (← mkConstWithFreshMVarLevels lem)
+      if gs.isEmpty then return () else
+        logError <| MessageData.tagged `Tactic.unsolvedGoals <| m!"unsolved goals\n
+          {goalsToMessageData gs}"
+    catch e =>
+      ex? := ex? <|> (some (← saveState, e)) -- stash the first failure of `apply`
+    s.restore
+  if let some (sErr, e) := ex? then
+    sErr.restore
+    throw e
+  else
+    throwError "rfl failed, no lemma with @[refl] applies"
+
+/--
+This tactic applies to a goal whose target has the form `x ~ x`, where `~` is a reflexive
+relation, that is, a relation which has a reflexive lemma tagged with the attribute [refl].
+-/
+elab_rules : tactic
+| `(tactic| rfl) => withMainContext do liftMetaFinishingTactic (·.rfl)

--- a/Std/Tactic/Relation/Rfl.lean
+++ b/Std/Tactic/Relation/Rfl.lean
@@ -46,7 +46,7 @@ open Elab Tactic
 This tactic applies to a goal whose target has the form `x ~ x`, where `~` is a reflexive
 relation, that is, a relation which has a reflexive lemma tagged with the attribute [refl].
 -/
-def _root_.Lean.MVarId.rfl (goal : MVarId) : MetaM Unit := do
+def _root_.Lean.MVarId.applyRfl (goal : MVarId) : MetaM Unit := do
   let .app (.app rel _) _ ← whnfR <|← instantiateMVars <|← goal.getType
     | throwError "reflexivity lemmas only apply to binary relations, not
       {indentExpr (← goal.getType)}"
@@ -72,4 +72,4 @@ This tactic applies to a goal whose target has the form `x ~ x`, where `~` is a 
 relation, that is, a relation which has a reflexive lemma tagged with the attribute [refl].
 -/
 elab_rules : tactic
-| `(tactic| rfl) => withMainContext do liftMetaFinishingTactic (·.rfl)
+| `(tactic| rfl) => withMainContext do liftMetaFinishingTactic (·.applyRfl)

--- a/Std/Tactic/Relation/Rfl.lean
+++ b/Std/Tactic/Relation/Rfl.lean
@@ -48,16 +48,16 @@ relation, that is, a relation which has a reflexive lemma tagged with the attrib
 -/
 def _root_.Lean.MVarId.applyRfl (goal : MVarId) : MetaM Unit := do
   let .app (.app rel _) _ ← whnfR <|← instantiateMVars <|← goal.getType
-    | throwError "reflexivity lemmas only apply to binary relations, not
-      {indentExpr (← goal.getType)}"
+    | throwError "reflexivity lemmas only apply to binary relations, not{
+        indentExpr (← goal.getType)}"
   let s ← saveState
   let mut ex? := none
   for lem in ← (reflExt.getState (← getEnv)).getMatch rel do
     try
       let gs ← goal.apply (← mkConstWithFreshMVarLevels lem)
       if gs.isEmpty then return () else
-        logError <| MessageData.tagged `Tactic.unsolvedGoals <| m!"unsolved goals\n
-          {goalsToMessageData gs}"
+        logError <| MessageData.tagged `Tactic.unsolvedGoals <| m!"unsolved goals\n{
+          goalsToMessageData gs}"
     catch e =>
       ex? := ex? <|> (some (← saveState, e)) -- stash the first failure of `apply`
     s.restore
@@ -72,4 +72,4 @@ This tactic applies to a goal whose target has the form `x ~ x`, where `~` is a 
 relation, that is, a relation which has a reflexive lemma tagged with the attribute [refl].
 -/
 elab_rules : tactic
-| `(tactic| rfl) => withMainContext do liftMetaFinishingTactic (·.applyRfl)
+  | `(tactic| rfl) => withMainContext do liftMetaFinishingTactic (·.applyRfl)

--- a/Std/Tactic/Relation/Symm.lean
+++ b/Std/Tactic/Relation/Symm.lean
@@ -48,19 +48,20 @@ open Std.Tactic
 namespace Lean.Expr
 
 /--
-Internal implementation of `Lean.Expr.symm`, `Lean.MVarId.symm`, and the user-facing tactic.
+Internal implementation of `Lean.Expr.applySymm`, `Lean.MVarId.applySymm`,
+and the user-facing tactic.
 
 `tgt` should be of the form `a ~ b`, and is used to index the symm lemmas.
 
 `k lem args body` should calculate a result,
 given a candidate `symm` lemma `lem`, which will have type `∀ args, body`.
 
-In `Lean.Expr.symm` this result will be a new `Expr`,
-and in `Lean.MVarId.symm` and `Lean.MVarId.symmAt` this result will be a new goal.
+In `Lean.Expr.applySymm` this result will be a new `Expr`,
+and in `Lean.MVarId.applySymm` and `Lean.MVarId.applySymmAt` this result will be a new goal.
 -/
 -- This function is rather opaque, but the design with a generic continuation `k`
 -- is necessary in order to factor out all the common requirements below.
-private def symmAux (tgt : Expr) (k : Expr → Array Expr → Expr → MetaM α) : MetaM α := do
+private def applySymmAux (tgt : Expr) (k : Expr → Array Expr → Expr → MetaM α) : MetaM α := do
   let .app (.app rel _) _ := tgt
     | throwError "symmetry lemmas only apply to binary relations, not{indentExpr tgt}"
   for lem in ← (symmExt.getState (← getEnv)).getMatch rel do
@@ -72,8 +73,8 @@ private def symmAux (tgt : Expr) (k : Expr → Array Expr → Expr → MetaM α)
   throwError "no applicable symmetry lemma found for{indentExpr tgt}"
 
 /-- Given a term `e : a ~ b`, construct a term in `b ~ a` using `@[symm]` lemmas. -/
-def symm (e : Expr) : MetaM Expr := do
-  symmAux (← instantiateMVars (← inferType e)) fun lem args body => do
+def applySymm (e : Expr) : MetaM Expr := do
+  applySymmAux (← instantiateMVars (← inferType e)) fun lem args body => do
     let .true ← isDefEq args.back e | failure
     mkExpectedTypeHint (mkAppN lem args) (← instantiateMVars body)
 
@@ -82,7 +83,7 @@ end Lean.Expr
 namespace Lean.MVarId
 
 /--
-Internal implementation of `Lean.MVarId.symm` and the user-facing tactic.
+Internal implementation of `Lean.MVarId.applySymm` and the user-facing tactic.
 
 `tgt` should be of the form `a ~ b`, and is used to index the symm lemmas.
 
@@ -91,24 +92,24 @@ given a candidate `symm` lemma `lem`, which will have type `∀ args, body`.
 Depending on whether we are working on a hypothesis or a goal,
 `k` will internally use either `replace` or `assign`.
 -/
-private def symmAux
+private def applySymmAux
     (tgt : Expr) (k : Expr → Array Expr → Expr → MVarId → MetaM MVarId) (g : MVarId) :
     MetaM MVarId := do
-  tgt.symmAux fun lem args body => do
+  tgt.applySymmAux fun lem args body => do
     let g' ← k lem args body g
     g'.setTag (← g.getTag)
     return g'
 
 /-- Apply a symmetry lemma (i.e. marked with `@[symm]`) to a metavariable. -/
-def symm (g : MVarId) : MetaM MVarId := do
-  g.symmAux (← g.getTypeCleanup) fun lem args body g => do
+def applySymm (g : MVarId) : MetaM MVarId := do
+  g.applySymmAux (← g.getTypeCleanup) fun lem args body g => do
     let .true ← isDefEq (← g.getType) body | failure
     g.assign (mkAppN lem args)
     return args.back.mvarId!
 
 /-- Use a symmetry lemma (i.e. marked with `@[symm]`) to replace a hypothesis in a goal. -/
-def symmAt (h : FVarId) (g : MVarId) : MetaM MVarId := do
-  let h' ← (Expr.fvar h).symm
+def applySymmAt (h : FVarId) (g : MVarId) : MetaM MVarId := do
+  let h' ← (Expr.fvar h).applySymm
   pure (← g.replace h h').mvarId
 
 end Lean.MVarId
@@ -124,6 +125,6 @@ open Lean.Elab.Tactic
 * `symm at h` will rewrite a hypothesis `h : t ~ u` to `h : u ~ t`.
 -/
 elab "symm" loc:((Parser.Tactic.location)?) : tactic =>
-  let atHyp h := liftMetaTactic1 fun g => g.symmAt h
-  let atTarget := liftMetaTactic1 fun g => g.symm
+  let atHyp h := liftMetaTactic1 fun g => g.applySymmAt h
+  let atTarget := liftMetaTactic1 fun g => g.applySymm
   withLocation (expandOptLocation loc) atHyp atTarget fun _ => throwError "symm made no progress"

--- a/Std/Tactic/Relation/Symm.lean
+++ b/Std/Tactic/Relation/Symm.lean
@@ -60,7 +60,7 @@ and in `Lean.MVarId.symm` and `Lean.MVarId.symmAt` this result will be a new goa
 -/
 -- This function is rather opaque, but the design with a generic continuation `k`
 -- is necessary in order to factor out all the common requirements below.
-def symmAux (tgt : Expr) (k : Expr → Array Expr → Expr → MetaM α) : MetaM α := do
+private def symmAux (tgt : Expr) (k : Expr → Array Expr → Expr → MetaM α) : MetaM α := do
   let .app (.app rel _) _ := tgt
     | throwError "symmetry lemmas only apply to binary relations, not{indentExpr tgt}"
   for lem in ← (symmExt.getState (← getEnv)).getMatch rel do
@@ -91,7 +91,8 @@ given a candidate `symm` lemma `lem`, which will have type `∀ args, body`.
 Depending on whether we are working on a hypothesis or a goal,
 `k` will internally use either `replace` or `assign`.
 -/
-def symmAux (tgt : Expr) (k : Expr → Array Expr → Expr → MVarId → MetaM MVarId) (g : MVarId) :
+private def symmAux
+    (tgt : Expr) (k : Expr → Array Expr → Expr → MVarId → MetaM MVarId) (g : MVarId) :
     MetaM MVarId := do
   tgt.symmAux fun lem args body => do
     let g' ← k lem args body g
@@ -112,7 +113,7 @@ def symmAt (h : FVarId) (g : MVarId) : MetaM MVarId := do
 
 end Lean.MVarId
 
-namespace Mathlib.Tactic
+namespace Std.Tactic
 
 open Lean.Elab.Tactic
 

--- a/Std/Tactic/Relation/Symm.lean
+++ b/Std/Tactic/Relation/Symm.lean
@@ -22,14 +22,14 @@ namespace Std.Tactic
 initialize symmExt :
     SimpleScopedEnvExtension (Name × Array (DiscrTree.Key true)) (DiscrTree Name true) ←
   registerSimpleScopedEnvExtension {
-    addEntry := fun dt (n, ks) ↦ dt.insertCore ks n
+    addEntry := fun dt (n, ks) => dt.insertCore ks n
     initial := {}
   }
 
 initialize registerBuiltinAttribute {
   name := `symm
   descr := "symmetric relation"
-  add := fun decl _ kind ↦ MetaM.run' do
+  add := fun decl _ kind => MetaM.run' do
     let declTy := (← getConstInfo decl).type
     let (xs, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
     let fail := throwError
@@ -125,4 +125,4 @@ open Lean.Elab.Tactic
 elab "symm" loc:((Parser.Tactic.location)?) : tactic =>
   let atHyp h := liftMetaTactic1 fun g => g.symmAt h
   let atTarget := liftMetaTactic1 fun g => g.symm
-  withLocation (expandOptLocation loc) atHyp atTarget fun _ ↦ throwError "symm made no progress"
+  withLocation (expandOptLocation loc) atHyp atTarget fun _ => throwError "symm made no progress"

--- a/Std/Tactic/Relation/Symm.lean
+++ b/Std/Tactic/Relation/Symm.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2022 Siddhartha Gadgil. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Siddhartha Gadgil, Mario Carneiro, Scott Morrison
+-/
+import Std.Lean.Meta.Basic
+
+/-!
+# `symm` tactic
+
+This implements the `symm` tactic, which can apply symmetry theorems to either the goal or a
+hypothesis.
+-/
+
+set_option autoImplicit true
+
+open Lean Meta
+
+namespace Std.Tactic
+
+/-- Environment extensions for symm lemmas -/
+initialize symmExt :
+    SimpleScopedEnvExtension (Name × Array (DiscrTree.Key true)) (DiscrTree Name true) ←
+  registerSimpleScopedEnvExtension {
+    addEntry := fun dt (n, ks) ↦ dt.insertCore ks n
+    initial := {}
+  }
+
+initialize registerBuiltinAttribute {
+  name := `symm
+  descr := "symmetric relation"
+  add := fun decl _ kind ↦ MetaM.run' do
+    let declTy := (← getConstInfo decl).type
+    let (xs, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
+    let fail := throwError
+      "@[symm] attribute only applies to lemmas proving x ∼ y → y ∼ x, got {declTy}"
+    let some _ := xs.back? | fail
+    let targetTy ← reduce targetTy
+    let .app (.app rel _) _ := targetTy | fail
+    let key ← withReducible <| DiscrTree.mkPath rel
+    symmExt.add (decl, key) kind
+}
+
+end Std.Tactic
+
+open Std.Tactic
+
+namespace Lean.Expr
+
+/--
+Internal implementation of `Lean.Expr.symm`, `Lean.MVarId.symm`, and the user-facing tactic.
+
+`tgt` should be of the form `a ~ b`, and is used to index the symm lemmas.
+
+`k lem args body` should calculate a result,
+given a candidate `symm` lemma `lem`, which will have type `∀ args, body`.
+
+In `Lean.Expr.symm` this result will be a new `Expr`,
+and in `Lean.MVarId.symm` and `Lean.MVarId.symmAt` this result will be a new goal.
+-/
+-- This function is rather opaque, but the design with a generic continuation `k`
+-- is necessary in order to factor out all the common requirements below.
+def symmAux (tgt : Expr) (k : Expr → Array Expr → Expr → MetaM α) : MetaM α := do
+  let .app (.app rel _) _ := tgt
+    | throwError "symmetry lemmas only apply to binary relations, not{indentExpr tgt}"
+  for lem in ← (symmExt.getState (← getEnv)).getMatch rel do
+    try
+      let lem ← mkConstWithFreshMVarLevels lem
+      let (args, _, body) ← withReducible <| forallMetaTelescopeReducing (← inferType lem)
+      return (← k lem args body)
+    catch _ => pure ()
+  throwError "no applicable symmetry lemma found for{indentExpr tgt}"
+
+/-- Given a term `e : a ~ b`, construct a term in `b ~ a` using `@[symm]` lemmas. -/
+def symm (e : Expr) : MetaM Expr := do
+  symmAux (← instantiateMVars (← inferType e)) fun lem args body => do
+    let .true ← isDefEq args.back e | failure
+    mkExpectedTypeHint (mkAppN lem args) (← instantiateMVars body)
+
+end Lean.Expr
+
+namespace Lean.MVarId
+
+/--
+Internal implementation of `Lean.MVarId.symm` and the user-facing tactic.
+
+`tgt` should be of the form `a ~ b`, and is used to index the symm lemmas.
+
+`k lem args body goal` should transform `goal` into a new goal,
+given a candidate `symm` lemma `lem`, which will have type `∀ args, body`.
+Depending on whether we are working on a hypothesis or a goal,
+`k` will internally use either `replace` or `assign`.
+-/
+def symmAux (tgt : Expr) (k : Expr → Array Expr → Expr → MVarId → MetaM MVarId) (g : MVarId) :
+    MetaM MVarId := do
+  tgt.symmAux fun lem args body => do
+    let g' ← k lem args body g
+    g'.setTag (← g.getTag)
+    return g'
+
+/-- Apply a symmetry lemma (i.e. marked with `@[symm]`) to a metavariable. -/
+def symm (g : MVarId) : MetaM MVarId := do
+  g.symmAux (← g.getTypeCleanup) fun lem args body g => do
+    let .true ← isDefEq (← g.getType) body | failure
+    g.assign (mkAppN lem args)
+    return args.back.mvarId!
+
+/-- Use a symmetry lemma (i.e. marked with `@[symm]`) to replace a hypothesis in a goal. -/
+def symmAt (h : FVarId) (g : MVarId) : MetaM MVarId := do
+  let h' ← (Expr.fvar h).symm
+  pure (← g.replace h h').mvarId
+
+end Lean.MVarId
+
+namespace Mathlib.Tactic
+
+open Lean.Elab.Tactic
+
+/--
+* `symm` applies to a goal whose target has the form `t ~ u` where `~` is a symmetric relation,
+  that is, a relation which has a symmetry lemma tagged with the attribute [symm].
+  It replaces the target with `u ~ t`.
+* `symm at h` will rewrite a hypothesis `h : t ~ u` to `h : u ~ t`.
+-/
+elab "symm" loc:((Parser.Tactic.location)?) : tactic =>
+  let atHyp h := liftMetaTactic1 fun g => g.symmAt h
+  let atTarget := liftMetaTactic1 fun g => g.symm
+  withLocation (expandOptLocation loc) atHyp atTarget fun _ ↦ throwError "symm made no progress"

--- a/test/rfl.lean
+++ b/test/rfl.lean
@@ -1,0 +1,37 @@
+import Std.Tactic.Relation.Rfl
+
+set_option linter.missingDocs false
+
+example (a : Nat) : a = a := rfl
+
+example (a : Nat) : a = a := by rfl
+
+open Setoid
+
+universe u
+variable {α : Sort u} [Setoid α]
+
+@[refl] def iseqv_refl (a : α) : a ≈ a :=
+  iseqv.refl a
+
+example (a : α) : a ≈ a := by rfl
+
+example (a : Nat) : a ≤ a := by (fail_if_success rfl); apply Nat.le_refl
+
+attribute [refl] Nat.le_refl
+
+example (a : Nat) : a ≤ a := by rfl
+
+structure Foo
+
+def Foo.le (_ _ : Foo) := Unit → True
+instance : LE Foo := ⟨Foo.le⟩
+
+@[refl] theorem Foo.le_refl (a : Foo) : a ≤ a := fun _ => trivial
+
+example (a : Foo) : a ≤ a := by apply Foo.le_refl
+example (a : Foo) : a ≤ a := by rfl
+
+example (x : Nat) : x ≤ x := by
+  show _
+  rfl

--- a/test/symm.lean
+++ b/test/symm.lean
@@ -1,0 +1,28 @@
+import Std.Tactic.Relation.Symm
+import Std.Tactic.RCases
+
+set_option autoImplicit true
+set_option linter.missingDocs false
+
+-- testing that the attribute is recognized
+@[symm] def eq_symm {α : Type} (a b : α) : a = b → b = a := Eq.symm
+
+example (a b : Nat) : a = b → b = a := by intros; symm; assumption
+example (a b : Nat) : a = b → True → b = a := by intro h _; symm at h; assumption
+
+def sameParity : Nat → Nat → Prop
+  | n, m => n % 2 = m % 2
+
+@[symm] def sameParity_symm (n m : Nat) : sameParity n m → sameParity m n := Eq.symm
+
+example (a b : Nat) : sameParity a b → sameParity b a := by intros; symm; assumption
+
+def MyEq (n m : Nat) := ∃ k, n + k = m ∧ m + k = n
+
+@[symm] theorem MyEq.symm {n m : Nat} (h : MyEq n m) : MyEq m n := by
+  rcases h with ⟨k, h1, h2⟩
+  exact ⟨k, h2, h1⟩
+
+example {n m : Nat} (h : MyEq n m) : MyEq m n := by
+  symm
+  assumption


### PR DESCRIPTION
The `trans` tactic in Mathlib needs more polish than these, so I'll do that in a separate PR to ease reviewing.