### PR TITLE
fix: ignore `def`/`theorem` confusion in docBlame

### DIFF
--- a/Std/Tactic/Lint/Frontend.lean
+++ b/Std/Tactic/Lint/Frontend.lean
@@ -208,7 +208,9 @@ def getDeclsInPackage (pkg : Name) : CoreM (Array Name) := do
 syntax inProject := " in " ident
 
 open Elab Command in
-/-- The command `#lint` runs the linters on the current file (by default). -/
+/-- The command `#lint` runs the linters on the current file (by default).
+
+`#lint only someLinter` can be used to run only a single linter. -/
 elab tk:"#lint" verbosity:("+" <|> "-")? fast:"*"? only:(&" only")?
     linters:(ppSpace ident)* project:(inProject)? : command => do
   let (decls, whereDesc, groupByFilename) ← match project with

--- a/Std/Tactic/Lint/Misc.lean
+++ b/Std/Tactic/Lint/Misc.lean
@@ -66,11 +66,10 @@ We skip all declarations that contain `sorry` in their value. -/
     if let .str _ s := declName then
       if s == "parenthesizer" || s == "formatter" || s == "delaborator" || s == "quot" then
       return none
-    let info ← getConstInfo declName
-    let kind ← match info with
+    let kind ← match ← getConstInfo declName with
       | .axiomInfo .. => pure "axiom"
       | .opaqueInfo .. => pure "constant"
-      | .defnInfo .. =>
+      | .defnInfo info =>
           -- projections are generated as `def`s even when they should be `theorem`s
           if ← isProjectionFn declName <&&> isProp info.type then
             return none
@@ -87,10 +86,9 @@ We skip all declarations that contain `sorry` in their value. -/
   test declName := do
     if ← isAutoDecl declName then
       return none
-    let info ← getConstInfo declName
-    let kind ← match info with
+    let kind ← match ← getConstInfo declName with
       | .thmInfo .. => pure "theorem"
-      | .defnInfo .. =>
+      | .defnInfo info =>
           -- projections are generated as `def`s even when they should be `theorem`s
           if ← isProjectionFn declName <&&> isProp info.type then
             pure "Prop projection"

--- a/Std/Tactic/Lint/Misc.lean
+++ b/Std/Tactic/Lint/Misc.lean
@@ -72,7 +72,7 @@ We skip all declarations that contain `sorry` in their value. -/
       | .opaqueInfo .. => pure "constant"
       | .defnInfo .. =>
           -- projections are generated as `def`s even when they should be `theorem`s
-          if (← isProjectionFn declName) && (← isProp info.type) then
+          if ← isProjectionFn declName <&&> isProp info.type then
             return none
           pure "definition"
       | .inductInfo .. => pure "inductive"

--- a/Std/Tactic/Lint/Misc.lean
+++ b/Std/Tactic/Lint/Misc.lean
@@ -92,7 +92,7 @@ We skip all declarations that contain `sorry` in their value. -/
       | .thmInfo .. => pure "theorem"
       | .defnInfo .. =>
           -- projections are generated as `def`s even when they should be `theorem`s
-          if (← isProjectionFn declName) && (← isProp info.type) then
+          if ← isProjectionFn declName <&&> isProp info.type then
             return "Prop projection"
           else
             return none

--- a/Std/Tactic/Lint/Misc.lean
+++ b/Std/Tactic/Lint/Misc.lean
@@ -70,7 +70,7 @@ We skip all declarations that contain `sorry` in their value. -/
       | .axiomInfo .. => pure "axiom"
       | .opaqueInfo .. => pure "constant"
       | .defnInfo info =>
-          -- projections are generated as `def`s even when they should be `theorem`s
+          -- leanprover/lean4#2575: projections are generated as `def`s even when they should be `theorem`s
           if ← isProjectionFn declName <&&> isProp info.type then
             return none
           pure "definition"
@@ -89,7 +89,7 @@ We skip all declarations that contain `sorry` in their value. -/
     let kind ← match ← getConstInfo declName with
       | .thmInfo .. => pure "theorem"
       | .defnInfo info =>
-          -- projections are generated as `def`s even when they should be `theorem`s
+          -- leanprover/lean4#2575: projections are generated as `def`s even when they should be `theorem`s
           if ← isProjectionFn declName <&&> isProp info.type then
             pure "Prop projection"
           else
@@ -106,6 +106,7 @@ has been used. -/
   test declName := do
     if (← isAutoDecl declName) || isGlobalInstance (← getEnv) declName then
       return none
