### PR TITLE
feat: Upstream more `DiscrTree` APIs

### DIFF
--- a/Std/Lean/Meta/DiscrTree.lean
+++ b/Std/Lean/Meta/DiscrTree.lean
@@ -88,6 +88,12 @@ partial def size : Trie α s → Nat
     children.foldl (init := vs.size) fun n (_, c) => n + size c
 
 /--
+Whether the `Trie` is empty.
+-/
+partial def isEmpty : Trie α s → Bool
+  | .node vs children => vs.isEmpty && children.all fun (_, c) => c.isEmpty
+
+/--
 Merge two `Trie`s. Duplicate values are preserved.
 -/
 partial def mergePreservingDuplicates : Trie α s → Trie α s → Trie α s
@@ -100,6 +106,57 @@ where
     Array.mergeSortedMergingDuplicates
       (ord := ⟨compareOn (·.fst)⟩) cs₁ cs₂
       (fun (k₁, t₁) (_, t₂) => (k₁, mergePreservingDuplicates t₁ t₂))
+
+/-- The explicit stack of `mapArrays` -/
+private inductive Ctxt {α β s}
+  | empty : Ctxt
+  | ctxt : Array (Key s × Trie β s) → Array β → Array (Key s × Trie α s) → Key s → Ctxt → Ctxt
+
+/-- Apply a function to the array of values at each node in a `DiscrTree`. -/
+partial def mapArrays (t : Trie α s) (f : Array α → Array β) : Trie β s :=
+  let .node vs0 cs0 := t
+  go (.mkEmpty cs0.size) (f vs0) cs0.reverse Ctxt.empty
+where
+  /-- This implementation as a single tail-recursive function is chosen to not blow the
+      interpreter stack when the `Trie` is very deep -/
+  go cs vs todo ps :=
+    if todo.isEmpty then
+      let c := .node vs cs
+      match ps with
+      | .empty => c
+      | .ctxt cs' vs' todo k ps => go (cs'.push (k, c)) vs' todo ps
+    else
+      let (k, .node vs' cs') := todo.back
+      go (.mkEmpty cs'.size) (f vs') cs'.reverse (.ctxt cs vs todo.pop k ps)
+
+/--
+Remove elements for which `p` returns `false` from the given `Trie`.
+The removed elements are monadically folded over using `f` and `init`, so `f`
+is called once for each removed element and the final state of type `σ` is
+returned.
+-/
+@[specialize]
+private partial def filterFoldM [Monad m] [Inhabited σ] (f : σ → α → m σ)
+    (p : α → m (ULift Bool)) (init : σ) : Trie α s → m (Trie α s × σ)
+  | .node vs children => do
+    let (vs, acc) ← vs.foldlM (init := (#[], init)) λ (vs, acc) v => do
+      if (← p v).down then
+        return (vs.push v, acc)
+      else
+        return (vs, ← f acc v)
+    let (children, acc) ← go acc 0 children
+    let children := children.filter λ (_, c) => ! c.isEmpty
+    return (.node vs children, acc)
+  where
+    go (acc : σ) (i : Nat) (children : Array (Key s × Trie α s)) :
+        m (Array (Key s × Trie α s) × σ) := do
+      if h : i < children.size then
+        let (key, t) := children[i]'h
+        let (t, acc) ← filterFoldM f p acc t
+        go acc (i + 1) (children.set ⟨i, h⟩ (key, t))
+      else
+        return (children, acc)
+
 
 end Trie
 
@@ -156,9 +213,36 @@ def size (t : DiscrTree α s) : Nat :=
   t.root.foldl (init := 0) fun n _ t => n + t.size
 
 /--
+Whether the `DiscrTree` is empty.
+-/
+def isEmpty (t : DiscrTree α s) : Bool :=
+  t.root.foldl (init := True) fun b _ t => b && t.isEmpty
+
+/--
 Merge two `DiscrTree`s. Duplicate values are preserved.
 -/
 @[inline]
 def mergePreservingDuplicates (t u : DiscrTree α s) : DiscrTree α s :=
   ⟨t.root.mergeWith u.root fun _ trie₁ trie₂ =>
     trie₁.mergePreservingDuplicates trie₂⟩
+
+/-- Apply a function to the array of values at each node in a `DiscrTree`. -/
+def mapArrays (d : DiscrTree α s) (f : Array α → Array β) : DiscrTree β s :=
+  { root := d.root.map (fun t => t.mapArrays f) }
+
+/--
+Remove elements for which `p` returns `false` from the given `DiscrTrie`.
+The removed elements are monadically folded over using `f` and `init`, so `f`
+is called once for each removed element and the final state of type `σ` is
+returned.
+-/
+@[specialize]
+def filterFoldM [Monad m] [Inhabited σ] (p : α → m (ULift Bool))
+    (f : σ → α → m σ) (init : σ) (t : DiscrTree α s) :
+    m (DiscrTree α s × σ) := do
+  let (root, acc) ←
+    t.root.foldlM (init := (.empty, init)) λ (root, acc) key t => do
+      let (t, acc) ← t.filterFoldM f p acc
+      let root := if t.isEmpty then root else root.insert key t
+      return (root, acc)
+  return (⟨root⟩, acc)

--- a/Std/Lean/Meta/DiscrTree.lean
+++ b/Std/Lean/Meta/DiscrTree.lean
@@ -231,7 +231,7 @@ def mapArrays (d : DiscrTree α s) (f : Array α → Array β) : DiscrTree β s 
   { root := d.root.map (fun t => t.mapArrays f) }
 
 /--
-Remove elements for which `p` returns `false` from the given `DiscrTrie`.
+Remove elements for which `p` returns `false` from the given `DiscrTree`.
 The removed elements are monadically folded over using `f` and `init`, so `f`
 is called once for each removed element and the final state of type `σ` is
 returned.

--- a/Std/Lean/Meta/DiscrTree.lean
+++ b/Std/Lean/Meta/DiscrTree.lean
@@ -34,8 +34,9 @@ end Key
 
 namespace Trie
 
--- This is just a partial function, but Lean doesn't realise that its type is
--- inhabited.
+-- TODO: Many functions below are labeled partial (or even unsafe when Lean doesn't realize that
+-- their type is inhabited), which would be proven to be terminating.
+
 private unsafe def foldMUnsafe [Monad m] (initialKeys : Array (Key s))
     (f : σ → Array (Key s) → α → m σ) (init : σ) : Trie α s → m σ
   | Trie.node vs children => do
@@ -59,8 +60,6 @@ def fold (initialKeys : Array (Key s)) (f : σ → Array (Key s) → α → σ)
     (init : σ) (t : Trie α s) : σ :=
   Id.run <| t.foldM initialKeys (init := init) fun s k a => return f s k a
 
--- This is just a partial function, but Lean doesn't realise that its type is
--- inhabited.
 private unsafe def foldValuesMUnsafe [Monad m] (f : σ → α → m σ) (init : σ) :
     Trie α s → m σ
 | node vs children => do

--- a/Std/Lean/Meta/DiscrTree.lean
+++ b/Std/Lean/Meta/DiscrTree.lean
@@ -117,8 +117,9 @@ partial def mapArrays (t : Trie α s) (f : Array α → Array β) : Trie β s :=
   let .node vs0 cs0 := t
   go (.mkEmpty cs0.size) (f vs0) cs0.reverse Ctxt.empty
 where
-  /-- This implementation as a single tail-recursive function is chosen to not blow the
-      interpreter stack when the `Trie` is very deep -/
+  -- This implementation as a single tail-recursive function is chosen to not blow the
+  -- interpreter stack when the `Trie` is very deep
+  /-- Internal loop of `Trie.mapArrays` -/
   go cs vs todo ps :=
     if todo.isEmpty then
       let c := .node vs cs

--- a/Std/Lean/Meta/DiscrTree.lean
+++ b/Std/Lean/Meta/DiscrTree.lean
@@ -140,13 +140,13 @@ returned.
 private partial def filterFoldM [Monad m] [Inhabited σ] (f : σ → α → m σ)
     (p : α → m (ULift Bool)) (init : σ) : Trie α s → m (Trie α s × σ)
   | .node vs children => do
-    let (vs, acc) ← vs.foldlM (init := (#[], init)) λ (vs, acc) v => do
+    let (vs, acc) ← vs.foldlM (init := (#[], init)) fun (vs, acc) v => do
       if (← p v).down then
         return (vs.push v, acc)
       else
         return (vs, ← f acc v)
     let (children, acc) ← go acc 0 children
-    let children := children.filter λ (_, c) => ! c.isEmpty
+    let children := children.filter fun (_, c) => !c.isEmpty
     return (.node vs children, acc)
   where
     go (acc : σ) (i : Nat) (children : Array (Key s × Trie α s)) :
@@ -242,7 +242,7 @@ def filterFoldM [Monad m] [Inhabited σ] (p : α → m (ULift Bool))
     (f : σ → α → m σ) (init : σ) (t : DiscrTree α s) :
     m (DiscrTree α s × σ) := do
   let (root, acc) ←
-    t.root.foldlM (init := (.empty, init)) λ (root, acc) key t => do
+    t.root.foldlM (init := (.empty, init)) fun (root, acc) key t => do
       let (t, acc) ← t.filterFoldM f p acc
       let root := if t.isEmpty then root else root.insert key t
       return (root, acc)

--- a/Std/Tactic/Lint/Simp.lean
+++ b/Std/Tactic/Lint/Simp.lean
@@ -76,16 +76,6 @@ def checkAllSimpTheoremInfos (ty : Expr) (k : SimpTheoremInfo → MetaM (Option 
 def isSimpTheorem (declName : Name) : MetaM Bool := do
   pure $ (← getSimpTheorems).lemmaNames.contains (.decl declName)
 
-open Lean.Meta.DiscrTree in
-/-- Returns the list of elements in the discrimination tree. -/
-partial def _root_.Lean.Meta.DiscrTree.elements (d : DiscrTree α s) : Array α :=
-  d.root.foldl (init := #[]) fun arr _ => trieElements arr
-where
-  /-- Returns the list of elements in the trie. -/
-  trieElements (arr)
-  | Trie.node vs children =>
-    children.foldl (init := arr ++ vs) fun arr (_, child) => trieElements arr child
-
 open Std
 
 /-- Add message `msg` to any errors thrown inside `k`. -/


### PR DESCRIPTION
while working on https://github.com/leanprover/lean4/pull/2577 I noticed
that functions on `DiscrTree`s are scattered throughout std4, aesop and
mathlib4. This PR upstreams those functions look at the internals of
`DiscrTree`, in particular

* `mapArrays` from mathlib
  <https://github.com/leanprover-community/mathlib4/blob/c00742dc87c9656c6a5502317d75344c0284751b/Mathlib/Lean/Meta/DiscrTree.lean#L79-L81>
* `filterFoldM` from aesop
  <https://github.com/JLimperg/aesop/blob/831865d91f9dcc8ef9295d6d6053606766cdb6a3/Aesop/Util/Basic.lean#L123-L138>
  (renamed to put the `Trie`/`DiscrTree` into the namespace)

The other function in mathlib that operate on `DiscrTree`, is a reimplementation of `.values`.

Also drop the reimplementation `.elements` in std4.

Collecting all operations in one place not only avoids such reimplementations (hopefully), but
also makes it easier to refactor the internals of the data structure.