### PR TITLE
chore: create nightly-testing-YYYY-MM-DD branches when nightly-testing passes CI

### DIFF
--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -7,6 +7,8 @@ on:
       - completed
 
 jobs:
+  # Whenever `nightly-testing` fails CI,
+  # notify the 'mathlib reviewers' stream on Zulip.
   handle_failure:
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'nightly-testing' }}
     runs-on: ubuntu-latest
@@ -23,3 +25,27 @@ jobs:
         topic: 'CI failure on the nightly-testing branch'
         content: |
           The latest CI for Std's [`nightly-testing`](https://github.com/leanprover/std4/tree/nightly-testing) branch has [failed](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}).
+
+  # Whenever `nightly-testing` passes CI,
+  # push it to `nightly-testing-YYYY-MM-DD` so we have a known good version of Std on that nightly release.
+  handle_success:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'nightly-testing' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: nightly-testing # checkout nightly-testing branch
+        fetch-depth: 0 # checkout all branches so that we can push from `nightly-testing` to `nightly-testing-YYYY-MM-DD`
+        token: ${{ secrets.NIGHTLY_TESTING }}
+    - name: Update the nightly-testing-YYYY-MM-DD branch
+      run: |
+        toolchain=$(<lean-toolchain)
+        if [[ $toolchain =~ leanprover/lean4:nightly-([a-zA-Z0-9_-]+) ]]; then
+          version=${BASH_REMATCH[1]}
+          git push origin refs/heads/nightly-testing:refs/heads/nightly-testing-$version
+        else
+          echo "Error: The file lean-toolchain does not contain the expected pattern."
+          exit 1
+        fi


### PR DESCRIPTION
We already do this on Mathlib.

The idea is to have known good commits on the `nightly-testing` branch for each nightly release. This makes it much saner when creating `lean-pr-testing-NNNN` branches, because we can use an appropriate commit from `nightly-testing` that is known to work on the Lean nightly on which the Lean PR is based.