### PR TITLE
fix: github nightly workflow shouldn't run on forks

### DIFF
--- a/.github/workflows/nightly_bump_toolchain.yml
+++ b/.github/workflows/nightly_bump_toolchain.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update-toolchain:
+    if: github.repository_owner == 'leanprover'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   merge-to-nightly:
+    if: github.repository_owner == 'leanprover'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
These workflows don't make sense on forks and should only run if the repository owner is `leanprover`.