### PR TITLE
feat: a linter for instances that are not classes

### DIFF
--- a/Std/Tactic/Lint/TypeClass.lean
+++ b/Std/Tactic/Lint/TypeClass.lean
@@ -32,3 +32,15 @@ another instance-implicit argument or the return type."
       return some m!"argument {i+1} {arg} : {← inferType arg}"
     if impossibleArgs.isEmpty then return none
     addMessageContextFull <| .joinSep impossibleArgs.toList ", "
+
+/--
+A linter for checking if any declaration whose type is not a class is marked as an instance.
+-/
+@[std_linter] def nonClassInstance : Linter where
+  noErrorsFound := "No instances of non-classes"
+  errorsFound := "INSTANCES OF NON-CLASSES"
+  test declName := do
+    if !(← isInstance declName) then return none
+    let info ← getConstInfo declName
+    if !(← isClass? info.type).isSome then return "should not be an instance"
+    return none

--- a/test/lintTC.lean
+++ b/test/lintTC.lean
@@ -5,3 +5,10 @@ namespace A
 local instance impossible {α β : Type} [Inhabited α] : Nonempty α := ⟨default⟩
 #eval do guard (← impossibleInstance.test ``impossible).isSome
 end A
+
+namespace B
+instance bad : Nat := 1
+#eval do guard (← nonClassInstance.test ``bad).isSome
+instance good : Inhabited Nat := ⟨1⟩
+#eval do guard (← nonClassInstance.test ``good).isNone
+end B


### PR DESCRIPTION
was https://github.com/leanprover-community/mathlib4/pull/7250/

Following https://github.com/leanprover-community/mathlib4/pull/7245, [leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/isClass.3F.20panic!/near/391779504](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/isClass.3F.20panic!/near/391779504).