### PR TITLE
chore: add grep-based linter for ↦

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,10 @@ jobs:
 
       - name: check that all files are imported
         run: git diff --exit-code
+
+      - name: Check for forbidden character ↦
+        run: |
+          if grep -r --include=\*.lean -e '↦' . ; then
+            echo "Error: Found forbidden character ↦"
+            exit 1
+          fi

--- a/Std/Data/HashMap/Basic.lean
+++ b/Std/Data/HashMap/Basic.lean
@@ -280,7 +280,7 @@ def insert (self : HashMap α β) (a : α) (b : β) : HashMap α β := ⟨self.1
 
 /--
 Similar to `insert`, but also returns a boolean flag indicating whether an existing entry has been
-replaced with `a ↦ b`.
+replaced with `a => b`.
 -/
 @[inline] def insert' (m : HashMap α β) (a : α) (b : β) : HashMap α β × Bool :=
   let old := m.size

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1852,8 +1852,8 @@ attribute [simp] Chain.nil
 
 @[simp]
 theorem chain_cons {a b : α} {l : List α} : Chain R a (b :: l) ↔ R a b ∧ Chain R b l :=
-  ⟨fun p ↦ by cases p with | cons n p => exact ⟨n, p⟩,
-   fun ⟨n, p⟩ ↦ p.cons n⟩
+  ⟨fun p => by cases p with | cons n p => exact ⟨n, p⟩,
+   fun ⟨n, p⟩ => p.cons n⟩
 
 theorem rel_of_chain_cons {a b : α} {l : List α} (p : Chain R a (b :: l)) : R a b :=
   (chain_cons.1 p).1

--- a/Std/Lean/HashSet.lean
+++ b/Std/Lean/HashSet.lean
@@ -49,7 +49,7 @@ instance : BEq (HashSet α) where
 
 /--
 `O(1)` amortized. Similar to `insert`, but also returns a Boolean flag indicating whether an
-existing entry has been replaced with `a ↦ b`.
+existing entry has been replaced with `a => b`.
 -/
 @[inline]
 def insert' (s : HashSet α) (a : α) : HashSet α × Bool :=

--- a/Std/Lean/PersistentHashMap.lean
+++ b/Std/Lean/PersistentHashMap.lean
@@ -12,7 +12,7 @@ variable [BEq α] [Hashable α]
 
 /--
 Similar to `insert`, but also returns a Boolean flag indicating whether an
-existing entry has been replaced with `a ↦ b`.
+existing entry has been replaced with `a => b`.
 -/
 def insert' (m : PersistentHashMap α β) (a : α) (b : β) : PersistentHashMap α β × Bool :=
   let oldSize := m.size

--- a/Std/Lean/PersistentHashSet.lean
+++ b/Std/Lean/PersistentHashSet.lean
@@ -58,7 +58,7 @@ instance : BEq (PersistentHashSet α) where
 
 /--
 Similar to `insert`, but also returns a Boolean flag indicating whether an
-existing entry has been replaced with `a ↦ b`.
+existing entry has been replaced with `a => b`.
 -/
 @[inline]
 def insert' (s : PersistentHashSet α) (a : α) : PersistentHashSet α × Bool :=

--- a/Std/Tactic/Alias.lean
+++ b/Std/Tactic/Alias.lean
@@ -130,7 +130,7 @@ Given a possibly forall-quantified iff expression `prf`, produce a value for one
 of the implication directions (determined by `mp`).
 -/
 def mkIffMpApp (mp : Bool) (ty prf : Expr) : MetaM Expr := do
-  Meta.forallTelescope ty fun xs ty ↦ do
+  Meta.forallTelescope ty fun xs ty => do
     let some (lhs, rhs) := ty.iff?
       | throwError "Target theorem must have the form `∀ x y z, a ↔ b`"
     Meta.mkLambdaFVars xs <|

--- a/Std/Tactic/Basic.lean
+++ b/Std/Tactic/Basic.lean
@@ -152,7 +152,7 @@ macro (name := Conv.exact) "exact " t:term : conv => `(conv| tactic => exact $t)
 /-- The `conv` tactic `equals` claims that the currently focused subexpression is equal
  to the given expression, and proves this claim using the given tactic.
 ```
-example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
+example (P : (Nat → Nat) → Prop) : P (fun n => n - n) := by
   conv in (_ - _) => equals 0 =>
     -- current goal: ⊢ n - n = 0
     apply Nat.sub_self

--- a/Std/Tactic/SqueezeScope.lean
+++ b/Std/Tactic/SqueezeScope.lean
@@ -65,7 +65,7 @@ open Meta
 
 /--
 We implement `squeeze_scope` using a global variable that tracks all `squeeze_scope` invocations
-in flight. It is a map `a ↦ (x ↦ (stx, simps))` where `a` is a unique identifier for
+in flight. It is a map `a => (x => (stx, simps))` where `a` is a unique identifier for
 the `squeeze_scope` invocation which is shared with all contained simps, and `x` is a unique
 identifier for a particular piece of simp syntax (which can be called multiple times).
 Within that, `stx` is the simp syntax itself, and `simps` is the aggregated list of simps used

--- a/test/conv_equals.lean
+++ b/test/conv_equals.lean
@@ -14,7 +14,7 @@ import Std.Tactic.GuardExpr
 
 /-- warning: declaration uses 'sorry' -/
 #guard_msgs in
-example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
+example (P : (Nat → Nat) → Prop) : P (fun n => n - n) := by
   conv in (_ - _) => equals 0 =>
     -- current goal: ⊢ n - n = 0
     guard_target =ₛ n - n = 0
@@ -37,7 +37,7 @@ n : Nat
 error: no goals to be solved
 -/
 #guard_msgs in
-example (P : (Nat → Nat) → Prop) : P (fun n ↦ n - n) := by
+example (P : (Nat → Nat) → Prop) : P (fun n => n - n) := by
   conv in (_ - _) =>
     equals 0 => skip -- this should complain
     -- and at this point, there should be no goal left


### PR DESCRIPTION
Simplest possible implementation of a linter forbidding `↦`. I propose not building more general infrastructure until we want it.