### PR TITLE
chore: bump toolchain to v4.3.0-rc1, incorporating changes from #297, #306, #316

### DIFF
--- a/Std/CodeAction/Deprecated.lean
+++ b/Std/CodeAction/Deprecated.lean
@@ -60,7 +60,7 @@ def deprecatedCodeActionProvider : CodeActionProvider := fun params snap => do
         let pos := doc.meta.text.leanPosToLspPos msg.pos
         let endPos' := doc.meta.text.leanPosToLspPos endPos
         pure { eager with
-          edit? := some <| .ofTextEdit params.textDocument.uri {
+          edit? := some <| .ofTextEdit doc.versionedIdentifier {
             range := ⟨pos, endPos'⟩
             newText := toString c'
           }

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -14,7 +14,8 @@ namespace Fin
 /-- If you actually have an element of `Fin n`, then the `n` is always positive -/
 theorem size_pos (i : Fin n) : 0 < n := Nat.lt_of_le_of_lt (Nat.zero_le _) i.2
 
-theorem mod_def (a m : Fin n) : a % m = Fin.mk ((a % m) % n) (Nat.mod_lt _ a.size_pos) := rfl
+theorem mod_def (a m : Fin n) : a % m = Fin.mk (a % m) (Nat.lt_of_le_of_lt (Nat.mod_le _ _) a.2) :=
+  rfl
 
 theorem mul_def (a b : Fin n) : a * b = Fin.mk ((a * b) % n) (Nat.mod_lt _ a.size_pos) := rfl
 
@@ -58,13 +59,13 @@ theorem mk_val (i : Fin n) : (⟨i, i.isLt⟩ : Fin n) = i := Fin.eta ..
 @[simp] theorem ofNat'_zero_val : (Fin.ofNat' 0 h).val = 0 := Nat.zero_mod _
 
 @[simp] theorem mod_val (a b : Fin n) : (a % b).val = a.val % b.val :=
-  Nat.mod_eq_of_lt (Nat.lt_of_le_of_lt (Nat.mod_le ..) a.2)
+  rfl
 
 @[simp] theorem div_val (a b : Fin n) : (a / b).val = a.val / b.val :=
-  Nat.mod_eq_of_lt (Nat.lt_of_le_of_lt (Nat.div_le_self ..) a.2)
+  rfl
 
 @[simp] theorem modn_val (a : Fin n) (b : Nat) : (a.modn b).val = a.val % b :=
-  Nat.mod_eq_of_lt (Nat.lt_of_le_of_lt (Nat.mod_le ..) a.2)
+  rfl
 
 theorem ite_val {n : Nat} {c : Prop} [Decidable c] {x : c → Fin n} (y : ¬c → Fin n) :
     (if h : c then x h else y h).val = if h : c then (x h).val else (y h).val := by

--- a/Std/Tactic/GuardMsgs.lean
+++ b/Std/Tactic/GuardMsgs.lean
@@ -163,7 +163,7 @@ elab_rules : command
 open CodeAction Server RequestM in
 /-- A code action which will update the doc comment on a `#guard_msgs` invocation. -/
 @[command_code_action guardMsgsCmd]
-def guardMsgsCodeAction : CommandCodeAction := fun params _ _ node => do
+def guardMsgsCodeAction : CommandCodeAction := fun _ _ _ node => do
   let .node _ ts := node | return #[]
   let res := ts.findSome? fun
     | .node (.ofCustomInfo { stx, value }) _ => return (stx, (← value.get? GuardMsgFailure).res)
@@ -187,7 +187,7 @@ def guardMsgsCodeAction : CommandCodeAction := fun params _ _ node => do
       else
         s!"/--\n{res}\n-/\n"
       pure { eager with
-        edit? := some <|.ofTextEdit params.textDocument.uri {
+        edit? := some <|.ofTextEdit doc.versionedIdentifier {
           range := doc.meta.text.utf8RangeToLspRange ⟨start, tail⟩
           newText
         }

--- a/Std/Tactic/Instances.lean
+++ b/Std/Tactic/Instances.lean
@@ -35,7 +35,7 @@ elab (name := instancesCmd) tk:"#instances " stx:term : command => runTermElabM 
     let some className ← isClass? type
       | throwErrorAt stx "type class instance expected{indentExpr type}"
     let globalInstances ← getGlobalInstancesIndex
-    let result ← globalInstances.getUnify type
+    let result ← globalInstances.getUnify type tcDtConfig
     let erasedInstances ← getErasedInstances
     let mut msgs := #[]
     for e in result.insertionSort fun e₁ e₂ => e₁.priority < e₂.priority do

--- a/Std/Tactic/Lint/Simp.lean
+++ b/Std/Tactic/Lint/Simp.lean
@@ -78,7 +78,7 @@ def isSimpTheorem (declName : Name) : MetaM Bool := do
 
 open Lean.Meta.DiscrTree in
 /-- Returns the list of elements in the discrimination tree. -/
-partial def _root_.Lean.Meta.DiscrTree.elements (d : DiscrTree α s) : Array α :=
+partial def _root_.Lean.Meta.DiscrTree.elements (d : DiscrTree α) : Array α :=
   d.root.foldl (init := #[]) fun arr _ => trieElements arr
 where
   /-- Returns the list of elements in the trie. -/
@@ -229,7 +229,8 @@ Some commutativity lemmas are simp lemmas:"
     unless ← isDefEq rhs lhs' do return none
     unless ← withNewMCtxDepth (isDefEq rhs lhs') do return none
     -- make sure that the discrimination tree will actually find this match (see #69)
-    if (← (← DiscrTree.empty.insert (s := true) rhs ()).getMatch lhs').isEmpty then return none
+    if (← (← DiscrTree.empty.insert rhs () simpDtConfig).getMatch lhs' simpDtConfig).isEmpty then
+      return none
     -- ensure that the second application makes progress:
     if ← isDefEq lhs' rhs' then return none
     pure m!"should not be marked simp"

--- a/Std/Tactic/Relation/Rfl.lean
+++ b/Std/Tactic/Relation/Rfl.lean
@@ -17,11 +17,14 @@ namespace Std.Tactic
 
 open Lean Meta
 
+/-- Discrimation tree settings for the `refl` extension. -/
+def reflExt.config : WhnfCoreConfig := {}
+
 /-- Environment extensions for `refl` lemmas -/
 initialize reflExt :
-    SimpleScopedEnvExtension (Name × Array (DiscrTree.Key true)) (DiscrTree Name true) ←
+    SimpleScopedEnvExtension (Name × Array DiscrTree.Key) (DiscrTree Name) ←
   registerSimpleScopedEnvExtension {
-    addEntry := fun dt (n, ks) => dt.insertCore ks n
+    addEntry := fun dt (n, ks) => dt.insertCore ks n reflExt.config
     initial := {}
   }
 
@@ -35,7 +38,7 @@ initialize registerBuiltinAttribute {
       "@[refl] attribute only applies to lemmas proving x ∼ x, got {declTy}"
     let .app (.app rel lhs) rhs := targetTy | fail
     unless ← withNewMCtxDepth <| isDefEq lhs rhs do fail
-    let key ← DiscrTree.mkPath rel
+    let key ← DiscrTree.mkPath rel reflExt.config
     reflExt.add (decl, key) kind
 }
 
@@ -52,7 +55,7 @@ def _root_.Lean.MVarId.applyRfl (goal : MVarId) : MetaM Unit := do
         indentExpr (← goal.getType)}"
   let s ← saveState
   let mut ex? := none
-  for lem in ← (reflExt.getState (← getEnv)).getMatch rel do
+  for lem in ← (reflExt.getState (← getEnv)).getMatch rel reflExt.config do
     try
       let gs ← goal.apply (← mkConstWithFreshMVarLevels lem)
       if gs.isEmpty then return () else

--- a/Std/Tactic/TryThis.lean
+++ b/Std/Tactic/TryThis.lean
@@ -102,7 +102,7 @@ apply the replacement.
         eager.kind? := "quickfix"
         -- Only make the first option preferred
         eager.isPreferred? := if i = 0 then true else none
-        eager.edit? := some <| .ofTextEdit params.textDocument.uri { range, newText }
+        eager.edit? := some <| .ofTextEdit doc.versionedIdentifier { range, newText }
       }
     result
 

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,0 +1,1 @@
+{"version": 6, "packagesDir": "lake-packages", "packages": [], "name": "std"}

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0-rc4
+leanprover/lean4:v4.2.0

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0
+leanprover/lean4:v4.3.0-rc1


### PR DESCRIPTION
This should only be merged after #337.

Includes the changes from PRs #297, #306, and #316, which can be closed when this is merged.