### PR TITLE
chore: bump to nightly-2023-09-14

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.0.0
+leanprover/lean4:nightly-2023-09-14

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -37,7 +37,7 @@ unsafe def main (args : List String) : IO Unit := do
   let nolintsFile := "scripts/nolints.json"
   let nolints ← readJsonFile NoLints nolintsFile
   searchPathRef.set compile_time_search_path%
-  withImportModules [{module}] {} (trustLevel := 1024) fun env =>
+  withImportModules #[{module}] {} (trustLevel := 1024) fun env =>
     let ctx := {fileName := "", fileMap := default}
     let state := {env}
     Prod.fst <$> (CoreM.toIO · ctx state) do


### PR DESCRIPTION
No need to merge this, just for use on Mathlib's `nightly-testing`. We can bump to `v4.1.0-rc` tomorrow.