### PR TITLE
feat: add non-monotone map function to RBSet

### DIFF
--- a/Std/Data/RBMap/Basic.lean
+++ b/Std/Data/RBMap/Basic.lean
@@ -835,6 +835,13 @@ def filter (t : RBSet α cmp) (p : α → Bool) : RBSet α cmp :=
   t.foldl (init := ∅) fun acc a => bif p a then acc.insert a else acc
 
 /--
+`O(n * log n)`. Map a function on every value in the set.
+If the function is monotone, consider using the more efficient `RBSet.mapMonotone` instead.
+-/
+def map (t : RBSet α cmpα) (f : α → β) : RBSet β cmpβ :=
+  t.foldl (fun acc a => acc.insert <| f a) (mkRBSet β cmpβ)
+
+/--
 `O(n₁ * (log n₁ + log n₂))`. Constructs the set of all elements of `t₁` that are not in `t₂`.
 -/
 def sdiff (t₁ t₂ : RBSet α cmp) : RBSet α cmp := t₁.filter (!t₂.contains ·)

--- a/Std/Data/RBMap/Basic.lean
+++ b/Std/Data/RBMap/Basic.lean
@@ -839,7 +839,7 @@ def filter (t : RBSet α cmp) (p : α → Bool) : RBSet α cmp :=
 If the function is monotone, consider using the more efficient `RBSet.mapMonotone` instead.
 -/
 def map (t : RBSet α cmpα) (f : α → β) : RBSet β cmpβ :=
-  t.foldl (fun acc a => acc.insert <| f a) (mkRBSet β cmpβ)
+  t.foldl (init := ∅) fun acc a => acc.insert <| f a
 
 /--
 `O(n₁ * (log n₁ + log n₂))`. Constructs the set of all elements of `t₁` that are not in `t₂`.

--- a/Std/Data/RBMap/Basic.lean
+++ b/Std/Data/RBMap/Basic.lean
@@ -836,9 +836,9 @@ def filter (t : RBSet α cmp) (p : α → Bool) : RBSet α cmp :=
 
 /--
 `O(n * log n)`. Map a function on every value in the set.
-If the function is monotone, consider using the more efficient `RBSet.mapMonotone` instead.
+If the function is monotone, consider using the more efficient `RBSet.map` instead.
 -/
-def map (t : RBSet α cmpα) (f : α → β) : RBSet β cmpβ :=
+def image (t : RBSet α cmpα) (f : α → β) : RBSet β cmpβ :=
   t.foldl (init := ∅) fun acc a => acc.insert <| f a
 
 /--

--- a/Std/Data/RBMap/Basic.lean
+++ b/Std/Data/RBMap/Basic.lean
@@ -836,9 +836,9 @@ def filter (t : RBSet α cmp) (p : α → Bool) : RBSet α cmp :=
 
 /--
 `O(n * log n)`. Map a function on every value in the set.
-If the function is monotone, consider using the more efficient `RBSet.map` instead.
+If the function is monotone, consider using the more efficient `RBSet.mapMonotone` instead.
 -/
-def image (t : RBSet α cmpα) (f : α → β) : RBSet β cmpβ :=
+def map (t : RBSet α cmpα) (f : α → β) : RBSet β cmpβ :=
   t.foldl (init := ∅) fun acc a => acc.insert <| f a
 
 /--

--- a/Std/Data/RBMap/WF.lean
+++ b/Std/Data/RBMap/WF.lean
@@ -508,9 +508,9 @@ export RBNode (IsMonotone)
 /--
 `O(n)`. Map a function on every value in the set.
 This requires `IsMonotone` on the function in order to preserve the order invariant.
-If the function is not monotone, use `RBSet.image` instead.
+If the function is not monotone, use `RBSet.map` instead.
 -/
-@[inline] def map (f : α → β) [IsMonotone cmpα cmpβ f] (t : RBSet α cmpα) : RBSet β cmpβ :=
+@[inline] def mapMonotone (f : α → β) [IsMonotone cmpα cmpβ f] (t : RBSet α cmpα) : RBSet β cmpβ :=
   ⟨t.1.map f, have ⟨h₁, _, _, h₂⟩ := t.2.out; .mk (h₁.map _) h₂.map⟩
 
 end RBSet
@@ -539,6 +539,6 @@ instance (cmp : α → α → Ordering) (f : α → β → γ) :
 end Imp
 
 /-- `O(n)`. Map a function on the values in the map. -/
