### PR TITLE
feat: Upstream the coercion arrows from mathlib, and use them in the coe delaborator

### DIFF
--- a/Std/Tactic/CoeExt.lean
+++ b/Std/Tactic/CoeExt.lean
@@ -26,7 +26,7 @@ namespace Std.Tactic.Coe
 /-- `⇑ t` coerces `t` to a function. -/
 -- We increase the right precedence so this goes above most binary operators.
 -- Otherwise `⇑f = g` will parse as `⇑(f = g)`.
-elab "⇑" m:term:80 : term => do
+elab:1024 "⇑" m:term:1024 : term => do
   let x ← elabTerm m none
   if let some ty ← coerceToFunction? x then
     return ty
@@ -34,7 +34,7 @@ elab "⇑" m:term:80 : term => do
     throwError "cannot coerce to function{indentExpr x}"
 
 /-- `↥ t` coerces `t` to a type. -/
-elab "↥" t:term:80 : term => do
+elab:1024 "↥" t:term:1024 : term => do
   let x ← elabTerm t none
   if let some ty ← coerceToSort? x then
     return ty

--- a/Std/Tactic/CoeExt.lean
+++ b/Std/Tactic/CoeExt.lean
@@ -18,15 +18,16 @@ def A.toB (a : A) : B := sorry
 instance : Coe A B where coe := A.toB
 ```
 is used, then `A.toB a` will be pretty-printed as `↑a`.
+
+This file also provides `⇑f` and `↥t` notation, which are syntax for `Lean.meta.coerceToFunction?`
+and `Lean.Meta.coerceToSort?` respectively.
 -/
 
 namespace Std.Tactic.Coe
 
-
 /-- `⇑ t` coerces `t` to a function. -/
--- We increase the right precedence so this goes above most binary operators.
--- Otherwise `⇑f = g` will parse as `⇑(f = g)`.
-elab:1024 "⇑" m:term:1024 : term => do
+-- the precendence matches that of `coeNotation`
+elab:1024 (name := coeFunNotation) "⇑" m:term:1024 : term => do
   let x ← elabTerm m none
   if let some ty ← coerceToFunction? x then
     return ty
@@ -34,13 +35,12 @@ elab:1024 "⇑" m:term:1024 : term => do
     throwError "cannot coerce to function{indentExpr x}"
 
 /-- `↥ t` coerces `t` to a type. -/
-elab:1024 "↥" t:term:1024 : term => do
+elab:1024 (name := coeSortNotation) "↥" t:term:1024 : term => do
   let x ← elabTerm t none
   if let some ty ← coerceToSort? x then
     return ty
   else
     throwError "cannot coerce to sort{indentExpr x}"
-
 
 /-- The different types of coercions that are supported by the `coe` attribute. -/
 inductive CoeFnType

--- a/Std/Tactic/CoeExt.lean
+++ b/Std/Tactic/CoeExt.lean
@@ -19,7 +19,7 @@ instance : Coe A B where coe := A.toB
 ```
 is used, then `A.toB a` will be pretty-printed as `↑a`.
 
-This file also provides `⇑f` and `↥t` notation, which are syntax for `Lean.meta.coerceToFunction?`
+This file also provides `⇑f` and `↥t` notation, which are syntax for `Lean.Meta.coerceToFunction?`
 and `Lean.Meta.coerceToSort?` respectively.
 -/
 

--- a/Std/Tactic/CoeExt.lean
+++ b/Std/Tactic/CoeExt.lean
@@ -7,6 +7,19 @@ import Lean.PrettyPrinter.Delaborator.Builtins
 import Std.Lean.Delaborator
 open Lean Elab.Term Meta Std
 
+/-!
+# The `@[coe]` attribute, used to delaborate coercion functions as `↑`
+
+When writing a coercion, if the pattern
+```
+@[coe]
+def A.toB (a : A) : B := sorry
+
+instance : Coe A B where coe := A.toB
+```
+is used, then `A.toB a` will be pretty-printed as `↑a`.
+-/
+
 namespace Std.Tactic.Coe
 
 

