### PR TITLE
perf: improve kernel reduction of `List.sublists`

### DIFF
--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -897,8 +897,10 @@ def sublistsFast (l : List α) : List (List α) :=
     fun r l => (r.push l).push (a :: l)
   (l.foldr f #[[]]).toList
 
--- The fact that this transformation is safe is proved in mathlib. Using a `csimp` lemma here is
--- impractical as we are missing a lot of lemmas about lists.
+-- The fact that this transformation is safe is proved in mathlib4 as `sublists_eq_sublistsFast`.
+-- Using a `csimp` lemma here is impractical as we are missing a lot of lemmas about lists.
+-- TODO(std4#307): upstream the necessary results about `sublists` and put the `csimp` lemma in
+-- `Std/Data/List/Lemmas.lean`.
 attribute [implemented_by sublistsFast] sublists
 
 section Forall₂

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -889,9 +889,17 @@ sublists [1, 2, 3] = [[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]]
 ```
 -/
 def sublists (l : List α) : List (List α) :=
+  l.foldr (fun a acc => join (acc.map fun x => [x, a :: x])) [[]]
+
+/-- A version of `List.sublists` that has faster runtime performance but worse kernel performance -/
+def sublistsFast (l : List α) : List (List α) :=
   let f a arr := arr.foldl (init := Array.mkEmpty (arr.size * 2))
     fun r l => (r.push l).push (a :: l)
   (l.foldr f #[[]]).toList
+
+-- The fact that this transformation is safe is proved in mathlib. Using a `csimp` lemma here is
+-- impractical as we are missing a lot of lemmas about lists.
+attribute [implemented_by sublistsFast] sublists
 
 section Forall₂
 

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -889,7 +889,7 @@ sublists [1, 2, 3] = [[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]]
 ```
 -/
 def sublists (l : List α) : List (List α) :=
-  l.foldr (fun a acc => join (acc.map fun x => [x, a :: x])) [[]]
+  l.foldr (fun a acc => acc.bind fun x => [x, a :: x]) [[]]
 
 /-- A version of `List.sublists` that has faster runtime performance but worse kernel performance -/
 def sublistsFast (l : List α) : List (List α) :=

--- a/test/list_sublists.lean
+++ b/test/list_sublists.lean
@@ -1,0 +1,10 @@
+import Std.Data.List.Basic
+
+-- this times out with `sublistsFast`
+set_option maxRecDepth 561 in
+example : [1, 2, 3].sublists.sublists.length = 256 := rfl
+
+-- TODO(std4#307): until we have the `csimp` lemma in std, this is a sanity check that these two
+-- are equal.
+example : ([] : List Nat).sublists = [].sublistsFast := rfl
+example : [1, 2, 3].sublists = [1, 2, 3].sublistsFast := rfl


### PR DESCRIPTION
This replaces leanprover-community/mathlib4#7388, where @ChrisHughes notes

> I suspect the cause of the slowdown was the use of `Array` in `List.sublists`. An `Array` in the Kernel is just a `List`, but compiled to something more efficient. `List.sublists` uses `Array.push`, which is slow in the kernel becuase it's `l ++ [a]` on the underlying list, so it's linear time instead of constant time. So this new implementation is a better complexity in the kernel.

The difference can be seen as follows; this is fast:
```lean
set_option maxRecDepth 561 in
example : [1, 2, 3].sublists.sublists.length = 256 := rfl
```
but this hits a deterministic timeout
```lean
example : [1, 2, 3].sublistsFast.sublistsFast.length = 256 := rfl
```

---

This should not be merged until leanprover-community/mathlib4#7746 is delegated.