### PR TITLE
chore: generalise `exists_eq_right_right`

### DIFF
--- a/Std/Logic.lean
+++ b/Std/Logic.lean
@@ -482,10 +482,10 @@ theorem not_forall_of_exists_not {p : α → Prop} : (∃ x, ¬p x) → ¬∀ x,
 @[simp] theorem exists_eq_or_imp : (∃ a, (a = a' ∨ q a) ∧ p a) ↔ p a' ∨ ∃ a, q a ∧ p a := by
   simp only [or_and_right, exists_or, exists_eq_left]
 
-@[simp] theorem exists_eq_right_right : (∃ (a : α), p a ∧ b ∧ a = a') ↔ p a' ∧ b := by
+@[simp] theorem exists_eq_right_right : (∃ (a : α), p a ∧ q a ∧ a = a') ↔ p a' ∧ q a' := by
   simp [← and_assoc]
 
-@[simp] theorem exists_eq_right_right' : (∃ (a : α), p a ∧ b ∧ a' = a) ↔ p a' ∧ b := by
+@[simp] theorem exists_eq_right_right' : (∃ (a : α), p a ∧ q a ∧ a' = a) ↔ p a' ∧ q a' := by
   (conv in _=_ => rw [eq_comm]); simp
 
 @[simp] theorem exists_prop : (∃ _h : a, b) ↔ a ∧ b :=


### PR DESCRIPTION
This change was made in mathlib3 around a year and a half ago: https://github.com/leanprover-community/mathlib/commit/d787d4990bac1c8d0bbd8043a1d47fd318e9a5ba, but it was seemingly missed in the port and subsequent upstreaming of logic lemmas.
(This missing simp lemma was found in the exponential ramsey project)