--- a/Std/Tactic/CoeExt.lean
+++ b/Std/Tactic/CoeExt.lean
@@ -92,10 +92,15 @@ For example, `Int.ofNat` is a coercion, so instead of printing `ofNat n` we just
 and when re-parsing this we can (usually) recover the specific coercion being used.
 -/
 def coeDelaborator (info : CoeFnInfo) : Delab := whenPPOption getPPCoercions do
+  let n := (← getExpr).getAppNumArgs
   withOverApp info.numArgs do
     match info.type with
     | .coe => `(↑$(← withNaryArg info.coercee delab))
-    | .coeFun => `(⇑$(← withNaryArg info.coercee delab))
+    | .coeFun =>
+      if n = info.numArgs then
+        `(⇑$(← withNaryArg info.coercee delab))
+      else
+        withNaryArg info.coercee delab
     | .coeSort => `(↥$(← withNaryArg info.coercee delab))
 
 /-- Add a coercion delaborator for the given function. -/

--- a/test/coe.lean
+++ b/test/coe.lean
@@ -7,8 +7,8 @@ structure WrappedNat where
   val : Nat
 
 
-structure WrappedFun where
-  fn : Nat → Nat
+structure WrappedFun (α) where
+  fn : Nat → α
 
 
 structure WrappedType where
@@ -17,19 +17,24 @@ structure WrappedType where
 attribute [coe] WrappedNat.val
 instance : Coe WrappedNat Nat where coe := WrappedNat.val
 
-#eval Std.Tactic.Coe.registerCoercion ``WrappedFun.fn (some ⟨1, 0, .coeFun⟩)
-instance : CoeFun WrappedFun (fun _ => Nat → Nat) where coe := WrappedFun.fn
+#eval Std.Tactic.Coe.registerCoercion ``WrappedFun.fn (some ⟨2, 1, .coeFun⟩)
+instance : CoeFun (WrappedFun α) (fun _ => Nat → α) where coe := WrappedFun.fn
 
 #eval Std.Tactic.Coe.registerCoercion ``WrappedType.typ (some ⟨1, 0, .coeSort⟩)
 instance : CoeSort WrappedType Type where coe := WrappedType.typ
 
-
-variable (n : WrappedNat) (f : WrappedFun) (t : WrappedType)
+section coe
+variable (n : WrappedNat)
 
 /-- info: ↑n : Nat -/
 #guard_msgs in #check n.val
 /-- info: ↑n : Nat -/
 #guard_msgs in #check (↑n : Nat)
+
+end coe
+
+section coeFun
+variable (f : WrappedFun Nat) (g : Nat → WrappedFun Nat) (h : WrappedFun (WrappedFun Nat))
 
 /-- info: ⇑f : Nat → Nat -/
 #guard_msgs in #check f.fn
@@ -39,7 +44,28 @@ variable (n : WrappedNat) (f : WrappedFun) (t : WrappedType)
 /-- info: f 1 : Nat -/
 #guard_msgs in #check ⇑f 1
 
+/-- info: ⇑(g 1) : Nat → Nat -/
+#guard_msgs in #check ⇑(g 1)
+/-- info: (g 1) 2 : Nat -/  -- TODO: remove the `()`?
+#guard_msgs in #check g 1 2
+
+/-- info: ⇑h : Nat → WrappedFun Nat -/
+#guard_msgs in #check ⇑h
+/-- info: h 1 : WrappedFun Nat -/
+#guard_msgs in #check h 1
+/-- info: ⇑(h 1) : Nat → Nat -/
+#guard_msgs in #check ⇑(h 1)
+/-- info: (h 1) 2 : Nat -/  -- TODO: remove the `()`?
+#guard_msgs in #check h 1 2
+
+end coeFun
+
+section coeSort
+variable (t : WrappedType)
+
 /-- info: ↥t : Type -/
 #guard_msgs in #check t.typ
 /-- info: ↥t : Type -/
 #guard_msgs in #check ↥t
