### PR TITLE
chore: automation to maintain a nightly-testing branch

### DIFF
--- a/.github/nightly_bump_toolchain.yml
+++ b/.github/nightly_bump_toolchain.yml
@@ -1,0 +1,34 @@
+name: Bump lean-toolchain on nightly-testing
+
+on:
+  schedule:
+    - cron: '0 10 * * *'  # 11AM CET/2AM PT, 3 hours after lean4 starts building the nightly.
+
+jobs:
+  update-toolchain:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        ref: nightly-testing # checkout nightly-testing branch
+        token: ${{ secrets.NIGHTLY_TESTING }}
+
+    - name: Get latest release tag from leanprover/lean4-nightly
+      id: get-latest-release
+      run: |
+        RELEASE_TAG=$(curl -s "https://api.github.com/repos/leanprover/lean4-nightly/releases" | jq -r '.[0].tag_name')
+        echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
+
+    - name: Update lean-toolchain file
+      run: |
+        echo "leanprover/lean4:${RELEASE_TAG}" > lean-toolchain
+
+    - name: Commit and push changes
+      run: |
+        git config user.name "leanprover-community-mathlib4-bot"
+        git config user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
+        git add lean-toolchain
+        git commit -m "chore: bump to ${RELEASE_TAG}"
+        git push origin nightly-testing

--- a/.github/nightly_bump_toolchain.yml
+++ b/.github/nightly_bump_toolchain.yml
@@ -2,7 +2,9 @@ name: Bump lean-toolchain on nightly-testing
 
 on:
   schedule:
-    - cron: '0 10 * * *'  # 11AM CET/2AM PT, 3 hours after lean4 starts building the nightly.
+    - cron: '0 9 * * *' 
+    # 10AM CET/1AM PT, 2 hours after lean4 starts building the nightly.
+    # Mathlib's `nightly-testing` branch is bumped one hour later.
 
 jobs:
   update-toolchain:

--- a/.github/nightly_detect_failure.yml
+++ b/.github/nightly_detect_failure.yml
@@ -1,0 +1,25 @@
+name: Post to zulip if the nightly-testing branch is failing.
+
+on:
+  workflow_run:
+    workflows: ["continuous integration"]
+    types:
+      - completed
+
+jobs:
+  handle_failure:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'nightly-testing' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Send message on Zulip
+      uses: zulip/github-actions-zulip/send-message@v1
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+        organization-url: 'https://leanprover.zulipchat.com'
+        to: 'mathlib reviewers'
+        type: 'stream'
+        topic: 'CI failure on the nightly-testing branch'
+        content: |
+          The latest CI for branch#nightly-testing has [failed](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}).

--- a/.github/nightly_detect_failure.yml
+++ b/.github/nightly_detect_failure.yml
@@ -22,4 +22,4 @@ jobs:
         type: 'stream'
         topic: 'CI failure on the nightly-testing branch'
         content: |
-          The latest CI for branch#nightly-testing has [failed](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}).
+          The latest CI for Std's [`night-testing`](https://github.com/leanprover/std4/tree/nightly-testing) branch has [failed](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}).

--- a/.github/nightly_merge_master.yml
+++ b/.github/nightly_merge_master.yml
@@ -1,6 +1,6 @@
 # This job merges every commit to `main` into `nightly-testing`, resolving merge conflicts in favor of `nightly-testing`.
 
-name: Merge master to nightly
+name: Merge main to nightly
 
 on:
   push:

--- a/.github/nightly_merge_master.yml
+++ b/.github/nightly_merge_master.yml
@@ -1,0 +1,30 @@
+# This job merges every commit to `main` into `nightly-testing`, resolving merge conflicts in favor of `nightly-testing`.
+
+name: Merge master to nightly
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge-to-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.NIGHTLY_TESTING }}
+
+      - name: Configure Git User
+        run: |
+          git config user.name "leanprover-community-mathlib4-bot"
+          git config user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
+
+      - name: Merge main to nightly favoring nightly changes
+        run: |
+          git checkout nightly-testing
+          git merge main --strategy-option ours --no-commit --allow-unrelated-histories
+          git commit -m "Merge main into nightly-testing"
+          git push origin nightly-testing


### PR DESCRIPTION
Adds the following steps to CI:
* On every commit to `main`, merges `main` into `nightly-testing` (with all conflicts resolved in favour of `nightly-testing`)
* Once per day, updates `lean-toolchain` on the `nightly-testing` branch to point to the latest nightly release.
* On each CI failure on the `nightly-testing` branch, writes a message to the [mathlib reviewers](https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers) > [CI failure on the nightly-testing branch](https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/CI.20failure.20on.20the.20nightly-testing.20branch) topic.

I plan to merge `depends on core changes` labelled PRs into `nightly-testing` as the corresponding PRs to Lean land in nightly releases.

Finally, I am going to tweak the Mathlib CI for `nightly-testing` so that it runs `lake update std` daily (it will be pointing at the  `nightly-testing` branch of Std).

---

This will need two secrets installed in the repository, which I'll message @joehendrix and @digama0 about privately.