### PR TITLE
Add HashMap model

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -39,6 +39,7 @@ import Std.Data.List.Count
 import Std.Data.List.Init.Lemmas
 import Std.Data.List.Lemmas
 import Std.Data.List.Pairwise
+import Std.Data.List.Perm
 import Std.Data.MLList.Basic
 import Std.Data.MLList.Heartbeats
 import Std.Data.Nat.Basic

--- a/Std/Classes/BEq.lean
+++ b/Std/Classes/BEq.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 
+import Std.Logic
+
 /-! ## Boolean equality -/
 
 /-- `PartialEquivBEq α` says that the `BEq` implementation is a
@@ -17,7 +19,32 @@ class PartialEquivBEq (α) [BEq α] : Prop where
   /-- Transitivity for `BEq`. If `a == b` and `b == c` then `a == c`. -/
   trans : (a : α) == b → b == c → a == c
 
+instance [BEq α] [LawfulBEq α] : PartialEquivBEq α where
+  symm h := by rw [beq_iff_eq] at *; rw [h]
+  trans h₁ h₂ := by rw [beq_iff_eq] at *; exact h₁.trans h₂
+
+theorem beq_symm [BEq α] [PartialEquivBEq α] {a b : α} : a == b → b == a :=
+  PartialEquivBEq.symm
+
+theorem beq_trans [BEq α] [PartialEquivBEq α] {a b c : α} : a == b → b == c → a == c:=
+  PartialEquivBEq.trans
+
+theorem bne_symm [BEq α] [PartialEquivBEq α] {a b : α} : a != b → b != a :=
+  fun h => Bool.bne_iff_not_beq.mpr fun h' =>
+    Bool.bne_iff_not_beq.mp h (beq_symm h')
+
+theorem bne_trans_right [BEq α] [PartialEquivBEq α] {a b c : α} :
+    a == b → b != c → a != c :=
+  fun h₁ h₂ => Bool.bne_iff_not_beq.mpr fun h₃ =>
+    have := beq_trans (beq_symm h₁) h₃
+    Bool.bne_iff_not_beq.mp h₂ this
+
+theorem bne_trans_left [BEq α] [PartialEquivBEq α] {a b c : α} :
+    a != b → b == c → a != c :=
+  fun h₁ h₂ => Bool.bne_iff_not_beq.mpr fun h₃ =>
+    have := beq_trans h₃ (beq_symm h₂)
+    Bool.bne_iff_not_beq.mp h₁ this
+
 @[simp] theorem beq_eq_false_iff_ne [BEq α] [LawfulBEq α]
     (a b : α) : (a == b) = false ↔ a ≠ b := by
-  rw [ne_eq, ← beq_iff_eq a b]
-  cases a == b <;> decide
+  simp only [Bool.beq_eq_false_iff, bne_iff_ne]

--- a/Std/Data/Array/Lemmas.lean
+++ b/Std/Data/Array/Lemmas.lean
@@ -53,6 +53,10 @@ theorem get?_len_le (a : Array α) (i : Nat) (h : a.size ≤ i) : a[i]? = none :
 theorem getElem_mem_data (a : Array α) (h : i < a.size) : a[i] ∈ a.data := by
   simp [getElem_eq_data_get, List.get_mem]
 
+theorem get_of_mem_data {as : Array α} {a : α} :
+    a ∈ as.data → ∃ (i : Fin as.size), as[i] = a :=
+  List.get_of_mem
+
 theorem getElem?_eq_data_get? (a : Array α) (i : Nat) : a[i]? = a.data.get? i := by
   by_cases i < a.size <;> simp_all [getElem?_pos, getElem?_neg, List.get?_eq_get, eq_comm]; rfl
 

--- a/Std/Data/HashMap/Basic.lean
+++ b/Std/Data/HashMap/Basic.lean
@@ -14,19 +14,22 @@ class LawfulHashable (α : Type _) [BEq α] [Hashable α] : Prop where
   /-- Two elements which compare equal under the `BEq` instance have equal hash. -/
   hash_eq {a b : α} : a == b → hash a = hash b
 
+instance [BEq α] [LawfulBEq α] [Hashable α] : LawfulHashable α where
+  hash_eq h := by rw [LawfulBEq.eq_of_beq h]
+
 namespace Imp
 
 /--
 The bucket array of a `HashMap` is a nonempty array of `AssocList`s.
 (This type is an internal implementation detail of `HashMap`.)
 -/
-def Buckets (α : Type u) (β : Type v) := {b : Array (AssocList α β) // 0 < b.size}
+def Buckets (α : Type u) (β : Type v) := {b : Array (AssocList α β) // b.size.isPowerOfTwo}
 
 namespace Buckets
 
-/-- Construct a new empty bucket array with the specified capacity. -/
-def mk (buckets := 8) (h : 0 < buckets := by decide) : Buckets α β :=
-  ⟨mkArray buckets .nil, by simp [h]⟩
+/-- Construct a new empty bucket array with the specified number of buckets. -/
+def mk (nBuckets : Nat) (h : nBuckets.isPowerOfTwo) : Buckets α β :=
+  ⟨mkArray nBuckets .nil, by simp [h]⟩
 
 /-- Update one bucket in the bucket array with a new value. -/
 def update (data : Buckets α β) (i : USize)
@@ -80,28 +83,24 @@ A "load factor" of 0.75 is the usual standard for hash maps, so we return `capac
   capacity * 4 / 3
 
 /-- Constructs an empty hash map with the specified nonzero number of buckets. -/
-@[inline] def empty' (buckets := 8) (h : 0 < buckets := by decide) : Imp α β :=
-  ⟨0, .mk buckets h⟩
+@[inline] def empty' (nBuckets : Nat) (h : nBuckets.isPowerOfTwo) : Imp α β :=
+  ⟨0, .mk nBuckets h⟩
 
 /-- Constructs an empty hash map with the specified target capacity. -/
-def empty (capacity := 0) : Imp α β :=
-  let nbuckets := numBucketsForCapacity capacity
-  let n : {n : Nat // 0 < n} :=
-    if h : nbuckets = 0 then ⟨8, by decide⟩
-    else ⟨nbuckets, Nat.zero_lt_of_ne_zero h⟩
-  empty' n n.2
+def empty (capacity := 8) : Imp α β :=
+  let nBuckets := numBucketsForCapacity capacity |>.nextPowerOfTwo
+  empty' nBuckets (Nat.isPowerOfTwo_nextPowerOfTwo _)
 
-/-- Calculates the bucket index from a hash value `u`. -/
-def mkIdx {n : Nat} (h : 0 < n) (u : USize) : {u : USize // u.toNat < n} :=
-  ⟨u % n, USize.modn_lt _ h⟩
+/-- Calculates the bucket index from a `hash` value. -/
+def mkIdx {sz : Nat} (hash : UInt64) (h : sz.isPowerOfTwo) : {u : USize // u.toNat < sz} :=
+  ⟨hash.toUSize % sz, USize.modn_lt _ (Nat.pos_of_isPowerOfTwo h)⟩
 
 /--
 Inserts a key-value pair into the bucket array. This function assumes that the data is not
 already in the array, which is appropriate when reinserting elements into the array after a resize.
 -/
-@[inline] def reinsertAux [Hashable α]
-    (data : Buckets α β) (a : α) (b : β) : Buckets α β :=
-  let ⟨i, h⟩ := mkIdx data.2 (hash a |>.toUSize)
+@[inline] def reinsertAux [Hashable α] (data : Buckets α β) (a : α) (b : β) : Buckets α β :=
+  let ⟨i, h⟩ := mkIdx (hash a) data.property
   data.update i (.cons a b data.1[i]) h
 
 /-- Folds a monadic function over the elements in the map (in arbitrary order). -/
@@ -110,7 +109,7 @@ already in the array, which is appropriate when reinserting elements into the ar
 
 /-- Folds a function over the elements in the map (in arbitrary order). -/
 @[inline] def fold (f : δ → α → β → δ) (d : δ) (m : Imp α β) : δ :=
-  Id.run $ foldM f d m
+  m.buckets.1.foldl (init := d) fun d b => b.foldl f d
 
 /-- Runs a monadic function over the elements in the map (in arbitrary order). -/
 @[inline] def forM [Monad m] (f : α → β → m PUnit) (h : Imp α β) : m PUnit :=
@@ -119,25 +118,26 @@ already in the array, which is appropriate when reinserting elements into the ar
 /-- Given a key `a`, returns a key-value pair in the map whose key compares equal to `a`. -/
 def findEntry? [BEq α] [Hashable α] (m : Imp α β) (a : α) : Option (α × β) :=
   let ⟨_, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx (hash a) buckets.property
   buckets.1[i].findEntry? a
 
 /-- Looks up an element in the map with key `a`. -/
 def find? [BEq α] [Hashable α] (m : Imp α β) (a : α) : Option β :=
   let ⟨_, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx (hash a) buckets.property
   buckets.1[i].find? a
 
 /-- Returns true if the element `a` is in the map. -/
 def contains [BEq α] [Hashable α] (m : Imp α β) (a : α) : Bool :=
   let ⟨_, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx (hash a) buckets.property
   buckets.1[i].contains a
 
 /-- Copies all the entries from `buckets` into a new hash map with a larger capacity. -/
 def expand [Hashable α] (size : Nat) (buckets : Buckets α β) : Imp α β :=
   let nbuckets := buckets.1.size * 2
-  { size, buckets := go 0 buckets.1 (.mk nbuckets (Nat.mul_pos buckets.2 (by decide))) }
+  have h : nbuckets.isPowerOfTwo := Nat.mul2_isPowerOfTwo_of_isPowerOfTwo buckets.property
+  { size, buckets := go 0 buckets.1 (.mk nbuckets h) }
 where
   /-- Inner loop of `expand`. Copies elements `source[i:]` into `target`,
   destroying `source` in the process. -/
@@ -159,7 +159,7 @@ If an element equal to `a` is already in the map, it is replaced by `b`.
 -/
 @[inline] def insert [BEq α] [Hashable α] (m : Imp α β) (a : α) (b : β) : Imp α β :=
   let ⟨size, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx (hash a) buckets.property
   let bkt := buckets.1[i]
   bif bkt.contains a then
     ⟨size, buckets.update i (bkt.replace a b) h⟩
@@ -176,7 +176,7 @@ Removes key `a` from the map. If it does not exist in the map, the map is return
 -/
 def erase [BEq α] [Hashable α] (m : Imp α β) (a : α) : Imp α β :=
   let ⟨size, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx (hash a) buckets.property
   let bkt := buckets.1[i]
   bif bkt.contains a then ⟨size - 1, buckets.update i (bkt.erase a) h⟩ else m
 
@@ -187,7 +187,7 @@ def erase [BEq α] [Hashable α] (m : Imp α β) (a : α) : Imp α β :=
 /-- Performs an in-place edit of the value, ensuring that the value is used linearly. -/
 def modify [BEq α] [Hashable α] (m : Imp α β) (a : α) (f : α → β → β) : Imp α β :=
   let ⟨size, buckets⟩ := m
-  let ⟨i, h⟩ := mkIdx buckets.2 (hash a |>.toUSize)
+  let ⟨i, h⟩ := mkIdx (hash a) buckets.property
   let bkt := buckets.1[i]
   let buckets := buckets.update i .nil h -- for linearity
   ⟨size, buckets.update i (bkt.modify a f) ((Buckets.update_size ..).symm ▸ h)⟩
@@ -199,7 +199,7 @@ Applies `f` to each key-value pair `a, b` in the map. If it returns `some c` the
 @[specialize] def filterMap {α : Type u} {β : Type v} {γ : Type w}
     (f : α → β → Option γ) (m : Imp α β) : Imp α γ :=
   let m' := m.buckets.1.mapM (m := StateT (ULift Nat) Id) (go .nil) |>.run ⟨0⟩ |>.run
-  have : m'.1.size > 0 := by
+  have : m'.1.size.isPowerOfTwo := by
     have := Array.size_mapM (m := StateT (ULift Nat) Id) (go .nil) m.buckets.1
     simp [SatisfiesM_StateT_eq, SatisfiesM_Id_eq] at this
     simp [this, Id.run, StateT.run, m.2.2]
@@ -360,11 +360,11 @@ def numBuckets (self : HashMap α β) : Nat := self.1.buckets.1.size
 Builds a `HashMap` from a list of key-value pairs.
 Values of duplicated keys are replaced by their respective last occurrences.
 -/
-def ofList [BEq α] [Hashable α] (l : List (α × β)) : HashMap α β :=
+def ofList (l : List (α × β)) : HashMap α β :=
   l.foldl (init := HashMap.empty) fun m (k, v) => m.insert k v
 
 /-- Variant of `ofList` which accepts a function that combines values of duplicated keys. -/
-def ofListWith [BEq α] [Hashable α] (l : List (α × β)) (f : β → β → β) : HashMap α β :=
+def ofListWith (l : List (α × β)) (f : β → β → β) : HashMap α β :=
   l.foldl (init := HashMap.empty) fun m p =>
     match m.find? p.1 with
     | none   => m.insert p.1 p.2

--- a/Std/Data/HashMap/Lemmas.lean
+++ b/Std/Data/HashMap/Lemmas.lean
@@ -1,0 +1,338 @@
+/-
+Copyright (c) 2022-2023 Wojciech Nawrocki. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Wojciech Nawrocki
+-/
+
+import Std.Data.HashMap.Basic
+import Std.Data.HashMap.WF
+import Std.Data.List.Lemmas
+import Std.Data.List.Perm
+import Std.Data.List.AtMostOne
+import Std.Data.Array.Lemmas
+
+namespace Std.HashMap
+variable [BEq α] [Hashable α] [LawfulHashable α] [PartialEquivBEq α]
+
+namespace Imp
+open List
+
+-- NOTE(WN): These would ideally be solved by a congruence-closure-for-PERs tactic
+-- See https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Rewriting.20congruent.20relations
+-- Same for proofs about List.Perm
+private theorem beq_nonsense_1 {a b c : α} : a != b → a == c → b != c :=
+  fun h₁ h₂ => bne_trans_left (bne_symm h₁) h₂
+
+private theorem beq_nonsense_3 {a b c : α} : a != b → c == b → c != a :=
+  fun h₁ h₂ => bne_trans_right h₂ (bne_symm h₁)
+
+namespace Buckets
+
+/-! ## Basic lemmas about the mathematical model -/
+
+/-- The mathematical model of the bucket array is a list of (key, value) pairs.
+
+We use this instead of `HashMap.toList`
+because it's easier to reason about `foldl (append)`
+than about `foldl (foldl)`.
+
+We use `bkts.val.foldl` rather than `bkts.val.data.foldl`
+because we sometimes need to reason about array indices. -/
+noncomputable def toListModel (bkts : Buckets α β) : List (α × β) :=
+  bkts.val.foldl (init := []) (fun acc bkt => acc ++ bkt.toList)
+
+attribute [local simp] foldl_cons_fn foldl_append_fn
+
+theorem toListModel_eq (bkts : Buckets α β) : bkts.toListModel = bkts.val.data.bind (·.toList) := by
+  simp [toListModel, Array.foldl_eq_foldl_data]
+
+/-- A (key, value) pair is in the list iff it's in the correct hash-determined bucket. -/
+theorem mem_toListModel_iff_mem_bucket (bkts : Buckets α β) (H : bkts.WF) (ab : α × β) :
+    haveI := mkIdx (hash ab.fst) bkts.property
+    ab ∈ bkts.toListModel ↔ ab ∈ (bkts.val[this.1.toNat]'this.2).toList := by
+  have : ab ∈ bkts.toListModel ↔ ∃ bkt ∈ bkts.val.data, ab ∈ bkt.toList := by
+    simp [toListModel_eq, mem_bind]
+  rw [this]
+  clear this
+  apply Iff.intro
+  . intro ⟨bkt, hBkt, hMem⟩
+    have ⟨i, hGetI⟩ := Array.get_of_mem_data hBkt
+    simp only [getElem_fin] at hGetI
+    suffices (mkIdx (hash ab.fst) bkts.property).val.toNat = i by
+      simp [Array.ugetElem_eq_getElem, this, hGetI, hMem]
+    unfold Imp.mkIdx
+    dsimp
+    exact H.hash_self i.val i.isLt ab (hGetI ▸ hMem)
+  . intro h
+    refine ⟨_, Array.getElem_mem_data _ _, h⟩
+
+theorem exists_of_toListModel_update (bkts : Buckets α β) (i d h) :
+    ∃ l₁ l₂, bkts.toListModel = l₁ ++ bkts.1[i.toNat].toList ++ l₂
+      ∧ (bkts.update i d h).toListModel = l₁ ++ d.toList ++ l₂ := by
+  have ⟨bs₁, bs₂, hTgt, _, hUpd⟩ := bkts.exists_of_update i d h
+  refine ⟨bs₁.bind (·.toList), bs₂.bind (·.toList), ?_, ?_⟩
+  . simp [toListModel_eq, hTgt]
+  . simp [toListModel_eq, hUpd]
+
+theorem exists_of_toListModel_update_WF (bkts : Buckets α β) (H : bkts.WF) (i d h) :
+    ∃ l₁ l₂, bkts.toListModel = l₁ ++ bkts.1[i.toNat].toList ++ l₂
+      ∧ (bkts.update i d h).toListModel = l₁ ++ d.toList ++ l₂
+      ∧ ∀ ab ∈ l₁, ((hash ab.fst).toUSize % bkts.val.size) < i := by
+  have ⟨bs₁, bs₂, hTgt, hLen, hUpd⟩ := bkts.exists_of_update i d h
+  refine ⟨bs₁.bind (·.toList), bs₂.bind (·.toList), ?_, ?_, ?_⟩
+  . simp [toListModel_eq, hTgt]
+  . simp [toListModel_eq, hUpd]
+  . intro ab hMem
+    have ⟨bkt, hBkt, hAb⟩ := mem_bind.mp hMem
+    clear hMem
+    have ⟨⟨j, hJ⟩, hEq⟩ := get_of_mem hBkt
+    have hJ' : j < bkts.val.size := by
+      apply Nat.lt_trans hJ
+      simp [Array.size, hTgt, Nat.lt_add_of_pos_right (Nat.succ_pos _)]
+    have : ab ∈ (bkts.val[j]).toList := by
+      suffices bkt = bkts.val[j] by rwa [this] at hAb
+      have := @List.get_append _ _ (bkts.val[i] :: bs₂) j hJ
+      dsimp at this
+      rw [← hEq, ← this, ← get_of_eq hTgt ⟨j, _⟩]
+      rfl
+    rwa [hLen, ← H.hash_self _ _ _ this] at hJ
+
+/-! ## Uniqueness of keys -/
+
+/-- The contents of any given bucket are pairwise `bne`. -/
+theorem Pairwise_bne_bucket (bkts : Buckets α β) (H : bkts.WF) (h : i < bkts.val.size) :
+    Pairwise (·.1 != ·.1) bkts.val[i].toList := by
+  have := H.distinct bkts.val[i] (Array.getElem_mem_data _ _)
+  exact Pairwise.imp Bool.bne_iff_not_beq.mpr this
+
+theorem atMostOne_beq_bucket (bkts : Buckets α β) (H : bkts.WF) (h : i < bkts.val.size) (a : α) :
+    AtMostOne (·.1 == a) bkts.val[i].toList :=
+  Pairwise.imp (fun h h₁ => by
+    rw [Bool.not_eq_true]
+    exact Bool.beq_eq_false_iff.mpr <| bne_trans_left (bne_symm h) h₁)
+  (Pairwise_bne_bucket bkts H h)
+
+/-- The map does not store duplicate (by `beq`) keys. -/
+theorem Pairwise_bne_toListModel (bkts : Buckets α β) (H : bkts.WF) :
+    bkts.toListModel.Pairwise (·.1 != ·.1) := by
+  unfold toListModel
+  refine Array.foldl_induction
+    (motive := fun i (acc : List (α × β)) =>
+      -- The acc has the desired property
+      acc.Pairwise (·.1 != ·.1)
+      -- All not-yet-accumulated buckets are pairwise disjoint with the acc
+      ∧ ∀ j, i ≤ j → (_ : j < bkts.val.size) →
+        ∀ p ∈ acc, ∀ r ∈ bkts.val[j].toList, p.1 != r.1)
+    ?h0 ?hf |>.left
+  case h0 => exact ⟨Pairwise.nil, fun.⟩
+  case hf =>
+    intro i acc h
+    refine ⟨pairwise_append.mpr ⟨h.left, ?bkt, ?accbkt⟩, ?accbkts⟩
+    case bkt => apply Pairwise_bne_bucket bkts H
+    case accbkt =>
+      intro a hA b hB
+      exact h.right i.val (Nat.le_refl _) i.isLt a hA b hB
+    case accbkts =>
+      intro j hGe hLt p hP r hR
+      cases mem_append.mp hP
+      case inl hP => exact h.right j (Nat.le_of_succ_le hGe) hLt p hP r hR
+      case inr hP =>
+        -- Main proof 2: distinct buckets store bne keys
+        refine Bool.bne_iff_not_beq.mpr fun h => ?_
+        have hHashEq := LawfulHashable.hash_eq h
+        have hGt := Nat.lt_of_succ_le hGe
+        have hHashP := H.hash_self i (Nat.lt_trans hGt hLt) _ hP
+        have hHashR := H.hash_self j hLt _ hR
+        dsimp at hHashP hHashR
+        have : i.val = j := by
+          rw [hHashEq] at hHashP
+          exact .trans hHashP.symm hHashR
+        exact Nat.ne_of_lt hGt this
+
+theorem atMostOne_beq_toListModel (bkts : Buckets α β) (H : bkts.WF) (a : α) :
+    bkts.toListModel.AtMostOne (·.1 == a) :=
+  Pairwise.imp
+    (fun h h₁ => by
+      rw [Bool.not_eq_true, Bool.beq_eq_false_iff]
+      exact bne_trans_left (bne_symm h) h₁)
+    (Pairwise_bne_toListModel bkts H)
+
+/-! ## Commuting `toListModel` past map operations -/
+
+@[simp]
+theorem toListModel_mk (size : Nat) (h : size.isPowerOfTwo) :
+    (Buckets.mk (α := α) (β := β) size h).toListModel = [] := by
+  simp only [Buckets.mk, toListModel_eq, mkArray_data]
+  clear h
+  induction size <;> simp [*]
+
+theorem toListModel_reinsertAux (tgt : Buckets α β) (a : α) (b : β) :
+    (reinsertAux tgt a b).toListModel ~ (a, b) :: tgt.toListModel := by
+  unfold reinsertAux
+  have ⟨l₁, l₂, hTgt, hUpd⟩ :=
+    haveI := mkIdx (hash a) tgt.property
+    tgt.exists_of_toListModel_update this.1 (.cons a b (tgt.1[this.1.toNat]'this.2)) this.2
+  simp [hTgt, hUpd, perm_middle]
+
+theorem toListModel_foldl_reinsertAux (bkt : List (α × β)) (tgt : Buckets α β) :
+    (bkt.foldl (init := tgt) fun acc x => reinsertAux acc x.fst x.snd).toListModel
+    ~ tgt.toListModel ++ bkt := by
+  induction bkt generalizing tgt with
+  | nil => simp [Perm.refl]
+  | cons p ps ih =>
+    refine Perm.trans (ih _) ?_
+    refine Perm.trans (Perm.append_right ps (toListModel_reinsertAux _ _ _)) ?_
+    rw [cons_append]
+    refine Perm.trans (Perm.symm perm_middle) ?_
+    apply Perm.append_left _ (Perm.refl _)
+
+theorem toListModel_expand (size : Nat) (bkts : Buckets α β) :
+    (expand size bkts).buckets.toListModel ~ bkts.toListModel := by
+  refine (go _ _ _).trans ?_
+  rw [toListModel_mk, toListModel_eq]
+  simp [Perm.refl]
+where
+  go (i : Nat) (src : Array (AssocList α β)) (target : Buckets α β) :
+      (expand.go i src target).toListModel
+      ~ (src.data.drop i).foldl (init := target.toListModel) (fun a b => a ++ b.toList) := by
+    unfold expand.go; split
+    case inl hI =>
+      refine (go (i +1) _ _).trans ?_
+      have h₀ : (src.data.set i AssocList.nil).drop (i + 1) = src.data.drop (i + 1) := by
+        apply drop_ext
+        intro j hJ
+        apply get?_set_ne _ _ (Nat.ne_of_lt <| Nat.lt_of_succ_le hJ)
+      have h₁ : (drop i src.data).bind (·.toList) = src.data[i].toList
+          ++ (drop (i + 1) src.data).bind (·.toList) := by
+        have : i < src.data.length := by simp [hI]
+        simp [drop_eq_get_cons this]
+      simp [h₀, h₁]
+      rw [← append_assoc]
+      refine Perm.append ?_ (Perm.refl _)
+      refine Perm.trans (toListModel_foldl_reinsertAux (AssocList.toList src[i]) _) ?_
+      exact Perm.refl _
+    case inr hI =>
+      have : src.data.length ≤ i := by simp [Nat.le_of_not_lt, hI]
+      simp [Perm.refl, drop_eq_nil_of_le this]
+    termination_by _ i src _ => src.size - i
+
+end Buckets
+
+/-! ## Map operations expressed in terms of `toListModel` -/
+
+theorem findEntry?_eq (m : Imp α β) (H : m.buckets.WF) (a : α)
+    : m.findEntry? a = m.buckets.toListModel.find? (·.1 == a) := by
+  have hPairwiseBkt :
+      haveI := mkIdx (hash a) m.buckets.property
+      AtMostOne (·.1 == a) (m.buckets.val[this.1]'this.2).toList :=
+    by apply Buckets.atMostOne_beq_bucket m.buckets H
+  apply Option.ext
+  intro (a', b)
+  simp only [Option.mem_def, findEntry?, Imp.findEntry?, AssocList.findEntry?_eq,
+    hPairwiseBkt.find?_eq_some_iff,
+    (Buckets.atMostOne_beq_toListModel m.buckets H a).find?_eq_some_iff,
+    and_congr_left_iff]
+  intro hBeq
+  have : hash a' = hash a := LawfulHashable.hash_eq hBeq
+  simp [Buckets.mem_toListModel_iff_mem_bucket m.buckets H, mkIdx, this]
+
+theorem eraseP_toListModel_of_not_contains (m : Imp α β) (H : m.buckets.WF) (a : α) :
+    haveI := mkIdx (hash a) m.buckets.property
+    ¬(m.buckets.val[this.1.toNat]'this.2).contains a →
+    m.buckets.toListModel.eraseP (·.1 == a) = m.buckets.toListModel := by
+  intro hContains
+  apply eraseP_of_forall_not
+  intro ab hMem hEq
+  have :
+      haveI := mkIdx (hash a) m.buckets.property
+      (m.buckets.val[this.1.toNat]'this.2).contains a := by
+    simp only [AssocList.contains_eq, List.any_eq_true, mkIdx, ← LawfulHashable.hash_eq hEq]
+    exact ⟨ab, (Buckets.mem_toListModel_iff_mem_bucket m.buckets H ab).mp hMem, hEq⟩
+  contradiction
+
+theorem toListModel_insert_perm (m : Imp α β) (H : m.buckets.WF) (a : α) (b : β) :
+    (m.insert a b).buckets.toListModel ~ (a, b) :: m.buckets.toListModel.eraseP (·.1 == a) := by
+  dsimp [insert, cond]; split
+  next hContains =>
+    have ⟨l₁, l₂, hTgt, hUpd, hProp⟩ :=
+      haveI := mkIdx (hash a) m.buckets.property
+      m.buckets.exists_of_toListModel_update_WF H this.1
+        ((m.buckets.1[this.1.toNat]'this.2).replace a b) this.2
+    rw [hUpd, hTgt]
+    have hL₁ : ∀ ab ∈ l₁, ¬(ab.fst == a) := fun ab h hEq =>
+      Nat.ne_of_lt (LawfulHashable.hash_eq hEq ▸ hProp ab h) rfl
+    have ⟨p, hMem, hP⟩ := any_eq_true.mp (AssocList.contains_eq a _ ▸ hContains)
+    simp [eraseP_append_right _ hL₁,
+      eraseP_append_left (p := fun ab => ab.fst == a) hP _ hMem]
+    -- begin cursed manual proofs
+    refine Perm.trans ?_ perm_middle
+    refine Perm.append (Perm.refl _) ?_
+    rw [← cons_append]
+    refine Perm.append ?_ (Perm.refl _)
+
+    refine Perm.trans
+      (AtMostOne.replaceF_perm
+        (b := (a, b))
+        (f := fun a_1 => bif a_1.fst == a then some (a, b) else none)
+        (AtMostOne.imp
+          (fun a' => by cases h : a'.fst == a <;> simp [h])
+          (Buckets.atMostOne_beq_bucket m.buckets H _ a))
+        hMem
+        (by simp [hP]))
+      ?_
+    apply List.Perm.of_eq
+    congr
+    apply funext
+    intro x
+    cases h : x.fst == a <;> simp [h]
+    -- end cursed manual proofs
+
+  next hContains =>
+    rw [eraseP_toListModel_of_not_contains m H a (Bool.eq_false_iff.mp hContains)]
+    split
+    -- TODO(WN): how to merge the two branches below? They are identical except for the initial
+    -- `refine`
+    next =>
+      have ⟨l₁, l₂, hTgt, hUpd⟩ :=
+        haveI := mkIdx (hash a) m.buckets.property
+        m.buckets.exists_of_toListModel_update this.1
+          ((m.buckets.1[this.1.toNat]'this.2).cons a b) this.2
+      simp [hTgt, hUpd, perm_middle]
+    next =>
+      refine Perm.trans (Buckets.toListModel_expand _ _) ?_
+      have ⟨l₁, l₂, hTgt, hUpd⟩ :=
+        haveI := mkIdx (hash a) m.buckets.property
+        m.buckets.exists_of_toListModel_update this.1
+          ((m.buckets.1[this.1.toNat]'this.2).cons a b) this.2
+      simp [hTgt, hUpd, perm_middle]
+
+theorem toListModel_erase (m : Imp α β) (H : m.buckets.WF) (a : α) :
+    (m.erase a).buckets.toListModel = m.buckets.toListModel.eraseP (·.1 == a) := by
+  dsimp [erase, cond]; split
+  next hContains =>
+    have ⟨l₁, l₂, hTgt, hUpd, hProp⟩ :=
+      haveI := mkIdx (hash a) m.buckets.property
+      m.buckets.exists_of_toListModel_update_WF H this.1
+        ((m.buckets.1[this.1.toNat]'this.2).erase a) this.2
+    rw [hTgt, hUpd]
+    have hL₁ : ∀ ab ∈ l₁, ¬(ab.fst == a) := fun ab h hEq =>
+      Nat.ne_of_lt (LawfulHashable.hash_eq hEq ▸ hProp ab h) rfl
+    have ⟨p, hMem, hP⟩ := any_eq_true.mp (AssocList.contains_eq a _ ▸ hContains)
+    simp [eraseP_append_right _ hL₁, eraseP_append_left (p := fun ab => ab.fst == a) hP _ hMem]
+  next hContains =>
+    rw [eraseP_toListModel_of_not_contains m H a (Bool.eq_false_iff.mp hContains)]
+
+theorem eraseP_toListModel (m : Imp α β) (H : m.buckets.WF) (a : α) :
+    m.buckets.toListModel.eraseP (·.1 == a) = m.buckets.toListModel.filter (·.1 != a) := by
+  apply AtMostOne.eraseP_eq_filter
+  apply Buckets.atMostOne_beq_toListModel m.buckets H
+
+theorem toListModel_insert_perm' (m : Imp α β) (H : m.buckets.WF) (a : α) (b : β) :
+    (m.insert a b).buckets.toListModel ~ (a, b) :: m.buckets.toListModel.filter (·.1 != a) :=
+  eraseP_toListModel m H a ▸ toListModel_insert_perm m H a b
+
+theorem toListModel_erase' (m : Imp α β) (H : m.buckets.WF) (a : α) :
+    (m.erase a).buckets.toListModel = m.buckets.toListModel.filter (·.1 != a) :=
+  eraseP_toListModel m H a ▸ toListModel_erase m H a
+
+end Std.HashMap.Imp

--- a/Std/Data/HashMap/WF.lean
+++ b/Std/Data/HashMap/WF.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro
 import Std.Data.HashMap.Basic
 import Std.Data.List.Lemmas
 import Std.Data.Array.Lemmas
-import Std.Tactic.ShowTerm
 
 namespace Std.HashMap
 namespace Imp
@@ -21,8 +20,9 @@ namespace Buckets
 theorem update_data (self : Buckets α β) (i d h) :
     (self.update i d h).1.data = self.1.data.set i.toNat d := rfl
 
+/-- This theorem, small it may seem, is really useful. Apply whenever possible. -/
 theorem exists_of_update (self : Buckets α β) (i d h) :
-    ∃ l₁ l₂, self.1.data = l₁ ++ self.1[i] :: l₂ ∧ List.length l₁ = i.toNat ∧
+    ∃ l₁ l₂, self.1.data = l₁ ++ self.1[i.toNat] :: l₂ ∧ List.length l₁ = i.toNat ∧
       (self.update i d h).1.data = l₁ ++ d :: l₂ := by
   simp [Array.getElem_eq_data_get]; exact List.exists_of_set' h
 
@@ -69,7 +69,7 @@ theorem reinsertAux_size [Hashable α] (data : Buckets α β) (a : α) (b : β) 
 
 theorem reinsertAux_WF [BEq α] [Hashable α] {data : Buckets α β} {a : α} {b : β} (H : data.WF)
     (h₁ : ∀ [PartialEquivBEq α] [LawfulHashable α],
-      haveI := mkIdx data.2 (hash a).toUSize
+      haveI := mkIdx (hash a) data.2
       (data.val[this.1]'this.2).All fun x _ => ¬(a == x)) :
     (reinsertAux data a b).WF :=
   H.update (.cons h₁) fun
@@ -331,7 +331,7 @@ theorem WF.filterMap {α β γ} {f : α → β → Option γ} [BEq α] [Hashable
       simp; exact match f a.1 a.2 with
       | none => .cons _ ih
       | some b => .cons₂ _ ih
-  suffices ∀ bk sz (h : 0 < bk.length),
+  suffices ∀ bk sz (h : bk.length.isPowerOfTwo),
     m.buckets.val.mapM (m := M) (filterMap.go f .nil) ⟨0⟩ = (⟨bk⟩, ⟨sz⟩) →
     WF ⟨sz, ⟨bk⟩, h⟩ from this _ _ _ rfl
   simp [Array.mapM_eq_mapM_data, bind, StateT.bind, H2]

--- a/Std/Data/List/AtMostOne.lean
+++ b/Std/Data/List/AtMostOne.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2023 Wojciech Nawrocki. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Wojciech Nawrocki
+-/
+
+import Std.Data.List.Basic
+import Std.Data.List.Pairwise
+import Std.Data.List.Perm
+
+/-- There is at most one element satisfying `p` in `l`. -/
+def List.AtMostOne (p : α → Prop) (l : List α) : Prop :=
+  l.Pairwise (p · → ¬p ·)
+
+namespace List.AtMostOne
+
+theorem of_cons {x : α} {l : List α} {p : α → Prop} :
+    (x :: l).AtMostOne p → p x → ∀ y ∈ l, ¬p y :=
+  fun h hP _ hY => rel_of_pairwise_cons h hY hP
+
+theorem sublist {l₁ l₂ : List α} {p : α → Prop} :
+    l₁ <+ l₂ → l₂.AtMostOne p → l₁.AtMostOne p :=
+  Pairwise.sublist
+
+theorem perm {l₁ l₂ : List α} {p : α → Prop} : l₁ ~ l₂ →
+    l₁.AtMostOne p → l₂.AtMostOne p :=
+  fun h h₁ => h.pairwise h₁ fun H hB hA => H hA hB
+
+theorem imp {l : List α} {p q : α → Prop} (H : ∀ a, p a → q a) :
+    l.AtMostOne q → l.AtMostOne p :=
+  Pairwise.imp fun h hpa hpb => h (H _ hpa) (H _ hpb)
+
+theorem find?_eq_of_perm {l₁ l₂ : List α} {p : α → Bool} :
+    l₁.AtMostOne (p ·) → l₁ ~ l₂ → l₁.find? p = l₂.find? p := by
+  intro hUniq h
+  induction h using perm_induction_on with
+  | nil => rfl
+  | cons x l₁ _ _ ih =>
+    have := ih (hUniq.sublist (sublist_cons x l₁))
+    simp [find?, this]
+  | swap x y l₁ l₂ _ ih =>
+    dsimp [find?]
+    split <;> split <;> try rfl
+    next hY _ hX =>
+      have : ¬p x := hUniq.of_cons hY x (mem_cons_self _ _)
+      contradiction
+    next => exact ih <| hUniq.sublist <| sublist_of_cons_sublist <| sublist_cons y (x :: l₁)
+  | trans l₁ l₂ l₃ h₁₂ _ h₁ h₂ =>
+    simp [h₁ hUniq, h₂ (hUniq.perm h₁₂)]
+
+/-- If there is at most one element with the property `p`,
+finding that one element is the same as finding any. -/
+theorem find?_eq_some_iff {l : List α} {a : α} {p : α → Bool} :
+    l.AtMostOne (p ·)  → (l.find? p = some a ↔ (a ∈ l ∧ p a)) := by
+  refine fun h => ⟨fun h' => ⟨mem_of_find?_eq_some h', find?_some h'⟩, ?_⟩
+  induction l with
+  | nil => simp
+  | cons x xs ih =>
+    intro ⟨hMem, hP⟩
+    cases mem_cons.mp hMem with
+    | inl hX => simp [find?, ← hX, hP]
+    | inr hXs =>
+      unfold find?
+      cases hPX : (p x) with
+      | false =>
+        apply ih (Pairwise.sublist (sublist_cons x xs) h) ⟨hXs, hP⟩
+      | true =>
+        have := pairwise_cons.mp h |>.left a hXs hPX
+        contradiction
+
+/-- If there is at most one element with the property `p`,
+erasing one such element is the same as filtering out all of them. -/
+theorem eraseP_eq_filter (l : List α) (p : α → Bool) :
+    l.AtMostOne (p ·) → l.eraseP p = l.filter (!p ·) := by
+  intro h
+  induction l with
+  | nil => rfl
+  | cons x xs ih =>
+    specialize ih (Pairwise.sublist (sublist_cons x xs) h)
+    cases hP : p x with
+    | true =>
+      rw [AtMostOne, pairwise_cons] at h
+      have : ∀ a ∈ xs, !p a := fun a hA => by
+        have := h.left a hA hP
+        simp only [Bool.not_eq_true, Bool.not_eq_true'] at this ⊢
+        exact this
+      simp [eraseP, filter, hP, filter_eq_self.mpr this]
+    | false => simp [eraseP_cons, filter, hP, ih]
+
+theorem replaceF_perm {a b : α} {l : List α} (f : α → Option α) :
+    l.AtMostOne (fun a => (f a).isSome) →
+    a ∈ l → f a = some b →
+    l.replaceF f ~ b :: l.eraseP (f · |>.isSome) := by
+  intro hAmo hMem hF
+  induction l with
+  | nil => cases hMem
+  | cons x xs ih =>
+    unfold replaceF eraseP
+    cases mem_cons.mp hMem with
+    | inl hMem => simp [← hMem, hF, Perm.refl]
+    | inr hMem =>
+      have : f x = none := by
+        have .cons hAmo _ := hAmo
+        exact Option.eq_none_iff_forall_not_mem.mpr fun b hB' =>
+          have h₁ : (f x).isSome := hB' ▸rfl
+          have h₂ : (f a).isSome := hF ▸ Option.isSome_some
+          hAmo a hMem h₁ h₂
+      simp only [this, Option.isSome_none, cond_false]
+      have := ih (hAmo.sublist <| sublist_cons _ _) hMem
+      exact .trans (.cons x this) (.swap b x _)
+
+end List.AtMostOne

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1053,6 +1053,13 @@ theorem map_drop {α β : Type u} (f : α → β) :
     dsimp
     rw [map_drop f t]
 
+theorem drop_ext (l₁ l₂ : List α) (j : Nat)
+    : (∀ i ≥ j, l₁.get? i = l₂.get? i) → l₁.drop j = l₂.drop j := by
+  intro H
+  apply ext fun k => ?_
+  rw [get?_drop, get?_drop]
+  apply H _ (Nat.le_add_right _ _)
+
 theorem reverse_take {α} {xs : List α} (n : Nat) (h : n ≤ xs.length) :
     xs.reverse.take n = (xs.drop (xs.length - n)).reverse := by
   induction xs generalizing n <;>
@@ -1811,6 +1818,14 @@ theorem foldl_hom (f : α₁ → α₂) (g₁ : α₁ → β → α₁) (g₂ : 
 theorem foldr_hom (f : β₁ → β₂) (g₁ : α → β₁ → β₁) (g₂ : α → β₂ → β₂) (l : List α) (init : β₁)
     (H : ∀ x y, g₂ x (f y) = f (g₁ x y)) : l.foldr g₂ (f init) = f (l.foldr g₁ init) := by
   induction l <;> simp [*, H]
+
+theorem foldl_cons_fn (l₁ l₂ : List α) :
+    l₁.foldl (init := l₂) (fun acc x => x :: acc) = l₁.reverse ++ l₂ := by
+  induction l₁ generalizing l₂ <;> simp [*]
+
+theorem foldl_append_fn (l₁ : List α) (l₂ : List β) (f : α → List β) :
+    l₁.foldl (init := l₂) (fun acc x => acc ++ f x) = l₂ ++ l₁.bind f := by
+  induction l₁ generalizing l₂ <;> simp [*]
 
 /-! ### union -/
 

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -312,6 +312,8 @@ theorem getLast_cons' {a : α} {l : List α} : ∀ (h₁ : a :: l ≠ nil) (h₂
   getLast (a :: l) h₁ = getLast l h₂ := by
   induction l <;> intros; {contradiction}; rfl
 
+@[simp] theorem getLast_singleton (a h) : @getLast α [a] h = a := rfl
+
 @[simp] theorem getLast_append {a : α} : ∀ (l : List α) h, getLast (l ++ [a]) h = a
   | [], _ => rfl
   | a::t, h => by
@@ -325,6 +327,26 @@ theorem eq_nil_or_concat : ∀ l : List α, l = [] ∨ ∃ L b, l = L ++ [b]
   | a::l => match l, eq_nil_or_concat l with
     | _, .inl rfl => .inr ⟨[], a, rfl⟩
     | _, .inr ⟨L, b, rfl⟩ => .inr ⟨a::L, b, rfl⟩
+
+@[simp] theorem getLastD_nil (a) : @getLastD α [] a = a := rfl
+@[simp] theorem getLastD_cons (a b l) : @getLastD α (b::l) a = getLastD l b := by cases l <;> rfl
+
+theorem getLast_eq_getLastD (a l h) : @getLast α (a::l) h = getLastD l a := by
+  cases l <;> rfl
+
+theorem getLastD_eq_getLast? (a l) : @getLastD α l a = (getLast? l).getD a := by
+  cases l <;> rfl
+
+theorem getLast!_cons [Inhabited α] : @getLast! α _ (a::l) = getLastD l a := by
+  simp [getLast!, getLast_eq_getLastD]
+
+@[simp] theorem getLast?_nil : @getLast? α [] = none := rfl
+theorem getLast?_cons : @getLast? α (a::l) = getLastD l a := by
+  simp [getLast?, getLast_eq_getLastD]
+
+theorem getLast?_eq_getLast : ∀ l h, @getLast? α l = some (getLast l h)
+  | [], h => nomatch h rfl
+  | _::_, _ => rfl
 
 /-! ### sublists -/
 
@@ -499,36 +521,24 @@ theorem tail_eq_tail? (l) : @tail α l = (tail? l).getD [] := by simp [tail_eq_t
 @[simp] theorem next?_nil : @next? α [] = none := rfl
 @[simp] theorem next?_cons (a l) : @next? α (a :: l) = some (a, l) := rfl
 
-/-! ### getLast -/
-
-@[simp] theorem getLastD_nil (a) : @getLastD α [] a = a := rfl
-@[simp] theorem getLastD_cons (a b l) : @getLastD α (b::l) a = getLastD l b := by cases l <;> rfl
-
-theorem getLast_eq_getLastD (a l h) : @getLast α (a::l) h = getLastD l a := by
-  cases l <;> rfl
-
-theorem getLastD_eq_getLast? (a l) : @getLastD α l a = (getLast? l).getD a := by
-  cases l <;> rfl
-
-theorem getLast_singleton (a h) : @getLast α [a] h = a := rfl
-
-theorem getLast!_cons [Inhabited α] : @getLast! α _ (a::l) = getLastD l a := by
-  simp [getLast!, getLast_eq_getLastD]
-
-@[simp] theorem getLast?_nil : @getLast? α [] = none := rfl
-theorem getLast?_cons : @getLast? α (a::l) = getLastD l a := by
-  simp [getLast?, getLast_eq_getLastD]
-
-theorem getLast?_eq_getLast : ∀ l h, @getLast? α l = some (getLast l h)
-  | [], h => nomatch h rfl
-  | _::_, _ => rfl
-
 /-! ### dropLast -/
 
-@[simp] theorem dropLast_append_cons : dropLast (l₁ ++ b::l₂) = l₁ ++ dropLast (b::l₂) := by
-  induction l₁ <;> simp [*, dropLast]
+theorem dropLast_cons_of_ne_nil {α : Type u} {x : α}
+    {l : List α} (h : l ≠ []) : (x :: l).dropLast = x :: l.dropLast :=
+  by simp [dropLast, h]
+
+@[simp]
+theorem dropLast_append_of_ne_nil {α : Type u} {l : List α} :
+    ∀ (l' : List α) (_ : l ≠ []), (l' ++ l).dropLast = l' ++ l.dropLast
+  | [], _ => by simp only [nil_append]
+  | a :: l', h => by
+    rw [cons_append, dropLast, dropLast_append_of_ne_nil l' h, cons_append]
+    simp [h]
 
 @[simp 1100] theorem dropLast_concat : dropLast (l₁ ++ [b]) = l₁ := by simp
+
+theorem dropLast_append_cons : dropLast (l₁ ++ b::l₂) = l₁ ++ dropLast (b::l₂) := by
+  induction l₁ <;> simp [*, dropLast]
 
 /-! ### nth element -/
 
@@ -749,7 +759,11 @@ theorem getD_eq_get? : ∀ l n (a : α), getD l n a = (get? l n).getD a
   | _a::_, 0   => rfl
   | _a::l, n+1 => get!_eq_getD l n
 
-/-! ### take and drop -/
+/-! ### take -/
+
+@[simp]
+theorem take_cons (n) (a : α) (l : List α) : take (succ n) (a :: l) = a :: take n l :=
+  rfl
 
 @[simp] theorem take_succ_cons : (a :: as).take (i + 1) = a :: as.take i := rfl
 
@@ -760,23 +774,138 @@ theorem getD_eq_get? : ∀ l n (a : α), getD l n a = (get? l n).getD a
 
 theorem length_take_le (n) (l : List α) : length (take n l) ≤ n := by simp [Nat.min_le_left]
 
+theorem length_take_le' (n) (l : List α) : length (take n l) ≤ l.length :=
+  by simp [Nat.min_le_right]
+
 theorem length_take_of_le (h : n ≤ length l) : length (take n l) = n := by simp [Nat.min_eq_left h]
 
-theorem get_cons_drop : ∀ (l : List α) i, get l i :: drop (i + 1) l = drop i l
-  | _::_, ⟨0, _⟩ => rfl
-  | _::_, ⟨i+1, _⟩ => get_cons_drop _ ⟨i, _⟩
+theorem take_all_of_le : ∀ {n} {l : List α}, length l ≤ n → take n l = l
+  | 0, [], _ => rfl
+  | 0, a :: l, h => absurd h (Nat.not_le_of_gt (zero_lt_succ _))
+  | n + 1, [], _ => rfl
+  | n + 1, a :: l, h => by
+    show a :: take n l = a :: l
+    rw [take_all_of_le (le_of_succ_le_succ h)]
 
-theorem drop_eq_nil_of_eq_nil : ∀ {as : List α} {i}, as = [] → as.drop i = []
-  | _, _, rfl => drop_nil
+@[simp]
+theorem take_left : ∀ l₁ l₂ : List α, take (length l₁) (l₁ ++ l₂) = l₁
+  | [], _ => rfl
+  | a :: l₁, l₂ => congrArg (cons a) (take_left l₁ l₂)
 
-theorem take_eq_nil_of_eq_nil : ∀ {as : List α} {i}, as = [] → as.take i = []
-  | _, _, rfl => take_nil
+theorem take_left' {l₁ l₂ : List α} {n} (h : length l₁ = n) : take n (l₁ ++ l₂) = l₁ := by
+  rw [← h]; apply take_left
 
-theorem ne_nil_of_drop_ne_nil {as : List α} {i : Nat} (h: as.drop i ≠ []) : as ≠ [] :=
-  mt drop_eq_nil_of_eq_nil h
+theorem take_take : ∀ (n m) (l : List α), take n (take m l) = take (min n m) l
+  | n, 0, l => by rw [Nat.min_zero, take_zero, take_nil]
+  | 0, m, l => by rw [Nat.zero_min, take_zero, take_zero]
+  | succ n, succ m, nil => by simp only [take_nil]
+  | succ n, succ m, a :: l => by
+    simp only [take, min_succ_succ, take_take n m l]
 
-theorem ne_nil_of_take_ne_nil {as : List α} {i : Nat} (h: as.take i ≠ []) : as ≠ [] :=
-  mt take_eq_nil_of_eq_nil h
+theorem take_replicate (a : α) : ∀ n m : Nat, take n (replicate m a) = replicate (min n m) a
+  | n, 0 => by simp [Nat.min_zero]
+  | 0, m => by simp [Nat.zero_min]
+  | succ n, succ m => by simp [min_succ_succ, take_replicate]
+
+theorem map_take {α β : Type u} (f : α → β) :
+    ∀ (L : List α) (i : Nat), (L.take i).map f = (L.map f).take i
+  | [], i => by simp
+  | _, 0 => by simp
+  | h :: t, n + 1 => by dsimp; rw [map_take f t n]
+
+/-- Taking the first `n` elements in `l₁ ++ l₂` is the same as appending the first `n` elements
+of `l₁` to the first `n - l₁.length` elements of `l₂`. -/
+theorem take_append_eq_append_take {l₁ l₂ : List α} {n : Nat} :
+    take n (l₁ ++ l₂) = take n l₁ ++ take (n - l₁.length) l₂ := by
+  induction l₁ generalizing n; {simp}
+  cases n <;> simp [*]
+
+theorem take_append_of_le_length {l₁ l₂ : List α} {n : Nat} (h : n ≤ l₁.length) :
+    (l₁ ++ l₂).take n = l₁.take n :=
+  by simp [take_append_eq_append_take, Nat.sub_eq_zero_of_le h]
+
+/-- Taking the first `l₁.length + i` elements in `l₁ ++ l₂` is the same as appending the first
+`i` elements of `l₂` to `l₁`. -/
+theorem take_append {l₁ l₂ : List α} (i : Nat) :
+    take (l₁.length + i) (l₁ ++ l₂) = l₁ ++ take i l₂ := by
+  rw [take_append_eq_append_take, take_all_of_le (Nat.le_add_right _ _), Nat.add_sub_cancel_left]
+
+/-- The `i`-th element of a list coincides with the `i`-th element of any of its prefixes of
+length `> i`. Version designed to rewrite from the big list to the small list. -/
+theorem get_take (L : List α) {i j : Nat} (hi : i < L.length) (hj : i < j) :
+    get L ⟨i, hi⟩ = get (L.take j) ⟨i, length_take .. ▸ Nat.lt_min.mpr ⟨hj, hi⟩⟩ :=
+  get_of_eq (take_append_drop j L).symm _ ▸ get_append ..
+
+/-- The `i`-th element of a list coincides with the `i`-th element of any of its prefixes of
+length `> i`. Version designed to rewrite from the small list to the big list. -/
+theorem get_take' (L : List α) {j i} :
+    get (L.take j) i =
+    get L ⟨i.1, Nat.lt_of_lt_of_le i.2 (length_take_le' _ _)⟩ := by
+  let ⟨i, hi⟩ := i; rw [length_take, Nat.lt_min] at hi; rw [get_take L _ hi.1]
+
+theorem get?_take {l : List α} {n m : Nat} (h : m < n) : (l.take n).get? m = l.get? m := by
+  induction n generalizing l m with
+  | zero =>
+    simp only [Nat.zero_eq] at h
+    exact absurd h (Nat.not_lt_of_le m.zero_le)
+  | succ _ hn =>
+    cases l with
+    | nil => simp only [take_nil]
+    | cons hd tl =>
+      · cases m
+        · simp only [get?, take]
+        · simpa only using hn (Nat.lt_of_succ_lt_succ h)
+
+@[simp]
+theorem nth_take_of_succ {l : List α} {n : Nat} : (l.take (n + 1)).get? n = l.get? n :=
+  get?_take (Nat.lt_succ_self n)
+
+theorem take_succ {l : List α} {n : Nat} : l.take (n + 1) = l.take n ++ (l.get? n).toList := by
+  induction l generalizing n with
+  | nil =>
+    simp only [Option.toList, get?, take_nil, append_nil]
+  | cons hd tl hl =>
+    cases n
+    · simp only [Option.toList, get?, eq_self_iff_true, take, nil_append]
+    · simp only [hl, cons_append, get?, eq_self_iff_true, take]
+
+@[simp]
+theorem take_eq_nil_iff {l : List α} {k : Nat} : l.take k = [] ↔ l = [] ∨ k = 0 := by
+  cases l <;> cases k <;> simp [Nat.succ_ne_zero]
+
+theorem take_eq_take :
+    ∀ {l : List α} {m n : Nat}, l.take m = l.take n ↔ min m l.length = min n l.length
+  | [], m, n => by simp [Nat.min_zero]
+  | _ :: xs, 0, 0 => by simp
+  | x :: xs, m + 1, 0 => by simp [Nat.zero_min, Nat.min_succ_succ]
+  | x :: xs, 0, n + 1 => by simp [Nat.zero_min, Nat.min_succ_succ]
+  | x :: xs, m + 1, n + 1 => by simp [Nat.min_succ_succ, take_eq_take]
+
+theorem take_add (l : List α) (m n : Nat) : l.take (m + n) = l.take m ++ (l.drop m).take n := by
+  suffices take (m + n) (take m l ++ drop m l) = take m l ++ take n (drop m l) by
+    rw [take_append_drop] at this
+    assumption
+  rw [take_append_eq_append_take, take_all_of_le, append_right_inj]
+  . simp only [take_eq_take, length_take, length_drop]
+    generalize l.length = k; by_cases h : m ≤ k
+    . rw [Nat.min_eq_left h, Nat.add_sub_cancel_left]
+    . simp at h
+      simp [Nat.sub_eq_zero_of_le (Nat.le_of_lt h), Nat.min_zero]
+  apply Nat.le_trans (m := m)
+  . apply length_take_le
+  . apply Nat.le_add_right
+
+theorem dropLast_eq_take (l : List α) : l.dropLast = l.take l.length.pred := by
+  cases l with
+  | nil => simp [dropLast]
+  | cons x l =>
+    induction l generalizing x with
+    | nil => simp [dropLast]
+    | cons hd tl hl => simp [dropLast, hl]
+
+theorem dropLast_take {n : Nat} {l : List α} (h : n < l.length) :
+    (l.take n).dropLast = l.take n.pred := by
+  simp only [dropLast_eq_take, length_take, Nat.le_of_lt h, take_take, pred_le, Nat.min_eq_left]
 
 theorem map_eq_append_split {f : α → β} {l : List α} {s₁ s₂ : List β}
     (h : map f l = s₁ ++ s₂) : ∃ l₁ l₂, l = l₁ ++ l₂ ∧ map f l₁ = s₁ ∧ map f l₂ = s₂ := by
@@ -788,16 +917,161 @@ theorem map_eq_append_split {f : α → β} {l : List α} {s₁ s₂ : List β}
   rw [← length_map l f, h, length_append]
   apply Nat.le_add_right
 
+/-! ### drop -/
+
+theorem drop_eq_get_cons : ∀ {n} {l : List α} (h), drop n l = get l ⟨n, h⟩ :: drop (n + 1) l
+  | 0, _ :: _, _ => rfl
+  | n + 1, _ :: _, _ => drop_eq_get_cons (n := n) _
+
+theorem drop_eq_nil_iff_le {l : List α} {k : Nat} : l.drop k = [] ↔ l.length ≤ k := by
+  refine' ⟨fun h => _, drop_eq_nil_of_le⟩
+  induction k generalizing l with
+  | zero =>
+    simp only [drop] at h
+    simp [h]
+  | succ k hk =>
+    cases l
+    · simp
+    · simp only [drop] at h
+      simpa [Nat.succ_le_succ_iff] using hk h
+
+theorem tail_drop (l : List α) (n : Nat) : (l.drop n).tail = l.drop (n + 1) := by
+  induction l generalizing n with
+  | nil => simp
+  | cons hd tl hl =>
+    cases n
+    · simp
+    · simp [hl]
+
+@[simp]
+theorem drop_one : ∀ l : List α, drop 1 l = tail l
+  | [] | _ :: _ => rfl
+
+theorem drop_add : ∀ (m n) (l : List α), drop (m + n) l = drop m (drop n l)
+  | _, 0, _ => rfl
+  | _, _ + 1, [] => drop_nil.symm
+  | m, n + 1, _ :: _ => drop_add m n _
+
+@[simp]
+theorem drop_left : ∀ l₁ l₂ : List α, drop (length l₁) (l₁ ++ l₂) = l₂
+  | [], _ => rfl
+  | _ :: l₁, l₂ => drop_left l₁ l₂
+
+theorem drop_left' {l₁ l₂ : List α} {n} (h : length l₁ = n) : drop n (l₁ ++ l₂) = l₂ := by
+  rw [← h]; apply drop_left
+
+theorem drop_length_cons {l : List α} (h : l ≠ []) (a : α) :
+    (a :: l).drop l.length = [l.getLast h] := by
+  induction l generalizing a with
+  | nil =>
+    cases h rfl
+  | cons y l ih =>
+    simp only [drop, length]
+    by_cases h₁ : l = []
+    . simp [h₁]
+    rw [getLast_cons' _ h₁]
+    exact ih h₁ y
+
 /-- Dropping the elements up to `n` in `l₁ ++ l₂` is the same as dropping the elements up to `n`
 in `l₁`, dropping the elements up to `n - l₁.length` in `l₂`, and appending them. -/
-theorem drop_append_eq_append_drop {l₁ l₂ : List α} :
+theorem drop_append_eq_append_drop {l₁ l₂ : List α} {n : Nat} :
     drop n (l₁ ++ l₂) = drop n l₁ ++ drop (n - l₁.length) l₂ := by
   induction l₁ generalizing n; · simp
   cases n <;> simp [*]
 
-theorem drop_append_of_le_length {l₁ l₂ : List α} (h : n ≤ l₁.length) :
+theorem drop_append_of_le_length {l₁ l₂ : List α} {n : Nat} (h : n ≤ l₁.length) :
     (l₁ ++ l₂).drop n = l₁.drop n ++ l₂ := by
   simp [drop_append_eq_append_drop, Nat.sub_eq_zero_of_le h]
+
+/-- Dropping the elements up to `l₁.length + i` in `l₁ + l₂` is the same as dropping the elements
+up to `i` in `l₂`. -/
+theorem drop_append {l₁ l₂ : List α} (i : Nat) : drop (l₁.length + i) (l₁ ++ l₂) = drop i l₂ := by
+  rw [drop_append_eq_append_drop, drop_eq_nil_of_le] <;>
+    simp [Nat.add_sub_cancel_left, Nat.le_add_right]
+
+theorem drop_sizeOf_le [SizeOf α] (l : List α) (n : Nat) : sizeOf (l.drop n) ≤ sizeOf l := by
+  induction l generalizing n with
+  | nil => rw [drop_nil]; apply Nat.le_refl
+  | cons _ _ lih =>
+    induction n with
+    | zero => apply Nat.le_refl
+    | succ n =>
+      exact Trans.trans (lih _) (Nat.le_add_left _ _)
+
+/-- The `i + j`-th element of a list coincides with the `j`-th element of the list obtained by
+dropping the first `i` elements. Version designed to rewrite from the big list to the small list. -/
+theorem get_drop (L : List α) {i j : Nat} (h : i + j < L.length) :
+    get L ⟨i + j, h⟩ = get (L.drop i) ⟨j, by
+      have A : i < L.length := Nat.lt_of_le_of_lt (Nat.le.intro rfl) h
+      rw [(take_append_drop i L).symm] at h
+      simpa only [Nat.le_of_lt A, Nat.min_eq_left, Nat.add_lt_add_iff_left, length_take,
+        length_append] using h⟩ := by
+  have : i ≤ L.length := Nat.le_trans (Nat.le_add_right _ _) (Nat.le_of_lt h)
+  rw [get_of_eq (take_append_drop i L).symm ⟨i + j, h⟩, get_append_right'] <;>
+    simp [Nat.min_eq_left this, Nat.add_sub_cancel_left, Nat.le_add_right]
+
+/-- The `i + j`-th element of a list coincides with the `j`-th element of the list obtained by
+dropping the first `i` elements. Version designed to rewrite from the small list to the big list. -/
+theorem get_drop' (L : List α) {i j} :
+    get (L.drop i) j = get L ⟨i + j, by
+      rw [Nat.add_comm]
+      exact Nat.add_lt_of_lt_sub (length_drop i L ▸ j.2)⟩ := by
+  rw [get_drop]
+
+theorem get?_drop (L : List α) (i j : Nat) : get? (L.drop i) j = get? L (i + j) := by
+  ext
+  simp only [get?_eq_some, get_drop', Option.mem_def]
+  constructor <;> intro ⟨h, ha⟩
+  . exact ⟨_, ha⟩
+  . refine ⟨?_, ha⟩
+    rw [length_drop]
+    rw [Nat.add_comm] at h
+    apply Nat.lt_sub_of_add_lt h
+
+@[simp]
+theorem drop_drop (n : Nat) : ∀ (m) (l : List α), drop n (drop m l) = drop (n + m) l
+  | m, [] => by simp
+  | 0, l => by simp
+  | m + 1, a :: l =>
+    calc
+      drop n (drop (m + 1) (a :: l)) = drop n (drop m l) := rfl
+      _ = drop (n + m) l := drop_drop n m l
+      _ = drop (n + (m + 1)) (a :: l) := rfl
+
+theorem drop_take : ∀ (m n : Nat) (l : List α), drop m (take (m + n) l) = take n (drop m l)
+  | 0, n, _ => by simp
+  | m + 1, n, nil => by simp
+  | m + 1, n, _ :: l => by
+    have h : m + 1 + n = m + n + 1 := by rw [Nat.add_assoc, Nat.add_comm 1 n, ← Nat.add_assoc]
+    simpa [take_cons, h] using drop_take m n l
+
+theorem map_drop {α β : Type u} (f : α → β) :
+    ∀ (L : List α) (i : Nat), (L.drop i).map f = (L.map f).drop i
+  | [], i => by simp
+  | L, 0 => by simp
+  | h :: t, n + 1 => by
+    dsimp
+    rw [map_drop f t]
+
+theorem reverse_take {α} {xs : List α} (n : Nat) (h : n ≤ xs.length) :
+    xs.reverse.take n = (xs.drop (xs.length - n)).reverse := by
+  induction xs generalizing n <;>
+    simp only [reverse_cons, drop, reverse_nil, Nat.zero_sub, length, take_nil]
+  next xs_hd xs_tl xs_ih =>
+    cases Nat.lt_or_eq_of_le h with
+    | inl h' =>
+      have h' := Nat.le_of_succ_le_succ h'
+      rw [take_append_of_le_length, xs_ih _ h']
+      rw [show xs_tl.length + 1 - n = succ (xs_tl.length - n) from _, drop]
+      · rwa [succ_eq_add_one, Nat.sub_add_comm]
+      · rwa [length_reverse]
+    | inr h' =>
+      subst h'
+      rw [length, Nat.sub_self, drop]
+      suffices xs_tl.length + 1 = (xs_tl.reverse ++ [xs_hd]).length by
+        rw [this, take_length, reverse_cons]
+      rw [length_append, length_reverse]
+      rfl
 
 /-! ### modify nth -/
 
@@ -854,12 +1128,30 @@ theorem exists_of_modifyNth (f : α → α) {n} {l : List α} (h : n < l.length)
   | ⟨_, _::_, eq, hl, H⟩ => ⟨_, _, _, eq, hl, H⟩
   | ⟨_, [], eq, hl, _⟩ => nomatch Nat.ne_of_gt h (eq ▸ append_nil _ ▸ hl)
 
+theorem modifyNthTail_eq_take_drop (f : List α → List α) (H : f [] = []) :
+    ∀ n l, modifyNthTail f n l = take n l ++ f (drop n l)
+  | 0, _ => rfl
+  | _ + 1, [] => H.symm
+  | n + 1, b :: l => congrArg (cons b) (modifyNthTail_eq_take_drop f H n l)
+
+theorem modifyNth_eq_take_drop (f : α → α) :
+    ∀ n l, modifyNth f n l = take n l ++ modifyHead f (drop n l) :=
+  modifyNthTail_eq_take_drop _ rfl
+
+theorem modifyNth_eq_take_cons_drop (f : α → α) {n l} (h) :
+    modifyNth f n l = take n l ++ f (get l ⟨n, h⟩) :: drop (n + 1) l := by
+  rw [modifyNth_eq_take_drop, drop_eq_get_cons h]; rfl
+
 /-! ### set -/
 
 theorem set_eq_modifyNth (a : α) : ∀ n (l : List α), set l n a = modifyNth (fun _ => a) n l
   | 0, l => by cases l <;> rfl
   | n+1, [] => rfl
   | n+1, b :: l => congrArg (cons _) (set_eq_modifyNth _ _ _)
+
+theorem set_eq_take_cons_drop (a : α) {n l} (h : n < length l) :
+    set l n a = take n l ++ a :: drop (n + 1) l := by
+  rw [set_eq_modifyNth, modifyNth_eq_take_cons_drop _ h]
 
 theorem modifyNth_eq_set_get? (f : α → α) :
     ∀ n (l : List α), l.modifyNth f n = ((fun a => l.set n (f a)) <$> l.get? n).getD l
@@ -902,6 +1194,10 @@ theorem get?_set_of_lt' (a : α) {m n} (l : List α) (h : m < length l) :
   simp [get?_set]; split <;> subst_vars <;> simp [*, get?_eq_get h]
 
 @[simp] theorem set_nil (n : Nat) (a : α) : [].set n a = [] := rfl
+
+@[simp]
+theorem set_eq_nil (l : List α) (n : Nat) (a : α) : l.set n a = [] ↔ l = [] := by
+  cases l <;> cases n <;> simp only [set]
 
 @[simp] theorem set_succ (x : α) (xs : List α) (n : Nat) (a : α) :
   (x :: xs).set n.succ a = x :: xs.set n a := rfl

--- a/Std/Data/List/Pairwise.lean
+++ b/Std/Data/List/Pairwise.lean
@@ -213,7 +213,7 @@ theorem map_get_sublist {l : List α} {is : List (Fin l.length)} (h : is.Pairwis
     simp; cases hl'
     have := IH h.of_cons (hd+1) _ rfl (pairwise_cons.mp h).1
     specialize his hd (.head _)
-    have := get_cons_drop .. ▸ this.cons₂ (get l hd)
+    have := (drop_eq_get_cons ..).symm ▸ this.cons₂ (get l hd)
     have := Sublist.append (nil_sublist (take hd l |>.drop n)) this
     rwa [nil_append, ← (drop_append_of_le_length ?_), take_append_drop] at this
     simp [Nat.min_eq_left (Nat.le_of_lt hd.isLt), his]

--- a/Std/Data/List/Perm.lean
+++ b/Std/Data/List/Perm.lean
@@ -1,0 +1,908 @@
+/-
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
+-/
+import Std.Data.List.Lemmas
+import Std.Data.List.Count
+import Std.Data.List.Pairwise
+
+/-!
+# List Permutations
+
+This file introduces the `List.Perm` relation, which is true if two lists are permutations of one
+another.
+
+## Notation
+
+The notation `~` is used for permutation equivalence.
+-/
+
+
+open Nat
+
+universe uu vv
+
+namespace List
+
+variable {α : Type uu} {β : Type vv} {l₁ l₂ : List α}
+
+/-- `Perm l₁ l₂` or `l₁ ~ l₂` asserts that `l₁` and `l₂` are permutations
+  of each other. This is defined by induction using pairwise swaps. -/
+inductive Perm : List α → List α → Prop
+  /-- `[] ~ []` -/
+  | nil : Perm [] []
+  /-- `l₁ ~ l₂ → x::l₁ ~ x::l₂` -/
+  | cons (x : α) {l₁ l₂ : List α} : Perm l₁ l₂ → Perm (x :: l₁) (x :: l₂)
+  /-- `x::y::l ~ y::x::l` -/
+  | swap (x y : α) (l : List α) : Perm (y :: x :: l) (x :: y :: l)
+  /-- `Perm` is transitive. -/
+  | trans {l₁ l₂ l₃ : List α} : Perm l₁ l₂ → Perm l₂ l₃ → Perm l₁ l₃
+
+open Perm (swap)
+
+/-- `Perm l₁ l₂` or `l₁ ~ l₂` asserts that `l₁` and `l₂` are permutations
+  of each other. This is defined by induction using pairwise swaps. -/
+scoped infixl:50 " ~ " => Perm
+
+@[simp]
+protected theorem Perm.refl : ∀ l : List α, l ~ l
+  | [] => Perm.nil
+  | x :: xs => (Perm.refl xs).cons x
+
+protected theorem Perm.symm {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₂ ~ l₁ :=
+  p.rec
+    .nil
+    (fun x _ _ _ r₁ => .cons x r₁)
+    (fun x y l => .swap y x l)
+    (fun _ _ r₁ r₂ => .trans r₂ r₁)
+
+theorem perm_comm {l₁ l₂ : List α} : l₁ ~ l₂ ↔ l₂ ~ l₁ :=
+  ⟨Perm.symm, Perm.symm⟩
+
+theorem Perm.swap' (x y : α) {l₁ l₂ : List α} (p : l₁ ~ l₂) : y :: x :: l₁ ~ x :: y :: l₂ :=
+  (swap _ _ _).trans ((p.cons _).cons _)
+
+theorem Perm.eqv (α) : Equivalence (@Perm α) :=
+  ⟨Perm.refl, Perm.symm, Perm.trans⟩
+
+theorem Perm.of_eq (h : l₁ = l₂) : l₁ ~ l₂ :=
+  h ▸ Perm.refl l₁
+
+instance isSetoid (α) : Setoid (List α) :=
+  Setoid.mk (@Perm α) (Perm.eqv α)
+
+theorem Perm.subset {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₁ ⊆ l₂ := fun a =>
+  p.rec
+  (fun h => h)
+  (fun x l₁ l₂ _r hs h => by
+    cases h
+    . apply Mem.head
+    . apply Mem.tail
+      apply hs
+      assumption)
+  (fun x y l h => by
+    match h with
+    | .head _ => exact Mem.tail x (Mem.head l)
+    | .tail _ (.head _) => apply Mem.head
+    | .tail _ (.tail _ h) => exact Mem.tail x (Mem.tail y h))
+  (fun _ _ h₁ h₂ h => by
+    apply h₂
+    apply h₁
+    assumption)
+
+theorem Perm.mem_iff {a : α} {l₁ l₂ : List α} (h : l₁ ~ l₂) : a ∈ l₁ ↔ a ∈ l₂ :=
+  Iff.intro (fun m => h.subset m) fun m => h.symm.subset m
+
+theorem Perm.append_right {l₁ l₂ : List α} (t₁ : List α) (p : l₁ ~ l₂) : l₁ ++ t₁ ~ l₂ ++ t₁ :=
+  p.rec
+    (Perm.refl ([] ++ t₁))
+    (fun x _ _ _ r₁ => r₁.cons x)
+    (fun x y _ => swap x y _)
+    (fun _ _ r₁ r₂ => r₁.trans r₂)
+
+theorem Perm.append_left {t₁ t₂ : List α} : ∀ l : List α, t₁ ~ t₂ → l ++ t₁ ~ l ++ t₂
+  | [], p => p
+  | x :: xs, p => (p.append_left xs).cons x
+
+theorem Perm.append {l₁ l₂ t₁ t₂ : List α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁ ++ t₁ ~ l₂ ++ t₂ :=
+  (p₁.append_right t₁).trans (p₂.append_left l₂)
+
+theorem Perm.append_cons (a : α) {h₁ h₂ t₁ t₂ : List α} (p₁ : h₁ ~ h₂) (p₂ : t₁ ~ t₂) :
+    h₁ ++ a :: t₁ ~ h₂ ++ a :: t₂ :=
+  p₁.append (p₂.cons a)
+
+@[simp]
+theorem perm_middle {a : α} : ∀ {l₁ l₂ : List α}, l₁ ++ a :: l₂ ~ a :: (l₁ ++ l₂)
+  | [], _ => Perm.refl _
+  | b :: l₁, l₂ => ((@perm_middle a l₁ l₂).cons _).trans (swap a b _)
+
+@[simp]
+theorem perm_append_singleton (a : α) (l : List α) : l ++ [a] ~ a :: l :=
+  perm_middle.trans <| by rw [append_nil]; apply Perm.refl
+
+theorem perm_append_comm : ∀ {l₁ l₂ : List α}, l₁ ++ l₂ ~ l₂ ++ l₁
+  | [], l₂ => by simp
+  | a :: t, l₂ => (perm_append_comm.cons _).trans perm_middle.symm
+
+theorem concat_perm (l : List α) (a : α) : concat l a ~ a :: l := by simp
+
+theorem Perm.length_eq {l₁ l₂ : List α} (p : l₁ ~ l₂) : length l₁ = length l₂ :=
+  p.rec
+    rfl
+    (fun _x l₁ l₂ _p r => by simp [r])
+    (fun _x _y l => by simp)
+    (fun _p₁ _p₂ r₁ r₂ => Eq.trans r₁ r₂)
+
+theorem Perm.eq_nil {l : List α} (p : l ~ []) : l = [] :=
+  eq_nil_of_length_eq_zero p.length_eq
+
+theorem Perm.nil_eq {l : List α} (p : [] ~ l) : [] = l :=
+  p.symm.eq_nil.symm
+
+@[simp]
+theorem perm_nil {l₁ : List α} : l₁ ~ [] ↔ l₁ = [] :=
+  ⟨fun p => p.eq_nil, fun e => e ▸ Perm.refl _⟩
+
+@[simp]
+theorem nil_perm {l₁ : List α} : [] ~ l₁ ↔ l₁ = [] :=
+  perm_comm.trans perm_nil
+
+theorem not_perm_nil_cons (x : α) (l : List α) : ¬[] ~ x :: l
+  | p => by injection p.symm.eq_nil
+
+@[simp]
+theorem reverse_perm : ∀ l : List α, reverse l ~ l
+  | [] => Perm.nil
+  | a :: l => by
+    rw [reverse_cons]
+    exact (perm_append_singleton _ _).trans ((reverse_perm l).cons a)
+
+theorem perm_cons_append_cons {l l₁ l₂ : List α} (a : α) (p : l ~ l₁ ++ l₂) :
+    a :: l ~ l₁ ++ a :: l₂ :=
+  (p.cons a).trans perm_middle.symm
+
+@[simp]
+theorem perm_replicate {a : α} {n : Nat} {l : List α} :
+    l ~ List.replicate n a ↔ l = List.replicate n a :=
+  ⟨fun p => eq_replicate.2
+    ⟨p.length_eq.trans <| length_replicate _ _, fun _b m => eq_of_mem_replicate <| p.subset m⟩,
+    fun h => h ▸ Perm.refl _⟩
+
+@[simp]
+theorem replicate_perm {a : α} {n : Nat} {l : List α} :
+    List.replicate n a ~ l ↔ List.replicate n a = l :=
+  (perm_comm.trans perm_replicate).trans eq_comm
+
+@[simp]
+theorem perm_singleton {a : α} {l : List α} : l ~ [a] ↔ l = [a] :=
+  @perm_replicate α a 1 l
+
+@[simp]
+theorem singleton_perm {a : α} {l : List α} : [a] ~ l ↔ [a] = l :=
+  @replicate_perm α a 1 l
+
+theorem Perm.eq_singleton {a : α} {l : List α} (p : l ~ [a]) : l = [a] :=
+  perm_singleton.1 p
+
+theorem Perm.singleton_eq {a : α} {l : List α} (p : [a] ~ l) : [a] = l :=
+  p.symm.eq_singleton.symm
+
+theorem singleton_perm_singleton {a b : α} : [a] ~ [b] ↔ a = b := by simp
+
+theorem perm_cons_erase [DecidableEq α] {a : α} {l : List α} (h : a ∈ l) : l ~ a :: l.erase a :=
+  let ⟨_l₁, _l₂, _, e₁, e₂⟩ := exists_erase_eq h
+  e₂.symm ▸ e₁.symm ▸ perm_middle
+
+/-- The way Lean 4 computes the motive with `elab_as_elim` has changed
+relative to the behaviour of `elab_as_eliminator` in Lean 3.
+See
+https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Potential.20elaboration.20bug.20with.20.60elabAsElim.60/near/299573172
+for an explanation of the change made here relative to mathlib3.
+-/
+@[elab_as_elim]
+theorem perm_induction_on
+    {P : (l₁ : List α) → (l₂ : List α) → l₁ ~ l₂ → Prop} {l₁ l₂ : List α} (p : l₁ ~ l₂)
+    (nil : P [] [] .nil)
+    (cons : ∀ x l₁ l₂, (h : l₁ ~ l₂) → P l₁ l₂ h → P (x :: l₁) (x :: l₂) (.cons x h))
+    (swap : ∀ x y l₁ l₂, (h : l₁ ~ l₂) → P l₁ l₂ h →
+      P (y :: x :: l₁) (x :: y :: l₂) (.trans (.swap x y _) (.cons _ (.cons _ h))))
+    (trans : ∀ l₁ l₂ l₃, (h₁ : l₁ ~ l₂) → (h₂ : l₂ ~ l₃) → P l₁ l₂ h₁ → P l₂ l₃ h₂ →
+      P l₁ l₃ (.trans h₁ h₂)) : P l₁ l₂ p :=
+  have P_refl l : P l l (.refl l) :=
+    List.recOn l nil fun x xs ih => cons x xs xs (Perm.refl xs) ih
+  Perm.recOn p nil cons (fun x y l => swap x y l l (Perm.refl l) (P_refl l)) @trans
+
+@[deprecated]
+theorem perm_induction_on_old {P : List α → List α → Prop} {l₁ l₂ : List α} (p : l₁ ~ l₂)
+    (h₁ : P [] [])
+    (h₂ : ∀ x l₁ l₂, l₁ ~ l₂ → P l₁ l₂ → P (x :: l₁) (x :: l₂))
+    (h₃ : ∀ x y l₁ l₂, l₁ ~ l₂ → P l₁ l₂ → P (y :: x :: l₁) (x :: y :: l₂))
+    (h₄ : ∀ l₁ l₂ l₃, l₁ ~ l₂ → l₂ ~ l₃ → P l₁ l₂ → P l₂ l₃ → P l₁ l₃) : P l₁ l₂ :=
+  have P_refl : ∀ l, P l l := fun l => List.recOn l h₁ fun x xs ih => h₂ x xs xs (Perm.refl xs) ih
+  p.rec h₁ h₂ (fun x y l => h₃ x y l l (Perm.refl l) (P_refl l)) @h₄
+
+theorem Perm.filterMap (f : α → Option β) {l₁ l₂ : List α} (p : l₁ ~ l₂) :
+    filterMap f l₁ ~ filterMap f l₂ :=
+  by
+  induction p with
+  | nil => simp
+  | cons x _p IH =>
+    cases h : f x
+      <;> simp [h, filterMap, IH, Perm.cons]
+  | swap x y l₂ =>
+    cases hx : f x
+      <;> cases hy : f y
+        <;> simp [hx, hy, filterMap, swap]
+  | trans _p₁ _p₂ IH₁ IH₂ =>
+    exact IH₁.trans IH₂
+
+theorem Perm.map (f : α → β) {l₁ l₂ : List α} (p : l₁ ~ l₂) : map f l₁ ~ map f l₂ :=
+  filterMap_eq_map f ▸ p.filterMap _
+
+theorem Perm.filter (p : α → Prop) [DecidablePred p] {l₁ l₂ : List α} (s : l₁ ~ l₂) :
+    filter p l₁ ~ filter p l₂ := by rw [← filterMap_eq_filter] ; apply s.filterMap _
+
+theorem filter_append_perm (p : α → Prop) [DecidablePred p] (l : List α) :
+    filter p l ++ filter (fun x => ¬p x) l ~ l :=
+  by
+  induction l with
+  | nil => simp [filter]
+  | cons x l ih =>
+    by_cases h : p x
+    · simp only [h, filter_cons_of_pos, filter_cons_of_neg, not_true, not_false_iff, cons_append]
+      exact ih.cons x
+    · simp only [h, filter_cons_of_neg, not_false_iff, filter_cons_of_pos]
+      refine' Perm.trans _ (ih.cons x)
+      exact perm_append_comm.trans (perm_append_comm.cons _)
+
+theorem exists_perm_sublist {l₁ l₂ l₂' : List α} (s : l₁ <+ l₂) (p : l₂ ~ l₂') :
+    ∃ (l₁' : _) (_ : l₁' ~ l₁), l₁' <+ l₂' :=
+  by
+  induction p generalizing l₁ with
+  | nil =>
+    exact ⟨[], sublist_nil.mp s ▸ Perm.refl _, nil_sublist _⟩
+  | cons x _ IH =>
+    cases s
+    next _ _ _ s =>
+      exact
+        let ⟨l₁', p', s'⟩ := IH s
+        ⟨l₁', p', s'.cons _⟩
+    next l₁ _ _ s =>
+      exact
+        let ⟨l₁', p', s'⟩ := IH s
+        ⟨x :: l₁', p'.cons x, s'.cons₂ _⟩
+  | swap x y l' =>
+    cases s
+    next s =>
+      cases s
+      next s =>
+        exact ⟨l₁, Perm.refl _, (s.cons _).cons _⟩
+      next l₁ s =>
+        exact ⟨x :: l₁, Perm.refl _, (s.cons _).cons₂ _⟩
+    next s =>
+      cases s
+      next l'' s =>
+        exact ⟨y :: l'', Perm.refl _, (s.cons₂ _).cons _⟩
+      next l'' s =>
+        exact ⟨x :: y :: l'', Perm.swap _ _ _, (s.cons₂ _).cons₂ _⟩
+  | trans _ _ IH₁ IH₂ =>
+    exact
+      let ⟨m₁, pm, sm⟩ := IH₁ s
+      let ⟨r₁, pr, sr⟩ := IH₂ sm
+      ⟨r₁, pr.trans pm, sr⟩
+
+theorem Perm.sizeOf_eq_sizeOf [SizeOf α] {l₁ l₂ : List α} (h : l₁ ~ l₂) : sizeOf l₁ = sizeOf l₂ :=
+  by
+  induction h with -- hd l₁ l₂ h₁₂ h_sz₁₂ a b l l₁ l₂ l₃ h₁₂ h₂₃ h_sz₁₂ h_sz₂₃
+  | nil => rfl
+  | cons _ _ h_sz₁₂ => simp [h_sz₁₂]
+  | swap x y l => simp [←Nat.add_assoc, Nat.succ_add, Nat.add_succ]; rw [Nat.add_comm (sizeOf x)]
+  | trans _ _ h_sz₁₂ h_sz₂₃ => simp [h_sz₁₂, h_sz₂₃]
+
+
+section Subperm
+
+/-- `Subperm l₁ l₂`, denoted `l₁ <+~ l₂`, means that `l₁` is a sublist of
+  a permutation of `l₂`. This is an analogue of `l₁ ⊆ l₂` which respects
+  multiplicities of elements, and is used for the `≤` relation on multisets. -/
+def Subperm (l₁ l₂ : List α) : Prop :=
+  ∃ (l : _)(_ : l ~ l₁), l <+ l₂
+
+/-- `Subperm l₁ l₂`, denoted `l₁ <+~ l₂`, means that `l₁` is a sublist of
+  a permutation of `l₂`. This is an analogue of `l₁ ⊆ l₂` which respects
+  multiplicities of elements, and is used for the `≤` relation on multisets. -/
+scoped infixl:50 " <+~ " => Subperm
+
+theorem nil_subperm {l : List α} : [] <+~ l :=
+  ⟨[], Perm.nil, by simp⟩
+
+theorem Perm.subperm_left {l l₁ l₂ : List α} (p : l₁ ~ l₂) : l <+~ l₁ ↔ l <+~ l₂ :=
+  suffices ∀ {l₁ l₂ : List α}, l₁ ~ l₂ → l <+~ l₁ → l <+~ l₂ from ⟨this p, this p.symm⟩
+  fun p ⟨_u, pu, su⟩ =>
+  let ⟨v, pv, sv⟩ := exists_perm_sublist su p
+  ⟨v, pv.trans pu, sv⟩
+
+theorem Perm.subperm_right {l₁ l₂ l : List α} (p : l₁ ~ l₂) : l₁ <+~ l ↔ l₂ <+~ l :=
+  ⟨fun ⟨u, pu, su⟩ => ⟨u, pu.trans p, su⟩, fun ⟨u, pu, su⟩ => ⟨u, pu.trans p.symm, su⟩⟩
+
+theorem Sublist.subperm {l₁ l₂ : List α} (s : l₁ <+ l₂) : l₁ <+~ l₂ :=
+  ⟨l₁, Perm.refl _, s⟩
+
+theorem Perm.subperm {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₁ <+~ l₂ :=
+  ⟨l₂, p.symm, Sublist.refl _⟩
+
+theorem Subperm.refl (l : List α) : l <+~ l :=
+  (Perm.refl _).subperm
+
+theorem Subperm.trans {l₁ l₂ l₃ : List α} : l₁ <+~ l₂ → l₂ <+~ l₃ → l₁ <+~ l₃
+  | s, ⟨_l₂', p₂, s₂⟩ =>
+    let ⟨l₁', p₁, s₁⟩ := p₂.subperm_left.2 s
+    ⟨l₁', p₁, s₁.trans s₂⟩
+
+theorem Subperm.length_le {l₁ l₂ : List α} : l₁ <+~ l₂ → length l₁ ≤ length l₂
+  | ⟨_l, p, s⟩ => p.length_eq ▸ s.length_le
+
+theorem Subperm.perm_of_length_le {l₁ l₂ : List α} : l₁ <+~ l₂ → length l₂ ≤ length l₁ → l₁ ~ l₂
+  | ⟨_l, p, s⟩, h => (s.eq_of_length_le <| p.symm.length_eq ▸ h) ▸ p.symm
+
+theorem Subperm.antisymm {l₁ l₂ : List α} (h₁ : l₁ <+~ l₂) (h₂ : l₂ <+~ l₁) : l₁ ~ l₂ :=
+  h₁.perm_of_length_le h₂.length_le
+
+theorem Subperm.subset {l₁ l₂ : List α} : l₁ <+~ l₂ → l₁ ⊆ l₂
+  | ⟨_l, p, s⟩ => Subset.trans p.symm.subset s.subset
+
+theorem Subperm.filter (p : α → Prop) [DecidablePred p] ⦃l l' : List α⦄ (h : l <+~ l') :
+    filter p l <+~ filter p l' := by
+  obtain ⟨xs, hp, h⟩ := h
+  exact ⟨_, hp.filter p, h.filter _⟩
+
+end Subperm
+
+theorem Sublist.exists_perm_append : ∀ {l₁ l₂ : List α}, l₁ <+ l₂ → ∃ l, l₂ ~ l₁ ++ l
+  | _, _, Sublist.slnil => ⟨nil, Perm.refl _⟩
+  | _, _, Sublist.cons a s =>
+    let ⟨l, p⟩ := Sublist.exists_perm_append s
+    ⟨a :: l, (p.cons a).trans perm_middle.symm⟩
+  | _, _, Sublist.cons₂ a s =>
+    let ⟨l, p⟩ := Sublist.exists_perm_append s
+    ⟨l, p.cons a⟩
+
+theorem Perm.countP_eq (p : α → Prop) [DecidablePred p] {l₁ l₂ : List α} (s : l₁ ~ l₂) :
+    countP p l₁ = countP p l₂ := by
+  simp only [countP_eq_length_filter]
+  exact (s.filter _).length_eq
+
+theorem Subperm.countP_le (p : α → Prop) [DecidablePred p] {l₁ l₂ : List α} :
+    l₁ <+~ l₂ → countP p l₁ ≤ countP p l₂
+  | ⟨_l, p', s⟩ => p'.countP_eq p ▸ s.countP_le p
+
+theorem Perm.countP_congr (s : l₁ ~ l₂) {p p' : α → Prop} [DecidablePred p] [DecidablePred p']
+    (hp : ∀ x ∈ l₁, p x = p' x) : l₁.countP p = l₂.countP p' :=
+  by
+  rw [← s.countP_eq p']
+  clear s
+  induction l₁ with
+  | nil => rfl
+  | cons y s hs =>
+    simp only [mem_cons, forall_eq_or_imp] at hp
+    simp only [countP_cons, hs hp.2, hp.1]
+
+theorem countP_eq_countP_filter_add (l : List α) (p q : α → Prop) [DecidablePred p]
+    [DecidablePred q] : l.countP p = (l.filter q).countP p + (l.filter fun a => ¬q a).countP p :=
+  by
+  rw [← countP_append]
+  exact Perm.countP_eq _ (filter_append_perm _ _).symm
+
+theorem Perm.count_eq [DecidableEq α] {l₁ l₂ : List α} (p : l₁ ~ l₂) (a) :
+    count a l₁ = count a l₂ :=
+  p.countP_eq _
+
+theorem Subperm.count_le [DecidableEq α] {l₁ l₂ : List α} (s : l₁ <+~ l₂) (a) :
+    count a l₁ ≤ count a l₂ :=
+  s.countP_le _
+
+theorem Perm.foldl_eq' {f : β → α → β} {l₁ l₂ : List α} (p : l₁ ~ l₂) :
+    (∀ x ∈ l₁, ∀ y ∈ l₁, ∀ (z), f (f z x) y = f (f z y) x) → ∀ b, foldl f b l₁ = foldl f b l₂ :=
+  perm_induction_on p (fun _H b => rfl)
+    (fun x t₁ t₂ _p r H b => r (fun x hx y hy => H _ (.tail _ hx) _ (.tail _ hy)) _)
+    (fun x y t₁ t₂ _p r H b => by
+      simp only [foldl]
+      rw [H x (.tail _ <| .head _) y (.head _)]
+      exact r (fun x hx y hy => H _ (.tail _ <| .tail _ hx) _ (.tail _ <| .tail _ hy)) _)
+    fun t₁ t₂ t₃ p₁ _p₂ r₁ r₂ H b =>
+    Eq.trans (r₁ H b) (r₂ (fun x hx y hy => H _ (p₁.symm.subset hx) _ (p₁.symm.subset hy)) b)
+
+theorem Perm.rec_heq {β : List α → Sort _} {f : ∀ a l, β l → β (a :: l)} {b : β []} {l l' : List α}
+    (hl : Perm l l') (f_congr : ∀ {a l l' b b'}, Perm l l' → HEq b b' → HEq (f a l b) (f a l' b'))
+    (f_swap : ∀ {a a' l b}, HEq (f a (a' :: l) (f a' l b)) (f a' (a :: l) (f a l b))) :
+    HEq (@List.rec α β b f l) (@List.rec α β b f l') :=
+  by
+  induction hl
+  case nil => rfl
+  case cons a l l' h ih => exact f_congr h ih
+  case swap a a' l => exact f_swap
+  case trans l₁ l₂ l₃ _h₁ _h₂ ih₁ ih₂ => exact HEq.trans ih₁ ih₂
+
+theorem perm_inv_core {a : α} {l₁ l₂ r₁ r₂ : List α} :
+    l₁ ++ a :: r₁ ~ l₂ ++ a :: r₂ → l₁ ++ r₁ ~ l₂ ++ r₂ :=
+  by
+  generalize e₁ : l₁ ++ a :: r₁ = s₁; generalize e₂ : l₂ ++ a :: r₂ = s₂
+  intro p; revert l₁ l₂ r₁ r₂ e₁ e₂; clear l₁ l₂ β
+  show ∀ _ _ _ _, _
+  refine
+      perm_induction_on p ?_ (fun x t₁ t₂ p IH => ?_) (fun x y t₁ t₂ p IH => ?_)
+        fun t₁ t₂ t₃ p₁ p₂ IH₁ IH₂ => ?_
+    <;> intro l₁ l₂ r₁ r₂ e₁ e₂
+  · apply (not_mem_nil a).elim
+    rw [← e₁]
+    simp
+  · cases l₁ <;> cases l₂ <;> dsimp at e₁ e₂ <;> injections <;> subst_vars
+    case nil.nil =>
+      exact p
+    case nil.cons =>
+      exact p.trans perm_middle
+    case cons.nil =>
+      exact perm_middle.symm.trans p
+    case cons.cons =>
+      exact (IH _ _ _ _ rfl rfl).cons _
+  · rcases l₁ with (_ | ⟨y, _ | ⟨z, l₁⟩⟩) <;> rcases l₂ with (_ | ⟨u, _ | ⟨v, l₂⟩⟩) <;>
+          dsimp at e₁ e₂ <;> injections <;> subst_vars
+    · subst_vars
+      exact p.cons _
+    · subst_vars
+      exact p.cons u
+    · subst_vars
+      exact (p.trans perm_middle).cons u
+    · subst_vars
+      exact p.cons y
+    · subst_vars
+      exact p.cons _
+    · subst_vars
+      exact ((p.trans perm_middle).cons _).trans (swap _ _ _)
+    · subst_vars
+      exact (perm_middle.symm.trans p).cons y
+    · subst_vars
+      exact (swap _ _ _).trans ((perm_middle.symm.trans p).cons u)
+    · subst_vars
+      exact (IH _ _ _ _ rfl rfl).swap' _ _
+  · subst t₁ t₃
+    have : a ∈ t₂ := p₁.subset (by simp)
+    rcases append_of_mem this with ⟨l₂, r₂, e₂⟩
+    subst t₂
+    exact (IH₁ _ _ _ _ rfl rfl).trans (IH₂ _ _ _ _ rfl rfl)
+
+theorem Perm.cons_inv {a : α} {l₁ l₂ : List α} : a :: l₁ ~ a :: l₂ → l₁ ~ l₂ :=
+  @perm_inv_core _ _ [] [] _ _
+
+@[simp]
+theorem perm_cons (a : α) {l₁ l₂ : List α} : a :: l₁ ~ a :: l₂ ↔ l₁ ~ l₂ :=
+  ⟨Perm.cons_inv, Perm.cons a⟩
+
+theorem perm_append_left_iff {l₁ l₂ : List α} : ∀ l, l ++ l₁ ~ l ++ l₂ ↔ l₁ ~ l₂
+  | [] => Iff.rfl
+  | a :: l => (perm_cons a).trans (perm_append_left_iff l)
+
+theorem perm_append_right_iff {l₁ l₂ : List α} (l) : l₁ ++ l ~ l₂ ++ l ↔ l₁ ~ l₂ :=
+  ⟨fun p => (perm_append_left_iff _).1 <| perm_append_comm.trans <| p.trans perm_append_comm,
+    Perm.append_right _⟩
+
+theorem subperm_cons (a : α) {l₁ l₂ : List α} : a :: l₁ <+~ a :: l₂ ↔ l₁ <+~ l₂ :=
+  ⟨fun ⟨l, p, s⟩ => by
+    match s with
+    | .cons _ s' => exact (p.subperm_left.2 <| (sublist_cons _ _).subperm).trans s'.subperm
+    | .cons₂ _ s' => exact ⟨_, p.cons_inv, s'⟩
+  , fun ⟨l, p, s⟩ => ⟨a :: l, p.cons a, s.cons₂ _⟩⟩
+
+theorem cons_subperm_of_mem {a : α} {l₁ l₂ : List α} (d₁ : Nodup l₁) (h₁ : a ∉ l₁) (h₂ : a ∈ l₂)
+    (s : l₁ <+~ l₂) : a :: l₁ <+~ l₂ :=
+  by
+  rcases s with ⟨l, p, s⟩
+  induction s generalizing l₁
+  case slnil => cases h₂
+  case cons r₁ r₂ b s' ih =>
+    simp at h₂
+    match h₂ with
+    | .inl e =>
+      subst_vars
+      exact ⟨_ :: r₁, p.cons _, s'.cons₂ _⟩
+    | .inr m =>
+      rcases ih d₁ h₁ m p with ⟨t, p', s'⟩
+      exact ⟨t, p', s'.cons _⟩
+  case cons₂ r₁ r₂ b _ ih =>
+    have bm : b ∈ l₁ := p.subset <| mem_cons_self _ _
+    have am : a ∈ r₂ := by
+      simp only [find?, mem_cons] at h₂
+      exact h₂.resolve_left fun e => h₁ <| e.symm ▸ bm
+    rcases append_of_mem bm with ⟨t₁, t₂, rfl⟩
+    have st : t₁ ++ t₂ <+ t₁ ++ b :: t₂ := by simp
+    rcases ih (d₁.sublist st) (mt (fun x => st.subset x) h₁) am
+        (Perm.cons_inv <| p.trans perm_middle) with
+      ⟨t, p', s'⟩
+    exact
+      ⟨b :: t, (p'.cons b).trans <| (swap _ _ _).trans (perm_middle.symm.cons a), s'.cons₂ _⟩
+
+theorem subperm_append_left {l₁ l₂ : List α} : ∀ l, l ++ l₁ <+~ l ++ l₂ ↔ l₁ <+~ l₂
+  | [] => Iff.rfl
+  | a :: l => (subperm_cons a).trans (subperm_append_left l)
+
+theorem subperm_append_right {l₁ l₂ : List α} (l) : l₁ ++ l <+~ l₂ ++ l ↔ l₁ <+~ l₂ :=
+  (perm_append_comm.subperm_left.trans perm_append_comm.subperm_right).trans (subperm_append_left l)
+
+theorem Subperm.exists_of_length_lt {l₁ l₂ : List α} :
+    l₁ <+~ l₂ → length l₁ < length l₂ → ∃ a, a :: l₁ <+~ l₂
+  | ⟨l, p, s⟩, h => by
+    suffices length l < length l₂ → ∃ a : α, a :: l <+~ l₂ from
+      (this <| p.symm.length_eq ▸ h).imp fun a => (p.cons a).subperm_right.1
+    clear h p l₁
+    induction s with
+    | slnil => intro h; cases h
+    | cons a s IH =>
+      intro h
+      cases Nat.lt_or_eq_of_le (Nat.le_of_lt_succ h)
+      next h => exact (IH h).imp fun a s => s.trans (sublist_cons _ _).subperm
+      next h => exact ⟨a, s.eq_of_length h ▸ Subperm.refl _⟩
+    | cons₂ b _ IH =>
+      intro h
+      exact (IH <| Nat.lt_of_succ_lt_succ h).imp fun a s =>
+          (swap _ _ _).subperm_right.1 <| (subperm_cons _).2 s
+
+protected theorem Nodup.subperm (d : Nodup l₁) (H : l₁ ⊆ l₂) : l₁ <+~ l₂ :=
+  by
+  induction d with
+  | nil => exact ⟨nil, Perm.nil, nil_sublist _⟩
+  | cons h d IH =>
+    have ⟨H₁, H₂⟩ := forall_mem_cons.1 H
+    have := fun contra => h _ contra rfl
+    exact cons_subperm_of_mem d this H₁ (IH H₂)
+
+theorem perm_ext {l₁ l₂ : List α} (d₁ : Nodup l₁) (d₂ : Nodup l₂) :
+    l₁ ~ l₂ ↔ ∀ a, a ∈ l₁ ↔ a ∈ l₂ :=
+  ⟨fun p _ => p.mem_iff, fun H =>
+    (d₁.subperm fun a => (H a).1).antisymm <| d₂.subperm fun a => (H a).2⟩
+
+theorem Nodup.sublist_ext {l₁ l₂ l : List α} (d : Nodup l) (s₁ : l₁ <+ l) (s₂ : l₂ <+ l) :
+    l₁ ~ l₂ ↔ l₁ = l₂ :=
+  ⟨ fun h => by
+    induction s₂ generalizing l₁ with
+    | slnil => exact h.eq_nil
+    | cons a s₂ IH =>
+      simp [Nodup] at d
+      cases s₁
+      next _ _ _ s₁ =>
+        exact IH d.2 s₁ h
+      next l₁ _ _ s₁ =>
+        have := Subperm.subset ⟨_, h.symm, s₂⟩ (mem_cons_self _ _)
+        exact (d.1 _ this rfl).elim
+    | cons₂ a _ IH =>
+      simp [Nodup] at d
+      cases s₁
+      next _ _ _ s₁ =>
+        have := Subperm.subset ⟨_, h, s₁⟩ (mem_cons_self _ _)
+        exact (d.1 _ this rfl).elim
+      next l₁ _ _ s₁ =>
+        rw [IH d.2 s₁ h.cons_inv]
+  , fun h => by rw [h]; apply Perm.refl⟩
+
+
+section
+
+variable [DecidableEq α]
+
+theorem Perm.erase (a : α) {l₁ l₂ : List α} (p : l₁ ~ l₂) : l₁.erase a ~ l₂.erase a :=
+  if h₁ : a ∈ l₁ then
+    have h₂ : a ∈ l₂ := p.subset h₁
+    Perm.cons_inv <| (perm_cons_erase h₁).symm.trans <| p.trans (perm_cons_erase h₂)
+  else by
+    have h₂ : a ∉ l₂ := mt p.mem_iff.2 h₁
+    rw [erase_of_not_mem h₁, erase_of_not_mem h₂] ; exact p
+
+theorem subperm_cons_erase (a : α) (l : List α) : l <+~ a :: l.erase a :=
+  by
+  by_cases h : a ∈ l
+  · exact (perm_cons_erase h).subperm
+  · rw [erase_of_not_mem h]
+    exact (sublist_cons _ _).subperm
+
+theorem erase_subperm (a : α) (l : List α) : l.erase a <+~ l :=
+  (erase_sublist _ _).subperm
+
+theorem Subperm.erase {l₁ l₂ : List α} (a : α) (h : l₁ <+~ l₂) : l₁.erase a <+~ l₂.erase a :=
+  let ⟨l, hp, hs⟩ := h
+  ⟨l.erase a, hp.erase _, hs.erase _⟩
+
+theorem Perm.diff_right {l₁ l₂ : List α} (t : List α) (h : l₁ ~ l₂) : l₁.diff t ~ l₂.diff t := by
+  induction t generalizing l₁ l₂ h with
+  | nil => simp only [List.diff]; exact h
+  | cons x t ih =>
+    simp only [List.diff]
+    split
+    case inl hx =>
+      have : elem x l₂ = true := by
+        apply elem_eq_true_of_mem
+        apply h.subset
+        apply mem_of_elem_eq_true hx
+      simp [this]
+      apply ih (h.erase _)
+    case inr hx =>
+      have : ¬elem x l₂ = true := fun contra =>
+        hx <| elem_eq_true_of_mem <| h.symm.subset <| mem_of_elem_eq_true contra
+      simp [this]
+      apply ih h
+
+theorem Perm.diff_left (l : List α) {t₁ t₂ : List α} (h : t₁ ~ t₂) : l.diff t₁ = l.diff t₂ := by
+  induction h generalizing l with
+  | nil => simp
+  | cons x _ ih =>
+    simp [List.diff]; apply ite_congr rfl <;> (intro; apply ih)
+  | swap x y =>
+    simp [List.diff]
+    match (inferInstance : DecidableEq _) x y with
+    | isTrue h => simp [h]
+    | isFalse h =>
+    simp [mem_erase_of_ne h, mem_erase_of_ne (Ne.symm h), erase_comm x y]
+    split <;> (next h => simp [h])
+  | trans =>
+    simp only [*]
+
+theorem Perm.diff {l₁ l₂ t₁ t₂ : List α} (hl : l₁ ~ l₂) (ht : t₁ ~ t₂) : l₁.diff t₁ ~ l₂.diff t₂ :=
+  ht.diff_left l₂ ▸ hl.diff_right _
+
+theorem Subperm.diff_right {l₁ l₂ : List α} (h : l₁ <+~ l₂) (t : List α) :
+    l₁.diff t <+~ l₂.diff t := by
+  induction t generalizing l₁ l₂ h with
+  | nil => simp only [List.diff]; exact h
+  | cons x t ih =>
+    simp only [List.diff]
+    split
+    case inl hx =>
+      have : elem x l₂ = true := by
+        apply elem_eq_true_of_mem
+        apply h.subset (mem_of_elem_eq_true hx)
+      simp [this]
+      apply ih
+      apply h.erase
+    case inr hx1 =>
+      split
+      case inl hx2 =>
+        apply ih
+        have := h.erase x
+        simp [erase_of_not_mem (hx1 ∘ elem_eq_true_of_mem)] at this
+        exact this
+      case inr hx2 =>
+        apply ih h
+
+theorem erase_cons_subperm_cons_erase (a b : α) (l : List α) :
+    (a :: l).erase b <+~ a :: l.erase b :=
+  by
+  by_cases h : a = b
+  · subst b
+    rw [erase_cons_head]
+    apply subperm_cons_erase
+  · rw [erase_cons_tail _ h]
+    apply Subperm.refl
+
+theorem subperm_cons_diff {a : α} {l₁ l₂ : List α} : (a :: l₁).diff l₂ <+~ a :: l₁.diff l₂
+  := by
+  induction l₂ with
+  | nil => exact ⟨a :: l₁, by simp [List.diff]⟩
+  | cons b l₂ ih =>
+    rw [diff_cons, diff_cons, ←diff_erase, ←diff_erase]
+    refine Subperm.trans ?_ (erase_cons_subperm_cons_erase _ _ _)
+    apply Subperm.erase
+    exact ih
+
+theorem subset_cons_diff {a : α} {l₁ l₂ : List α} : (a :: l₁).diff l₂ ⊆ a :: l₁.diff l₂ :=
+  subperm_cons_diff.subset
+
+theorem cons_perm_iff_perm_erase {a : α} {l₁ l₂ : List α} :
+    a :: l₁ ~ l₂ ↔ a ∈ l₂ ∧ l₁ ~ l₂.erase a :=
+  ⟨fun h =>
+    have : a ∈ l₂ := h.subset (mem_cons_self a l₁)
+    ⟨this, (h.trans <| perm_cons_erase this).cons_inv⟩,
+    fun ⟨m, h⟩ => (h.cons a).trans (perm_cons_erase m).symm⟩
+
+theorem perm_iff_count {l₁ l₂ : List α} : l₁ ~ l₂ ↔ ∀ a, count a l₁ = count a l₂ :=
+  ⟨Perm.count_eq, fun H => by
+    induction l₁ generalizing l₂ with
+    | nil =>
+      match l₂ with
+      | nil => apply Perm.refl
+      | cons b l₂ =>
+        specialize H b
+        simp at H
+        contradiction
+    | cons a l₁ IH =>
+      have : a ∈ l₂ := count_pos_iff_mem.mp (by rw [← H] ; simp ; apply Nat.zero_lt_succ)
+      refine' ((IH fun b => _).cons a).trans (perm_cons_erase this).symm
+      specialize H b
+      rw [(perm_cons_erase this).count_eq] at H
+      by_cases h : b = a <;> simp [h] at H ⊢ <;> assumption⟩
+
+theorem Subperm.cons_right {α : Type _} {l l' : List α} (x : α) (h : l <+~ l') : l <+~ x :: l' :=
+  h.trans (sublist_cons x l').subperm
+
+/-- The list version of `add_tsub_cancel_of_le` for multisets. -/
+theorem subperm_append_diff_self_of_count_le {l₁ l₂ : List α}
+    (h : ∀ x ∈ l₁, count x l₁ ≤ count x l₂) : l₁ ++ l₂.diff l₁ ~ l₂ :=
+  by
+  induction l₁ generalizing l₂ with
+  | nil => simp
+  | cons hd tl IH =>
+    have : hd ∈ l₂ := by
+      rw [← count_pos_iff_mem]
+      exact Nat.lt_of_lt_of_le
+        (count_pos_iff_mem.mpr (mem_cons_self _ _))
+        (h hd (mem_cons_self _ _))
+    have := perm_cons_erase this
+    refine' Perm.trans _ this.symm
+    rw [cons_append, diff_cons, perm_cons]
+    refine' IH fun x hx => _
+    specialize h x (mem_cons_of_mem _ hx)
+    rw [perm_iff_count.mp this] at h
+    by_cases hx : x = hd
+    · subst hd
+      simp [Nat.succ_le_succ_iff] at h
+      simp [h]
+    · simp [hx] at h
+      simp [hx, h]
+
+/-- The list version of `Multiset.le_iff_count`. -/
+theorem subperm_ext_iff {l₁ l₂ : List α} : l₁ <+~ l₂ ↔ ∀ x ∈ l₁, count x l₁ ≤ count x l₂ := by
+  refine' ⟨fun h x _ => Subperm.count_le h x, fun h => _⟩
+  suffices l₁ <+~ l₂.diff l₁ ++ l₁ by
+    refine' this.trans (Perm.subperm _)
+    exact perm_append_comm.trans (subperm_append_diff_self_of_count_le h)
+  exact (subperm_append_right l₁).mpr nil_subperm
+
+instance decidableSubperm : DecidableRel ((· <+~ ·) : List α → List α → Prop) := fun _ _ =>
+  decidable_of_iff _ List.subperm_ext_iff.symm
+
+@[simp]
+theorem subperm_singleton_iff {α} {l : List α} {a : α} : [a] <+~ l ↔ a ∈ l :=
+  ⟨fun ⟨s, hla, h⟩ => by rwa [perm_singleton.mp hla, singleton_sublist] at h, fun h =>
+    ⟨[a], Perm.refl _, singleton_sublist.mpr h⟩⟩
+
+theorem Subperm.cons_left {l₁ l₂ : List α} (h : l₁ <+~ l₂) (x : α) (hx : count x l₁ < count x l₂) :
+    x :: l₁ <+~ l₂ := by
+  rw [subperm_ext_iff] at h⊢
+  intro y hy
+  by_cases hy' : y = x
+  · subst x
+    have := Nat.succ_le_of_lt hx
+    simp at this
+    simp [this]
+  · rw [count_cons_of_ne hy']
+    refine' h y _
+    simp [hy'] at hy
+    simp [hy]
+
+instance decidablePerm : ∀ l₁ l₂ : List α, Decidable (l₁ ~ l₂)
+  | [], [] => isTrue <| Perm.refl _
+  | [], b :: l₂ => isFalse fun h => by have := h.nil_eq; contradiction
+  | a :: l₁, l₂ =>
+    haveI := decidablePerm l₁ (l₂.erase a)
+    decidable_of_iff' _ cons_perm_iff_perm_erase
+
+theorem Perm.insert (a : α) {l₁ l₂ : List α} (p : l₁ ~ l₂)
+  : l₁.insert a ~ l₂.insert a
+  := by
+  if h : a ∈ l₁ then
+    simp [h, p.subset h, p]
+  else
+    have := p.cons a
+    simp at this
+    simp [h, mt p.mem_iff.2 h, this]
+
+theorem perm_insert_swap (x y : α) (l : List α) :
+    List.insert x (List.insert y l) ~ List.insert y (List.insert x l) := by
+  by_cases xl : x ∈ l <;> by_cases yl : y ∈ l <;> simp [xl, yl]
+  by_cases xy : x = y; · simp [xy]
+  simp [List.insert, xl, yl, xy, Ne.symm xy]
+  constructor
+
+theorem perm_insertNth {α} (x : α) (l : List α) {n} (h : n ≤ l.length) :
+    insertNth n x l ~ x :: l := by
+  induction l generalizing n with
+  | nil =>
+    cases n
+    . apply Perm.refl
+    . cases h
+  | cons _ _ l_ih =>
+    cases n
+    · simp [insertNth]
+    · simp only [insertNth, modifyNthTail]
+      refine' Perm.trans (Perm.cons _ (l_ih _)) _
+      · apply Nat.le_of_succ_le_succ h
+      · apply Perm.swap
+
+theorem Perm.union_right {l₁ l₂ : List α} (t₁ : List α) (h : l₁ ~ l₂) : l₁ ∪ t₁ ~ l₂ ∪ t₁ :=
+  by
+  induction h with
+  | nil         => apply Perm.refl
+  | cons a _ ih => exact ih.insert a
+  | swap        => apply perm_insert_swap
+  | trans _ _ ih_1 ih_2 => exact ih_1.trans ih_2
+
+theorem Perm.union_left (l : List α) {t₁ t₂ : List α} (h : t₁ ~ t₂) : l ∪ t₁ ~ l ∪ t₂ := by
+  induction l with
+  | nil => simp only [List.nil_union, h]
+  | cons _ _ ih => simp only [List.cons_union, insert _ ih]
+
+theorem Perm.union {l₁ l₂ t₁ t₂ : List α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) :
+    l₁ ∪ t₁ ~ l₂ ∪ t₂ :=
+  (p₁.union_right t₁).trans (p₂.union_left l₂)
+
+theorem Perm.inter_right {l₁ l₂ : List α} (t₁ : List α) : l₁ ~ l₂ → l₁ ∩ t₁ ~ l₂ ∩ t₁ :=
+  Perm.filter _
+
+theorem Perm.inter_left (l : List α) {t₁ t₂ : List α} (p : t₁ ~ t₂) : l ∩ t₁ = l ∩ t₂ :=
+  filter_congr' fun a _ => by
+    have := p.mem_iff (a := a)
+    simp at this
+    simp [this]
+
+theorem Perm.inter {l₁ l₂ t₁ t₂ : List α} (p₁ : l₁ ~ l₂) (p₂ : t₁ ~ t₂) : l₁ ∩ t₁ ~ l₂ ∩ t₂ :=
+  p₂.inter_left l₂ ▸ p₁.inter_right t₁
+
+end
+
+theorem Perm.pairwise_iff {R : α → α → Prop} (S : ∀ {x y}, R x y → R y x) :
+    ∀ {l₁ l₂ : List α} (_p : l₁ ~ l₂), Pairwise R l₁ ↔ Pairwise R l₂ :=
+  suffices ∀ {l₁ l₂}, l₁ ~ l₂ → Pairwise R l₁ → Pairwise R l₂
+    from fun p => ⟨this p, this p.symm⟩
+  @fun l₁ l₂ p d => by
+  induction d generalizing l₂ with
+  | nil =>
+    rw [← p.nil_eq]
+    constructor
+  | cons h _ IH =>
+    have : _ ∈ l₂ := p.subset (mem_cons_self _ _)
+    rcases append_of_mem this with ⟨s₂, t₂, rfl⟩
+    have p' := (p.trans perm_middle).cons_inv
+    refine' (pairwise_middle S).2 (pairwise_cons.2 ⟨fun b m => _, IH _ p'⟩)
+    exact h _ (p'.symm.subset m)
+
+theorem Pairwise.perm {R : α → α → Prop} {l l' : List α} (hR : l.Pairwise R) (hl : l ~ l')
+    (hsymm : ∀ {x y}, R x y → R y x) : l'.Pairwise R :=
+  (hl.pairwise_iff hsymm).mp hR
+
+theorem Perm.pairwise {R : α → α → Prop} {l l' : List α} (hl : l ~ l') (hR : l.Pairwise R)
+    (hsymm : ∀ {x y}, R x y → R y x) : l'.Pairwise R :=
+  hR.perm hl hsymm
+
+theorem Perm.nodup_iff {l₁ l₂ : List α} : l₁ ~ l₂ → (Nodup l₁ ↔ Nodup l₂) :=
+  Perm.pairwise_iff <| @Ne.symm α
+
+theorem Perm.join {l₁ l₂ : List (List α)} (h : l₁ ~ l₂) : l₁.join ~ l₂.join :=
+  Perm.recOn h (Perm.refl _) (fun x xs₁ xs₂ _ ih => ih.append_left x)
+    (fun x₁ x₂ xs => by
+      simp [join]
+      rw [←append_assoc, ←append_assoc]
+      refine perm_append_comm.append_right ?_)
+    @fun xs₁ xs₂ xs₃ _ _ => Perm.trans
+
+theorem Perm.bind_right {l₁ l₂ : List α} (f : α → List β) (p : l₁ ~ l₂) : l₁.bind f ~ l₂.bind f :=
+  (p.map _).join
+
+theorem Perm.join_congr :
+    ∀ {l₁ l₂ : List (List α)} (_ : List.Forall₂ (· ~ ·) l₁ l₂), l₁.join ~ l₂.join
+  | _, _, Forall₂.nil => Perm.refl _
+  | _ :: _, _ :: _, Forall₂.cons h₁ h₂ => h₁.append (Perm.join_congr h₂)
+
+theorem Perm.erasep (f : α → Prop) [DecidablePred f] {l₁ l₂ : List α}
+    (H : Pairwise (fun a b => f a → f b → False) l₁) (p : l₁ ~ l₂) : eraseP f l₁ ~ eraseP f l₂ := by
+  induction p with
+  | nil => simp
+  | cons a p IH =>
+    by_cases h : f a
+    · simp [h, p]
+    · simp [h]
+      exact IH (pairwise_cons.1 H).2
+  | swap a b l =>
+    by_cases h₁ : f a <;> by_cases h₂ : f b <;> simp [h₁, h₂]
+    · cases (pairwise_cons.1 H).1 _ (mem_cons.2 (Or.inl rfl)) h₂ h₁
+    · apply swap
+  | trans p₁ _ IH₁ IH₂ =>
+    refine' (IH₁ H).trans (IH₂ ((p₁.pairwise_iff _).1 H))
+    exact fun h h₁ h₂ => h h₂ h₁

--- a/Std/Data/String/Lemmas.lean
+++ b/Std/Data/String/Lemmas.lean
@@ -378,7 +378,7 @@ theorem firstDiffPos_loop_eq (l₁ l₂ r₁ r₂ stop p)
         refine Nat.lt_min.2 ⟨?_, ?_⟩ <;> exact Nat.lt_add_of_pos_right add_csize_pos,
       show get ⟨l₁ ++ a :: r₁⟩ ⟨p⟩ = a by simp [hl₁, get_of_valid],
       show get ⟨l₂ ++ b :: r₂⟩ ⟨p⟩ = b by simp [hl₂, get_of_valid]]
-    simp [bne]; split <;> simp
+    simp; split <;> simp
     subst b
     rw [show next ⟨l₁ ++ a :: r₁⟩ ⟨p⟩ = ⟨utf8Len l₁ + csize a⟩ by simp [hl₁, next_of_valid]]
     simpa [← hl₁, ← Nat.add_assoc, Nat.add_right_comm] using

--- a/Std/Logic.lean
+++ b/Std/Logic.lean
@@ -709,6 +709,28 @@ theorem apply_ite (f : α → β) (P : Prop) [Decidable P] (x y : α) :
 @[simp] theorem ite_not (P : Prop) [Decidable P] (x y : α) : ite (¬P) x y = ite P y x :=
   dite_not P (fun _ => x) (fun _ => y)
 
+/-! ## Bool -/
+
+theorem Bool.eq_false_or_eq_true : (b : Bool) → b = true ∨ b = false
+  | true => .inl rfl
+  | false => .inr rfl
+
+theorem Bool.eq_false_iff {b : Bool} : b = false ↔ b ≠ true :=
+  ⟨ne_true_of_eq_false, eq_false_of_ne_true⟩
+
+theorem Bool.eq_iff_iff {a b : Bool} : a = b ↔ (a ↔ b) := by cases b <;> simp
+
+theorem Bool.beq_eq_false_iff [BEq α] {a a' : α} :
+    (a == a') = false ↔ a != a' := by
+  simp only [bne, not_eq_true']
+
+@[simp] theorem Bool.bne_eq_false_iff [BEq α] {a a' : α} :
+    (a != a') = false ↔ a == a' := by
+  simp only [bne, not_eq_false']
+
+theorem Bool.bne_iff_not_beq [BEq α] {a a' : α} : a != a' ↔ ¬(a == a') := by
+  simp only [not_eq_true, beq_eq_false_iff]
+
 /-! ## miscellaneous -/
 
 attribute [simp] inline
@@ -761,14 +783,5 @@ example [Subsingleton α] (p : α → Prop) : Subsingleton (Subtype p) :=
   ⟨fun ⟨x, _⟩ ⟨y, _⟩ => by congr; exact Subsingleton.elim x y⟩
 
 theorem false_ne_true : False ≠ True := fun h => h.symm ▸ trivial
-
-theorem Bool.eq_false_or_eq_true : (b : Bool) → b = true ∨ b = false
-  | true => .inl rfl
-  | false => .inr rfl
-
-theorem Bool.eq_false_iff {b : Bool} : b = false ↔ b ≠ true :=
-  ⟨ne_true_of_eq_false, eq_false_of_ne_true⟩
-
-theorem Bool.eq_iff_iff {a b : Bool} : a = b ↔ (a ↔ b) := by cases b <;> simp
 
 theorem ne_comm {α} {a b : α} : a ≠ b ↔ b ≠ a := ⟨Ne.symm, Ne.symm⟩


### PR DESCRIPTION
This adds a function `Buckets.toListModel`. It models an array of buckets as a list of (key, value) pairs. We prove a number of lemmas about the behaviour of this model w.r.t. various map operations. No further propositions are proven in this PR, in particular it doesn't add any facts about the relations between user-facing HashMap operations just yet.

Depends on #89 and #272.