### PR TITLE
fix: version numbers in code actions 

### DIFF
--- a/Std/CodeAction/Deprecated.lean
+++ b/Std/CodeAction/Deprecated.lean
@@ -60,7 +60,7 @@ def deprecatedCodeActionProvider : CodeActionProvider := fun params snap => do
         let pos := doc.meta.text.leanPosToLspPos msg.pos
         let endPos' := doc.meta.text.leanPosToLspPos endPos
         pure { eager with
-          edit? := some <| .ofTextEdit params.textDocument.uri {
+          edit? := some <| .ofTextEdit doc.versionedIdentifier {
             range := ⟨pos, endPos'⟩
             newText := toString c'
           }

--- a/Std/Tactic/GuardMsgs.lean
+++ b/Std/Tactic/GuardMsgs.lean
@@ -163,7 +163,7 @@ elab_rules : command
 open CodeAction Server RequestM in
 /-- A code action which will update the doc comment on a `#guard_msgs` invocation. -/
 @[command_code_action guardMsgsCmd]
-def guardMsgsCodeAction : CommandCodeAction := fun params _ _ node => do
+def guardMsgsCodeAction : CommandCodeAction := fun _ _ _ node => do
   let .node _ ts := node | return #[]
   let res := ts.findSome? fun
     | .node (.ofCustomInfo { stx, value }) _ => return (stx, (← value.get? GuardMsgFailure).res)
@@ -187,7 +187,7 @@ def guardMsgsCodeAction : CommandCodeAction := fun params _ _ node => do
       else
         s!"/--\n{res}\n-/\n"
       pure { eager with
-        edit? := some <|.ofTextEdit params.textDocument.uri {
+        edit? := some <|.ofTextEdit doc.versionedIdentifier {
           range := doc.meta.text.utf8RangeToLspRange ⟨start, tail⟩
           newText
         }

--- a/Std/Tactic/TryThis.lean
+++ b/Std/Tactic/TryThis.lean
@@ -62,7 +62,7 @@ apply the replacement.
       eager.title := "Apply 'Try this'"
       eager.kind? := "quickfix"
       eager.isPreferred? := true
-      eager.edit? := some <| .ofTextEdit params.textDocument.uri { range, newText }
+      eager.edit? := some <| .ofTextEdit doc.versionedIdentifier { range, newText }
     }
 
 /-- Replace subexpressions like `?m.1234` with `?_` so it can be copy-pasted. -/

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0-rc4
+leanprover/lean4-pr-releases:pr-release-2721


### PR DESCRIPTION
[Zulip topic](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/LSP.20code.20action.20document.20version)

VS Code ignores the version number in a WorkspaceEdit but does not allow it to be null. There is at least one LSP client which does validate the version number, namely the Eglot client included in Emacs. By sending the correct version, we can be compatible with both.

~~This is a self-contained (std4-only) version, instead of the two changes (to lean4 and std4) that I mentioned on Zulip.~~