+
+end coeSort

--- a/test/coe.lean
+++ b/test/coe.lean
@@ -15,17 +15,30 @@ structure WrappedType where
   typ : Type
 
 attribute [coe] WrappedNat.val
+instance : Coe WrappedNat Nat where coe := WrappedNat.val
+
 #eval Std.Tactic.Coe.registerCoercion ``WrappedFun.fn (some ⟨1, 0, .coeFun⟩)
+instance : CoeFun WrappedFun (fun _ => Nat → Nat) where coe := WrappedFun.fn
+
 #eval Std.Tactic.Coe.registerCoercion ``WrappedType.typ (some ⟨1, 0, .coeSort⟩)
+instance : CoeSort WrappedType Type where coe := WrappedType.typ
 
 
 variable (n : WrappedNat) (f : WrappedFun) (t : WrappedType)
 
 /-- info: ↑n : Nat -/
 #guard_msgs in #check n.val
+/-- info: ↑n : Nat -/
+#guard_msgs in #check (↑n : Nat)
 
 /-- info: ⇑f : Nat → Nat-/
 #guard_msgs in #check f.fn
+/-- info: ⇑f : Nat → Nat-/
+#guard_msgs in #check ⇑f
+/-- info: ⇑f 1 : Nat-/
+#guard_msgs in #check ⇑f 1
 
 /-- info: ↥t : Type -/
 #guard_msgs in #check t.typ
+/-- info: ↥t : Type -/
+#guard_msgs in #check ↥t

--- a/test/coe.lean
+++ b/test/coe.lean
@@ -1,0 +1,31 @@
+import Std.Tactic.CoeExt
+import Std.Tactic.GuardMsgs
+
+set_option linter.missingDocs false
+
+structure WrappedNat where
+  val : Nat
+
+
+structure WrappedFun where
+  fn : Nat → Nat
+
+
+structure WrappedType where
+  typ : Type
+
+attribute [coe] WrappedNat.val
+#eval Std.Tactic.Coe.registerCoercion ``WrappedFun.fn (some ⟨1, 0, .coeFun⟩)
+#eval Std.Tactic.Coe.registerCoercion ``WrappedType.typ (some ⟨1, 0, .coeSort⟩)
+
+
+variable (n : WrappedNat) (f : WrappedFun) (t : WrappedType)
+
+/-- info: ↑n : Nat -/
+#guard_msgs in #check n.val
+
+/-- info: ⇑f : Nat → Nat-/
+#guard_msgs in #check f.fn
+
+/-- info: ↥t : Type -/
+#guard_msgs in #check t.typ

--- a/test/coe.lean
+++ b/test/coe.lean
@@ -31,11 +31,12 @@ variable (n : WrappedNat) (f : WrappedFun) (t : WrappedType)
 /-- info: ↑n : Nat -/
 #guard_msgs in #check (↑n : Nat)
 
-/-- info: ⇑f : Nat → Nat-/
+/-- info: ⇑f : Nat → Nat -/
 #guard_msgs in #check f.fn
-/-- info: ⇑f : Nat → Nat-/
+/-- info: ⇑f : Nat → Nat -/
 #guard_msgs in #check ⇑f
-/-- info: ⇑f 1 : Nat-/
+-- applied functions do not need the `⇑`
+/-- info: f 1 : Nat -/
 #guard_msgs in #check ⇑f 1
 
 /-- info: ↥t : Type -/


### PR DESCRIPTION
This means that it becomes easier to distinguish function coercion from "normal" coercion in a goal state.

This remains opt-in downstream; the `@[coe]` attribute does not provide syntax for the `coeFun` and `coeSort` versions.

This also does not upstream the unapplied versions.

Some more discussion is [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Bringing.20back.20.E2.87.91/near/401155616).