+    -- leanprover/lean4#2575: projections are generated as `def`s even when they should be `theorem`s
     if ← isProjectionFn declName then return none
     let info ← getConstInfo declName
     let isThm ← match info with

--- a/Std/Tactic/Lint/Misc.lean
+++ b/Std/Tactic/Lint/Misc.lean
@@ -70,7 +70,8 @@ We skip all declarations that contain `sorry` in their value. -/
       | .axiomInfo .. => pure "axiom"
       | .opaqueInfo .. => pure "constant"
       | .defnInfo info =>
-          -- leanprover/lean4#2575: projections are generated as `def`s even when they should be `theorem`s
+          -- leanprover/lean4#2575: 
+          -- projections are generated as `def`s even when they should be `theorem`s
           if ← isProjectionFn declName <&&> isProp info.type then
             return none
           pure "definition"
@@ -89,7 +90,8 @@ We skip all declarations that contain `sorry` in their value. -/
     let kind ← match ← getConstInfo declName with
       | .thmInfo .. => pure "theorem"
       | .defnInfo info =>
-          -- leanprover/lean4#2575: projections are generated as `def`s even when they should be `theorem`s
+          -- leanprover/lean4#2575: 
+          -- projections are generated as `def`s even when they should be `theorem`s
           if ← isProjectionFn declName <&&> isProp info.type then
             pure "Prop projection"
           else
@@ -106,7 +108,8 @@ has been used. -/
   test declName := do
     if (← isAutoDecl declName) || isGlobalInstance (← getEnv) declName then
       return none
-    -- leanprover/lean4#2575: projections are generated as `def`s even when they should be `theorem`s
+    -- leanprover/lean4#2575: 
+    -- projections are generated as `def`s even when they should be `theorem`s
     if ← isProjectionFn declName then return none
     let info ← getConstInfo declName
     let isThm ← match info with

--- a/Std/Tactic/Lint/Misc.lean
+++ b/Std/Tactic/Lint/Misc.lean
@@ -93,7 +93,7 @@ We skip all declarations that contain `sorry` in their value. -/
       | .defnInfo .. =>
           -- projections are generated as `def`s even when they should be `theorem`s
           if ← isProjectionFn declName <&&> isProp info.type then
-            return "Prop projection"
+            pure "Prop projection"
           else
             return none
       | _ => return none

--- a/test/lint_docBlame.lean
+++ b/test/lint_docBlame.lean
@@ -10,6 +10,6 @@ structure AtLeastThirtySeven where
   prop : 37 ≤ val
 
 -- or here
-theorem AtLeastThirdySeven.lt (x : AtLeastThirtySeven) : 36 < x.val := x.prop
+theorem AtLeastThirtySeven.lt (x : AtLeastThirtySeven) : 36 < x.val := x.prop
 
 #lint- only docBlame

--- a/test/lint_docBlame.lean
+++ b/test/lint_docBlame.lean
@@ -1,0 +1,15 @@
+import Std.Tactic.Lint
+
+set_option linter.missingDocs false
+
+/-- A docstring is needed here -/
+structure AtLeastThirtySeven where
+  /-- and here -/
+  val : Nat := 1
+  -- but not here
+  prop : 37 ≤ val
+
+-- or here
+theorem AtLeastThirdySeven.lt (x : AtLeastThirtySeven) : 36 < x.val := x.prop
+
+#lint- only docBlame

--- a/test/lint_docBlameThm.lean
+++ b/test/lint_docBlameThm.lean
@@ -10,6 +10,6 @@ structure AtLeastThirtySeven where
   prop : 37 ≤ val
 
 /-- and here -/
-theorem AtLeastThirdySeven.lt (x : AtLeastThirtySeven) : 36 < x.val := x.prop
+theorem AtLeastThirtySeven.lt (x : AtLeastThirtySeven) : 36 < x.val := x.prop
 
 #lint- only docBlameThm

--- a/test/lint_docBlameThm.lean
+++ b/test/lint_docBlameThm.lean
@@ -1,0 +1,15 @@
+import Std.Tactic.Lint
+
+set_option linter.missingDocs false
+
+-- A docstring is not needed here
+structure AtLeastThirtySeven where
+  -- or here
+  val : Nat := 1
+  /-- but is needed here -/
+  prop : 37 ≤ val
+
+/-- and here -/
+theorem AtLeastThirdySeven.lt (x : AtLeastThirtySeven) : 36 < x.val := x.prop
+
+#lint- only docBlameThm


### PR DESCRIPTION
Some `def`s are generated by core and should really be theorems; we treat them as such in the `docBlame` and `docBlameThm` linters.

This fixes #217.