-def mapVal (f : α → β → γ) (t : RBMap α β cmp) : RBMap α γ cmp := t.map (Imp.mapSnd f)
+def mapVal (f : α → β → γ) (t : RBMap α β cmp) : RBMap α γ cmp := t.mapMonotone (Imp.mapSnd f)
 
 end RBMap

--- a/Std/Data/RBMap/WF.lean
+++ b/Std/Data/RBMap/WF.lean
@@ -509,7 +509,7 @@ export RBNode (IsMonotone)
 `O(n)`. Map a function on every value in the tree.
 This requires `IsMonotone` on the function in order to preserve the order invariant.
 -/
-@[inline] def map (f : α → β) [IsMonotone cmpα cmpβ f] (t : RBSet α cmpα) : RBSet β cmpβ :=
+@[inline] def mapMonotone (f : α → β) [IsMonotone cmpα cmpβ f] (t : RBSet α cmpα) : RBSet β cmpβ :=
   ⟨t.1.map f, have ⟨h₁, _, _, h₂⟩ := t.2.out; .mk (h₁.map _) h₂.map⟩
 
 end RBSet
@@ -538,6 +538,6 @@ instance (cmp : α → α → Ordering) (f : α → β → γ) :
 end Imp
 
 /-- `O(n)`. Map a function on the values in the map. -/
-def mapVal (f : α → β → γ) (t : RBMap α β cmp) : RBMap α γ cmp := t.map (Imp.mapSnd f)
+def mapVal (f : α → β → γ) (t : RBMap α β cmp) : RBMap α γ cmp := t.mapMonotone (Imp.mapSnd f)
 
 end RBMap

--- a/Std/Data/RBMap/WF.lean
+++ b/Std/Data/RBMap/WF.lean
@@ -508,9 +508,9 @@ export RBNode (IsMonotone)
 /--
 `O(n)`. Map a function on every value in the set.
 This requires `IsMonotone` on the function in order to preserve the order invariant.
-If the function is not monotone, use `RBSet.map` instead.
+If the function is not monotone, use `RBSet.image` instead.
 -/
-@[inline] def mapMonotone (f : α → β) [IsMonotone cmpα cmpβ f] (t : RBSet α cmpα) : RBSet β cmpβ :=
+@[inline] def map (f : α → β) [IsMonotone cmpα cmpβ f] (t : RBSet α cmpα) : RBSet β cmpβ :=
   ⟨t.1.map f, have ⟨h₁, _, _, h₂⟩ := t.2.out; .mk (h₁.map _) h₂.map⟩
 
 end RBSet
@@ -539,6 +539,6 @@ instance (cmp : α → α → Ordering) (f : α → β → γ) :
 end Imp
 
 /-- `O(n)`. Map a function on the values in the map. -/
-def mapVal (f : α → β → γ) (t : RBMap α β cmp) : RBMap α γ cmp := t.mapMonotone (Imp.mapSnd f)
+def mapVal (f : α → β → γ) (t : RBMap α β cmp) : RBMap α γ cmp := t.map (Imp.mapSnd f)
 
 end RBMap

--- a/Std/Data/RBMap/WF.lean
+++ b/Std/Data/RBMap/WF.lean
@@ -506,8 +506,9 @@ namespace RBSet
 export RBNode (IsMonotone)
 
 /--
-`O(n)`. Map a function on every value in the tree.
+`O(n)`. Map a function on every value in the set.
 This requires `IsMonotone` on the function in order to preserve the order invariant.
+If the function is not monotone, use `RBSet.map` instead.
 -/
 @[inline] def mapMonotone (f : α → β) [IsMonotone cmpα cmpβ f] (t : RBSet α cmpα) : RBSet β cmpβ :=
   ⟨t.1.map f, have ⟨h₁, _, _, h₂⟩ := t.2.out; .mk (h₁.map _) h₂.map⟩


### PR DESCRIPTION
The rename makes Lean more consistent with OCaml and Haskell, where the default `Set.map` is not monotone.

- https://v2.ocaml.org/api/Set.S.html#VALmap
- https://hackage.haskell.org/package/containers-0.6.7/docs/Data-Set.html#g:10

Note that mathlib's `Finset` also has separate `map` and `image` functions, with `map` requiring extra conditions (injectivity). I think that reasoning doesn't apply for `RBSet` as the non-monotone case is much more common, and in this case consistency with Haskell/OCaml is more valuable than with mathlib.
