### PR TITLE
Operations for bit representation of `Nat` and `BitVec`.

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -31,6 +31,7 @@ import Std.Data.Char
 import Std.Data.DList
 import Std.Data.Fin.Basic
 import Std.Data.Fin.Init.Lemmas
+import Std.Data.Fin.Iterate
 import Std.Data.Fin.Lemmas
 import Std.Data.HashMap
 import Std.Data.HashMap.Basic

--- a/Std.lean
+++ b/Std.lean
@@ -48,6 +48,7 @@ import Std.Data.List.Pairwise
 import Std.Data.MLList.Basic
 import Std.Data.MLList.Heartbeats
 import Std.Data.Nat.Basic
+import Std.Data.Nat.Bitwise
 import Std.Data.Nat.Gcd
 import Std.Data.Nat.Init.Lemmas
 import Std.Data.Nat.Lemmas

--- a/Std.lean
+++ b/Std.lean
@@ -26,6 +26,9 @@ import Std.Data.BinomialHeap.Basic
 import Std.Data.BinomialHeap.Lemmas
 import Std.Data.BitVec
 import Std.Data.BitVec.Basic
+import Std.Data.BitVec.Bitblast
+import Std.Data.BitVec.Folds
+import Std.Data.BitVec.Lemmas
 import Std.Data.Bool
 import Std.Data.Char
 import Std.Data.DList

--- a/Std/Data/BinomialHeap/Lemmas.lean
+++ b/Std/Data/BinomialHeap/Lemmas.lean
@@ -30,6 +30,6 @@ theorem Heap.deleteMin_fst : ((s : Heap α).deleteMin le).map (·.1) = s.head? l
   | .nil, _ => rfl
   | .cons .., ⟨_, h₁, h₂⟩ => by
     simp [size, Nat.shiftLeft, size_eq h₂, Nat.pow_succ, Nat.mul_succ]
-    simp [Nat.add_assoc, Nat.one_shiftLeft, h₁.realSize_eq, h₂.size_eq]
+    simp [Nat.add_assoc, Nat.shiftLeft_eq, h₁.realSize_eq, h₂.size_eq]
 
 end Imp

--- a/Std/Data/BinomialHeap/Lemmas.lean
+++ b/Std/Data/BinomialHeap/Lemmas.lean
@@ -30,6 +30,6 @@ theorem Heap.deleteMin_fst : ((s : Heap α).deleteMin le).map (·.1) = s.head? l
   | .nil, _ => rfl
   | .cons .., ⟨_, h₁, h₂⟩ => by
     simp [size, Nat.shiftLeft, size_eq h₂, Nat.pow_succ, Nat.mul_succ]
-    simp [Nat.add_assoc, Nat.shiftLeft_eq, h₁.realSize_eq, h₂.size_eq]
+    simp [Nat.add_assoc, Nat.one_shiftLeft, h₁.realSize_eq, h₂.size_eq]
 
 end Imp

--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -292,7 +292,7 @@ Bitwise OR for bit vectors.
 SMT-Lib name: `bvor`.
 -/
 protected def or (x y : BitVec n) : BitVec n where toFin :=
-   ⟨x.toNat ||| y.toNat, Nat.or_lt_2_pow x.isLt y.isLt⟩
+   ⟨x.toNat ||| y.toNat, Nat.or_lt_two_pow x.isLt y.isLt⟩
 instance : OrOp (BitVec w) := ⟨.or⟩
 
 /--
@@ -305,7 +305,7 @@ instance : OrOp (BitVec w) := ⟨.or⟩
 SMT-Lib name: `bvxor`.
 -/
 protected def xor (x y : BitVec n) : BitVec n where toFin :=
-   ⟨x.toNat ^^^ y.toNat, Nat.xor_lt_2_pow x.isLt y.isLt⟩
+   ⟨x.toNat ^^^ y.toNat, Nat.xor_lt_two_pow x.isLt y.isLt⟩
 instance : Xor (BitVec w) := ⟨.xor⟩
 
 /--

--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -52,13 +52,13 @@ protected def ofNat (n : Nat) (i : Nat) : BitVec n where
 
 /-- Given a bitvector `a`, return the underlying `Nat`. This is O(1) because `BitVec` is a
 (zero-cost) wrapper around a `Nat`. -/
-protected def toNat : BitVec n → Nat | ⟨a, _⟩ => a
+protected def toNat (a : BitVec n) : Nat := a.toFin.val
 
 /-- Return the bound in terms of toNat. -/
 theorem isLt (x : BitVec w) : x.toNat < 2^w := x.toFin.isLt
 
 /-- Return the `i`-th least significant bit or `false` if `i ≥ w`. -/
-@[inline] def getLsb (x:BitVec w) (i:Nat) : Bool := x.toNat.testBit i
+@[inline] def getLsb (x : BitVec w) (i : Nat) : Bool := x.toNat.testBit i
 
 /-- Return the `i`-th most significant bit or `false` if `i ≥ w`. -/
 @[inline] def getMsb (x : BitVec w) (i : Nat) : Bool := i < w && getLsb x (w-1-i)

--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -96,7 +96,7 @@ attribute [match_pattern] BitVec.ofNat
   | _ => throw ()
 
 /-- Convert bitvector into a fixed-width hex number. -/
-protected def toHex {n:Nat} (x:BitVec n) : String :=
+protected def toHex {n : Nat} (x : BitVec n) : String :=
   let s := (Nat.toDigits 16 x.toNat).asString
   let t := (List.replicate ((n+3) / 4 - s.length) '0').asString
   t ++ s
@@ -374,7 +374,7 @@ def rotateRight (x : BitVec w) (n : Nat) : BitVec w := x >>> n ||| x <<< (w - n)
 /--
 A version of `zeroExtend` that requires a proof, but is a noop.
 -/
-def zeroExtend' {n w:Nat} (le : n ≤ w) (x : BitVec n)  : BitVec w :=
+def zeroExtend' {n w : Nat} (le : n ≤ w) (x : BitVec n)  : BitVec w :=
   ⟨x.toNat, by
     apply Nat.lt_of_lt_of_le x.isLt
     exact Nat.pow_le_pow_of_le_right (by trivial) le⟩
@@ -383,8 +383,8 @@ def zeroExtend' {n w:Nat} (le : n ≤ w) (x : BitVec n)  : BitVec w :=
 `shiftLeftZeroExtend x n` returns `zeroExtend (w+n) x <<< n` without
 needing to compute `x % 2^(2+n)`.
 -/
-def shiftLeftZeroExtend (msbs : BitVec w) (m:Nat) : BitVec (w+m) :=
-  let shiftLeftLt {x:Nat} (p : x < 2^w) (m:Nat) : x <<< m < 2^(w+m) := by
+def shiftLeftZeroExtend (msbs : BitVec w) (m : Nat) : BitVec (w+m) :=
+  let shiftLeftLt {x : Nat} (p : x < 2^w) (m : Nat) : x <<< m < 2^(w+m) := by
         simp [Nat.shiftLeft_eq, Nat.pow_add]
         apply Nat.mul_lt_mul_of_pos_right p
         exact (Nat.pow_two_pos m)
@@ -434,7 +434,7 @@ If `v < w` then it truncates the high bits instead.
 
 SMT-Lib name: `zero_extend`.
 -/
-def zeroExtend (v : Nat) (x:BitVec w) : BitVec v :=
+def zeroExtend (v : Nat) (x : BitVec w) : BitVec v :=
   if h : w ≤ v then
     zeroExtend' h x
   else
@@ -468,23 +468,20 @@ def signExtend (v : Nat) (x : BitVec w) : BitVec v := .ofInt v x.toInt
 @[simp] theorem mul_eq (x y : BitVec w)                   : BitVec.mul x y = x * y            := rfl
 @[simp] theorem zero_eq                                   : BitVec.zero n = 0#n               := rfl
 
-@[simp]
-theorem cast_ofNat {n m : Nat} (h : n = m) (x : Nat) :
+@[simp] theorem cast_ofNat {n m : Nat} (h : n = m) (x : Nat) :
     cast h (BitVec.ofNat n x) = BitVec.ofNat m x := by
   subst h; rfl
 
-@[simp]
-theorem cast_cast {n m k : Nat} (h₁ : n = m) (h₂ : m = k) (x : BitVec n) :
+@[simp] theorem cast_cast {n m k : Nat} (h₁ : n = m) (h₂ : m = k) (x : BitVec n) :
     cast h₂ (cast h₁ x) = cast (h₁ ▸ h₂) x :=
   rfl
 
-@[simp]
-theorem cast_eq {n : Nat} (h : n = n) (x : BitVec n) :
+@[simp] theorem cast_eq {n : Nat} (h : n = n) (x : BitVec n) :
     cast h x = x :=
   rfl
 
 /-- Turn a `Bool` into a bitvector of length `1` -/
-def ofBool (b:Bool) : BitVec 1 := cond b 1 0
+def ofBool (b : Bool) : BitVec 1 := cond b 1 0
 
 @[simp] theorem ofBool_false : ofBool false = 0 := by trivial
 @[simp] theorem ofBool_true  : ofBool true  = 1 := by trivial

--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -46,7 +46,7 @@ this is truncation of the high bits when downcasting and zero-extension when upc
 protected def ofNat (n : Nat) (i : Nat) : BitVec n where
   toFin :=
     let p : i &&& 2^n-1 < 2^n := by
-        apply Nat.and_lt_2_pow
+        apply Nat.and_lt_two_pow
         exact Nat.sub_lt (Nat.pow_two_pos n) (Nat.le_refl 1)
     ⟨i &&& 2^n-1, p⟩
 
@@ -279,7 +279,7 @@ Bitwise AND for bit vectors.
 SMT-Lib name: `bvand`.
 -/
 protected def and (x y : BitVec n) : BitVec n where toFin :=
-   ⟨x.toNat &&& y.toNat, Nat.and_lt_2_pow x.toNat y.isLt⟩
+   ⟨x.toNat &&& y.toNat, Nat.and_lt_two_pow x.toNat y.isLt⟩
 instance : AndOp (BitVec w) := ⟨.and⟩
 
 /--

--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -61,7 +61,7 @@ theorem toNat_eq (x y : BitVec n) : x = y ↔ x.toNat = y.toNat :=
   Iff.intro (congrArg BitVec.toNat) eq_of_toNat_eq
 
 /-- Return the `i`-th least significant bit or `false` if `i ≥ w`. -/
-@[inline] def getLsb : BitVec w -> Nat -> Bool | ⟨x,_⟩, i => (x >>> i) % 2 == 1
+@[inline] def getLsb : BitVec w -> Nat -> Bool | ⟨x,_⟩, i => x.testBit i
 
 /-- Return the `i`-th most significant bit or `false` if `i ≥ w`. -/
 @[inline] def getMsb (x : BitVec w) (i : Nat) : Bool := i < w && getLsb x (w-1-i)

--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -395,9 +395,6 @@ def append (msbs : BitVec n) (lsbs : BitVec m) : BitVec (n+m) :=
     exact msbs.isLt
   ⟩ ||| zeroExtend' (n+m) lsbs (by apply Nat.le_add_left)
 
-  -- (by apply Nat.le_add_right) <<< m)
-
-
 instance : HAppend (BitVec w) (BitVec v) (BitVec (w + v)) := ⟨.append⟩
 
 /--

--- a/Std/Data/BitVec/Bitblast.lean
+++ b/Std/Data/BitVec/Bitblast.lean
@@ -9,10 +9,16 @@ import Std.Data.BitVec.Folds
 /-!
 # Bitblasting of bitvectors
 
-We prove the equivalence of a bitblasting operations and their `BitVec` implementation.
+This module provides theorems for showing the equivalence between BitVec operations using
+the `Fin 2^n` representation and Boolean vectors.  It is still under development, but
+intended to provide a path for converting SAT and SMT solver proofs about BitVectors
+as vectors of bits into proofs about Lean `BitVec` values.
+
+The module is named for the bit-blasting operation in an SMT solver that converts bitvector
+expressions into expressions about individual bits in each vector.
 
 ## Main results
-* `BV_add`: Bitblasted addition `bitadd` is equivalent to `BitVec.add`.
+* `x + y : BitVec w` is equivalent to `adc x y false`.
 
 ## Future work
 All other operations are to be PR'ed later and are already proved in

--- a/Std/Data/BitVec/Bitblast.lean
+++ b/Std/Data/BitVec/Bitblast.lean
@@ -175,19 +175,6 @@ theorem adc_correct (w:Nat) (x y : BitVec w) (c : Bool) :
     case right =>
       simp [adc_value_step lt]
 
-@[simp]
-theorem toNat_zero (n : Nat) : (0#n).toNat = 0 := by trivial
 
-@[simp]
-theorem zeroExtend_zero (m n : Nat) : zeroExtend m (0#n) = 0#m := by
-  apply eq_of_toNat_eq
-  simp [toNat_zeroExtend]
-
-@[simp]
-theorem add_zero (x : BitVec n) : x + (0#n) = x := by
-  apply eq_of_toNat_eq
-  simp [toNat_add, isLt, Nat.mod_eq_of_lt]
-
-theorem add_as_adc (w:Nat) (x y : BitVec w) :
-  x + y = (adc x y false).snd := by
+theorem add_as_adc (w:Nat) (x y : BitVec w) : x + y = (adc x y false).snd := by
   simp [adc_correct]

--- a/Std/Data/BitVec/Bitblast.lean
+++ b/Std/Data/BitVec/Bitblast.lean
@@ -130,6 +130,8 @@ theorem carry_clean_succ (w x y : Nat) (c : Bool) :
           mul_le_add_right,
           le_add_right,
           Nat.not_le_of_lt,
+          Nat.add_succ,
+          Nat.succ_le_succ,
           sum_bnd,
           pred]
 
@@ -174,7 +176,7 @@ theorem adc_correct (w:Nat) (x y : BitVec w) (c : Bool) :
       rw [testBit_toNat, testBit_toNat]
       cases x.getLsb i <;>
       cases y.getLsb i <;>
-      cases carry_clean i x.toNat y.toNat c <;> simp
+      cases carry_clean i x.toNat y.toNat c <;> simp [Nat.succ_le_succ_iff]
     case right =>
       simp [adc_value_step lt]
 

--- a/Std/Data/BitVec/Bitblast.lean
+++ b/Std/Data/BitVec/Bitblast.lean
@@ -55,17 +55,9 @@ theorem mod_two_pow_succ (x i : Nat) :
   x % 2^(i+1) = 2^i*(x.testBit i).toNat + x % (2 ^ i):= by
   apply Nat.eq_of_testBit_eq
   intro j
-  simp only [
-        Nat.mul_add_lt_is_or,
-        testBit_or,
-        testBit_mod_two_pow,
-        testBit_shiftLeft,
-        Nat.testBit_bool_to_nat,
-        Nat.sub_eq_zero_iff_le,
-        Nat.mod_lt,
-        Nat.pow_two_pos,
-        testBit_mul_pow_two
-        ]
+  simp only [Nat.mul_add_lt_is_or, testBit_or, testBit_mod_two_pow, testBit_shiftLeft, 
+    Nat.testBit_bool_to_nat, Nat.sub_eq_zero_iff_le, Nat.mod_lt, Nat.pow_two_pos,
+    testBit_mul_pow_two]
   match Nat.lt_trichotomy i j with
   | Or.inl i_lt_j =>
     have i_le_j : i ≤ j := Nat.le_of_lt i_lt_j

--- a/Std/Data/BitVec/Bitblast.lean
+++ b/Std/Data/BitVec/Bitblast.lean
@@ -27,8 +27,8 @@ open Nat Bool
 
 namespace BitVec
 
-private
-theorem testBit_limit {x i : Nat} (x_lt_succ : x < 2^(i+1)) : testBit x i = decide (x ≥ 2^i) := by
+private theorem testBit_limit {x i : Nat} (x_lt_succ : x < 2^(i+1)) :
+    testBit x i = decide (x ≥ 2^i) := by
   cases xi : testBit x i with
   | true =>
     simp [testBit_implies_ge xi]
@@ -45,13 +45,11 @@ theorem testBit_limit {x i : Nat} (x_lt_succ : x < 2^(i+1)) : testBit x i = deci
       | inl x_lt =>
         exfalso
         apply Nat.lt_irrefl
-        exact
-            calc x < 2^(i+1) := x_lt_succ
-                 _ ≤ 2 ^ j := Nat.pow_le_pow_of_le_right Nat.zero_lt_two x_lt
-                 _ ≤ x := testBit_implies_ge jp
+        calc x < 2^(i+1) := x_lt_succ
+             _ ≤ 2 ^ j := Nat.pow_le_pow_of_le_right Nat.zero_lt_two x_lt
+             _ ≤ x := testBit_implies_ge jp
 
-private
-theorem mod_two_pow_succ (x i : Nat) :
+private theorem mod_two_pow_succ (x i : Nat) :
   x % 2^(i+1) = 2^i*(x.testBit i).toNat + x % (2 ^ i):= by
   apply Nat.eq_of_testBit_eq
   intro j
@@ -75,8 +73,7 @@ theorem mod_two_pow_succ (x i : Nat) :
     have not_j_ge_i : ¬(j ≥ i) := Nat.not_le_of_lt j_lt_i
     simp [j_lt_i, j_le_i, not_j_ge_i, j_le_i_succ]
 
-private
-theorem mod_two_pow_lt (x i : Nat) : x % 2 ^ i < 2^i := Nat.mod_lt _ (Nat.pow_two_pos _)
+private theorem mod_two_pow_lt (x i : Nat) : x % 2 ^ i < 2^i := Nat.mod_lt _ (Nat.pow_two_pos _)
 
 /-! ### Addition -/
 
@@ -90,9 +87,8 @@ def carry (w x y : Nat) (c : Bool) : Bool :=  decide (x % 2^w + y % 2^w + c.toNa
 def adcb (x y c : Bool) : Bool × Bool := (x && y || x && c || y && c, Bool.xor x (Bool.xor y c))
 
 /-- Bitwise addition implemented via a ripple carry adder. -/
-def adc {w:Nat} (x y : BitVec w) : Bool → Bool × BitVec w :=
-  iunfoldr fun (i:Fin w) c =>
-    adcb (x.getLsb i) (y.getLsb i) c
+def adc (x y : BitVec w) : Bool → Bool × BitVec w :=
+  iunfoldr fun (i : Fin w) c => adcb (x.getLsb i) (y.getLsb i) c
 
 theorem adc_overflow_limit (x y i : Nat) (c : Bool) : x % 2^i + (y % 2^i + c.toNat) < 2^(i+1) := by
   apply Nat.lt_of_succ_le
@@ -124,9 +120,9 @@ theorem carry_succ (w x y : Nat) (c : Bool) : carry (succ w) x y c =
           sum_bnd,
           pred]
 
-theorem adc_value_step {i : Nat} (i_lt : i < w) (x y : BitVec w) (c : Bool)
-    : getLsb (x + y + zeroExtend w (ofBool c)) i =
-        Bool.xor (getLsb x i) (Bool.xor (getLsb y i) (carry i x.toNat y.toNat c)) := by
+theorem adc_value_step {i : Nat} (i_lt : i < w) (x y : BitVec w) (c : Bool) :
+    getLsb (x + y + zeroExtend w (ofBool c)) i =
+      Bool.xor (getLsb x i) (Bool.xor (getLsb y i) (carry i x.toNat y.toNat c)) := by
   let ⟨x, x_lt⟩ := x
   let ⟨y, y_lt⟩ := y
   simp [getLsb, toNat_add, toNat_zeroExtend, i_lt]
@@ -144,7 +140,7 @@ theorem adc_value_step {i : Nat} (i_lt : i < w) (x y : BitVec w) (c : Bool)
     ]
   simp [testBit_to_div_mod, carry, Nat.add_assoc]
 
-theorem adc_correct (w:Nat) (x y : BitVec w) (c : Bool) :
+theorem adc_correct (x y : BitVec w) (c : Bool) :
     adc x y c = (carry w x.toNat y.toNat c, x + y + zeroExtend w (ofBool c)) := by
   simp only [adc]
   apply iunfoldr_replace
@@ -168,5 +164,5 @@ theorem adc_correct (w:Nat) (x y : BitVec w) (c : Bool) :
       simp [adc_value_step lt]
 
 
-theorem add_as_adc (w:Nat) (x y : BitVec w) : x + y = (adc x y false).snd := by
+theorem add_as_adc (w : Nat) (x y : BitVec w) : x + y = (adc x y false).snd := by
   simp [adc_correct]

--- a/Std/Data/BitVec/Folds.lean
+++ b/Std/Data/BitVec/Folds.lean
@@ -47,7 +47,7 @@ private theorem iunfoldr.eq_test
     case left =>
       simp [step]
     case right =>
-      simp [step, cons_getLsb_truncate]
+      simp [step, truncate_succ]
 
 theorem iunfoldr_replace
     {w:Nat}

--- a/Std/Data/BitVec/Folds.lean
+++ b/Std/Data/BitVec/Folds.lean
@@ -7,18 +7,15 @@ namespace Std.BitVec
 /--
 `iunfoldr f a` returns
 -/
-def iunfoldr (f : Fin w -> α → α × Bool) (a:α) : α × BitVec w :=
-  Fin.hIterate (fun i => α × BitVec i) (a, nil) fun i q =>
+def iunfoldr (f : Fin w -> α → α × Bool) (s : α) : α × BitVec w :=
+  Fin.hIterate (fun i => α × BitVec i) (s, nil) fun i q =>
     (fun p => ⟨p.fst, cons p.snd q.snd⟩) (f i q.fst)
 
 theorem iunfoldr.fst_eq
-    {w:Nat}
-    {f : Fin w → α → α × Bool}
-    (state : Nat → α)
-    (s : α)
+    {f : Fin w → α → α × Bool} (state : Nat → α) (s : α)
     (init : s = state 0)
-    (ind : ∀(i:Fin w), (f i (state i.val)).fst = state (i.val+1))
-    : (iunfoldr f s).fst = state w := by
+    (ind : ∀(i : Fin w), (f i (state i.val)).fst = state (i.val+1)) :
+    (iunfoldr f s).fst = state w := by
   unfold iunfoldr
   apply Fin.hIterate_elim (fun i (p : α × BitVec i) => p.fst = state i)
   case init =>
@@ -29,14 +26,10 @@ theorem iunfoldr.fst_eq
     simp [p, ind i]
 
 private theorem iunfoldr.eq_test
-    {w:Nat}
-    {f : Fin w → α → α × Bool}
-    (state : Nat → α)
-    (value : BitVec w)
-    (a : α)
+    {f : Fin w → α → α × Bool} (state : Nat → α) (value : BitVec w) (a : α)
     (init : state 0 = a)
-    (step : ∀(i:Fin w), f i (state i.val) = (state (i.val+1), value.getLsb i.val))
-    : iunfoldr f a = (state w, BitVec.truncate w value) := by
+    (step : ∀(i : Fin w), f i (state i.val) = (state (i.val+1), value.getLsb i.val)) :
+    iunfoldr f a = (state w, BitVec.truncate w value) := by
   apply Fin.hIterate_eq (fun i => ((state i, BitVec.truncate i value) : α × BitVec i))
   case init =>
     simp only [init, eq_nil]
@@ -50,13 +43,9 @@ private theorem iunfoldr.eq_test
       simp [step, truncate_succ]
 
 theorem iunfoldr_replace
-    {w:Nat}
-    {f : Fin w → α → α × Bool}
-    (state : Nat → α)
-    (value : BitVec w)
-    (a : α)
+    {f : Fin w → α → α × Bool} (state : Nat → α) (value : BitVec w) (a : α)
     (init : state 0 = a)
-    (step : ∀(i:Fin w), f i (state i.val) = (state (i.val+1), value.getLsb i.val))
-    : iunfoldr f a = (state w, value) := by
+    (step : ∀(i : Fin w), f i (state i.val) = (state (i.val+1), value.getLsb i.val)) :
+    iunfoldr f a = (state w, value) := by
   have h := iunfoldr.eq_test state value a init step
   simp [h]

--- a/Std/Data/BitVec/Folds.lean
+++ b/Std/Data/BitVec/Folds.lean
@@ -1,0 +1,62 @@
+import Std.Data.BitVec.Lemmas
+import Std.Data.Fin.Iterate
+import Std.Data.Nat.Lemmas
+
+namespace Std.BitVec
+
+/--
+`iunfoldr f a` returns
+-/
+def iunfoldr (f : Fin w -> α → α × Bool) (a:α) : α × BitVec w :=
+  Fin.hIterate (fun i => α × BitVec i) (a, nil) fun i q =>
+    (fun p => ⟨p.fst, cons p.snd q.snd⟩) (f i q.fst)
+
+theorem iunfoldr.fst_eq
+    {w:Nat}
+    {f : Fin w → α → α × Bool}
+    (state : Nat → α)
+    (s : α)
+    (init : s = state 0)
+    (ind : ∀(i:Fin w), (f i (state i.val)).fst = state (i.val+1))
+    : (iunfoldr f s).fst = state w := by
+  unfold iunfoldr
+  apply Fin.hIterate_elim (fun i (p : α × BitVec i) => p.fst = state i)
+  case init =>
+    exact init
+  case step =>
+    intro i ⟨s, v⟩ p
+    simp at p
+    simp [p, ind i]
+
+private theorem iunfoldr.eq_test
+    {w:Nat}
+    {f : Fin w → α → α × Bool}
+    (state : Nat → α)
+    (value : BitVec w)
+    (a : α)
+    (init : state 0 = a)
+    (step : ∀(i:Fin w), f i (state i.val) = (state (i.val+1), value.getLsb i.val))
+    : iunfoldr f a = (state w, BitVec.truncate w value) := by
+  apply Fin.hIterate_eq (fun i => ((state i, BitVec.truncate i value) : α × BitVec i))
+  case init =>
+    simp only [init, eq_nil]
+  case step =>
+    intro i
+    simp
+    apply And.intro
+    case left =>
+      simp [step]
+    case right =>
+      simp [step, cons_getLsb_truncate]
+
+theorem iunfoldr_replace
+    {w:Nat}
+    {f : Fin w → α → α × Bool}
+    (state : Nat → α)
+    (value : BitVec w)
+    (a : α)
+    (init : state 0 = a)
+    (step : ∀(i:Fin w), f i (state i.val) = (state (i.val+1), value.getLsb i.val))
+    : iunfoldr f a = (state w, value) := by
+  have h := iunfoldr.eq_test state value a init step
+  simp [h]

--- a/Std/Data/BitVec/Folds.lean
+++ b/Std/Data/BitVec/Folds.lean
@@ -2,11 +2,16 @@ import Std.Data.BitVec.Lemmas
 import Std.Data.Fin.Iterate
 import Std.Data.Nat.Lemmas
 
-
 namespace Std.BitVec
 
 /--
-`iunfoldr f a` returns
+iunfoldr is an iterative operation that applies a function `f` repeatedly.
+
+It produces a sequence of state values `[s_0, s_1 .. s_w]` and a bitvector
+`v` where `f i s_i = (s_{i+1}, b_i)` and `b_i` is bit `i`th least-significant bit
+in `v` (e.g., `getLsb v i = b_i`).
+
+Theorems involving `iunfoldr` can be eliminated using `iunfoldr_replace` below.
 -/
 def iunfoldr (f : Fin w -> α → α × Bool) (s : α) : α × BitVec w :=
   Fin.hIterate (fun i => α × BitVec i) (s, nil) fun i q =>
@@ -37,6 +42,9 @@ private theorem iunfoldr.eq_test
     intro i
     simp_all [truncate_succ]
 
+/--
+Correctness theorem for `iunfoldr`.
+-/
 theorem iunfoldr_replace
     {f : Fin w → α → α × Bool} (state : Nat → α) (value : BitVec w) (a : α)
     (init : state 0 = a)

--- a/Std/Data/BitVec/Folds.lean
+++ b/Std/Data/BitVec/Folds.lean
@@ -2,6 +2,7 @@ import Std.Data.BitVec.Lemmas
 import Std.Data.Fin.Iterate
 import Std.Data.Nat.Lemmas
 
+
 namespace Std.BitVec
 
 /--
@@ -22,8 +23,7 @@ theorem iunfoldr.fst_eq
     exact init
   case step =>
     intro i ⟨s, v⟩ p
-    simp at p
-    simp [p, ind i]
+    simp_all [ind i]
 
 private theorem iunfoldr.eq_test
     {f : Fin w → α → α × Bool} (state : Nat → α) (value : BitVec w) (a : α)
@@ -35,17 +35,11 @@ private theorem iunfoldr.eq_test
     simp only [init, eq_nil]
   case step =>
     intro i
-    simp
-    apply And.intro
-    case left =>
-      simp [step]
-    case right =>
-      simp [step, truncate_succ]
+    simp_all [truncate_succ]
 
 theorem iunfoldr_replace
     {f : Fin w → α → α × Bool} (state : Nat → α) (value : BitVec w) (a : α)
     (init : state 0 = a)
     (step : ∀(i : Fin w), f i (state i.val) = (state (i.val+1), value.getLsb i.val)) :
     iunfoldr f a = (state w, value) := by
-  have h := iunfoldr.eq_test state value a init step
-  simp [h]
+  simp [iunfoldr.eq_test state value a init step]

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -58,11 +58,10 @@ theorem eq_of_getMsb_eq {x y : BitVec w}
 theorem toNat_ofBool (b : Bool) : (ofBool b).toNat = b.toNat := by
   cases b <;> rfl
 
-@[simp]
-theorem toNat_ofFin (x : Fin (2^n)) : (BitVec.ofFin x).toNat = x.val := rfl
+@[simp] theorem toNat_ofFin (x : Fin (2^n)) : (BitVec.ofFin x).toNat = x.val := rfl
 
-theorem toNat_ofNat (x w : Nat)
-    : (BitVec.ofNat w x).toNat = x &&& 2^w-1 := rfl
+theorem toNat_ofNat (x w : Nat) : (BitVec.ofNat w x).toNat = x % 2^w := by
+  simp [BitVec.toNat, BitVec.ofNat]
 
 /--
 Definition of bitvector addition as a nat.
@@ -97,7 +96,7 @@ theorem toNat_cast (e:m = n) (x : BitVec m)
 theorem toNat_cons (b:Bool) (x : BitVec w)
     : (cons b x).toNat = (b.toNat <<< w) ||| x.toNat := by
     let ⟨x, _⟩ := x
-    simp [cons, toNat_append, toNat_ofBool,  toNat_ofNat]
+    simp [cons, toNat_append, toNat_ofBool]
 
 /-! ### cons -/
 

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -19,9 +19,8 @@ theorem testBit_toNat (x : BitVec w) : x.toNat.testBit i = x.getLsb i := rfl
   apply Nat.lt_of_lt_of_le x_lt
   apply Nat.pow_le_pow_of_le_right (by trivial : 0 < 2) ge
 
-theorem eq_of_getLsb_eq
-    {x y : BitVec w}
-    (pred : ∀(i:Fin w), x.getLsb i.val = y.getLsb i.val) : x = y := by
+theorem eq_of_getLsb_eq {x y : BitVec w}
+    (pred : ∀(i : Fin w), x.getLsb i.val = y.getLsb i.val) : x = y := by
   apply eq_of_toNat_eq
   apply Nat.eq_of_testBit_eq
   intro i
@@ -33,7 +32,7 @@ theorem eq_of_getLsb_eq
     simp [getLsb_ge _ _ p]
 
 theorem eq_of_getMsb_eq {x y : BitVec w}
-    (pred : ∀(i:Fin w), x.getMsb i = y.getMsb i.val) : x = y := by
+    (pred : ∀(i : Fin w), x.getMsb i = y.getMsb i.val) : x = y := by
   simp [getMsb] at pred
   apply eq_of_getLsb_eq
   intro ⟨i, i_lt⟩
@@ -54,8 +53,7 @@ theorem eq_of_getMsb_eq {x y : BitVec w}
     simp [q_lt, Nat.sub_sub_self, r] at q
     exact q
 
-@[simp]
-theorem toNat_ofBool (b : Bool) : (ofBool b).toNat = b.toNat := by
+@[simp] theorem toNat_ofBool (b : Bool) : (ofBool b).toNat = b.toNat := by
   cases b <;> rfl
 
 @[simp] theorem toNat_ofFin (x : Fin (2^n)) : (BitVec.ofFin x).toNat = x.val := rfl
@@ -63,16 +61,12 @@ theorem toNat_ofBool (b : Bool) : (ofBool b).toNat = b.toNat := by
 theorem toNat_ofNat (x w : Nat) : (BitVec.ofNat w x).toNat = x % 2^w := by
   simp [BitVec.toNat, BitVec.ofNat]
 
-@[simp]
-theorem toNat_zero (n : Nat) : (0#n).toNat = 0 := by trivial
+@[simp] theorem toNat_zero (n : Nat) : (0#n).toNat = 0 := by trivial
 
-private
-theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) : x < 2 ^ n :=
+private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) : x < 2 ^ n :=
   Nat.lt_of_lt_of_le lt (Nat.pow_le_pow_of_le_right (by trivial : 0 < 2) le)
 
-@[simp]
-theorem ofNat_toNat (m : Nat) (x : BitVec n)
-    : (BitVec.ofNat m x.toNat) = truncate m x := by
+@[simp] theorem ofNat_toNat (m : Nat) (x : BitVec n) : (BitVec.ofNat m x.toNat) = truncate m x := by
     let ⟨x, lt_n⟩ := x
     unfold truncate
     unfold zeroExtend
@@ -84,22 +78,20 @@ theorem ofNat_toNat (m : Nat) (x : BitVec n)
     else
       simp [h]
 
-theorem toNat_append (x : BitVec m) (y : BitVec n)
-    : (x ++ y).toNat = x.toNat <<< n ||| y.toNat := rfl
+theorem toNat_append (x : BitVec m) (y : BitVec n) : (x ++ y).toNat = x.toNat <<< n ||| y.toNat :=
+  rfl
 
-@[simp]
-theorem toNat_cast (e:m = n) (x : BitVec m)
-    : (cast e x).toNat = x.toNat := rfl
+@[simp] theorem toNat_cast (e : m = n) (x : BitVec m) : (cast e x).toNat = x.toNat := rfl
 
-theorem toNat_cons (b:Bool) (x : BitVec w)
-    : (cons b x).toNat = (b.toNat <<< w) ||| x.toNat := by
-    let ⟨x, _⟩ := x
-    simp [cons, toNat_append, toNat_ofBool]
+theorem toNat_cons (b : Bool) (x : BitVec w) :
+    (cons b x).toNat = (b.toNat <<< w) ||| x.toNat := by
+  let ⟨x, _⟩ := x
+  simp [cons, toNat_append, toNat_ofBool]
 
 /-! ### cons -/
 
-theorem getLsb_cons (b:Bool) {n} (x : BitVec n) (i:Nat)
-    : getLsb (cons b x) i = if i = n then b else getLsb x i := by
+theorem getLsb_cons (b : Bool) {n} (x : BitVec n) (i : Nat) :
+    getLsb (cons b x) i = if i = n then b else getLsb x i := by
   simp [getLsb, toNat_cons, Nat.testBit_or]
   rw [Nat.testBit_shiftLeft]
   match Nat.lt_trichotomy i n with
@@ -118,14 +110,13 @@ theorem getLsb_cons (b:Bool) {n} (x : BitVec n) (i:Nat)
 
 /-! ### zeroExtend and truncate -/
 
-@[simp]
-theorem toNat_zeroExtend' {m n : Nat} (p : m ≤ n) (x : BitVec m)
-    : (zeroExtend' p x).toNat = x.toNat := by
+@[simp] theorem toNat_zeroExtend' {m n : Nat} (p : m ≤ n) (x : BitVec m) :
+    (zeroExtend' p x).toNat = x.toNat := by
   unfold zeroExtend'
   simp [p, x.isLt, Nat.mod_eq_of_lt]
 
-theorem toNat_zeroExtend (i:Nat) (x : BitVec n)
-  : BitVec.toNat (zeroExtend i x) = x.toNat % 2^i := by
+theorem toNat_zeroExtend (i : Nat) (x : BitVec n) :
+    BitVec.toNat (zeroExtend i x) = x.toNat % 2^i := by
   let ⟨x, lt_n⟩ := x
   simp only [zeroExtend]
   if n_le_i : n ≤ i then
@@ -134,39 +125,35 @@ theorem toNat_zeroExtend (i:Nat) (x : BitVec n)
   else
     simp [n_le_i, toNat_ofNat]
 
-@[simp]
-theorem zeroExtend_eq (x : BitVec n) : zeroExtend n x = x := by
+@[simp] theorem zeroExtend_eq (x : BitVec n) : zeroExtend n x = x := by
   apply eq_of_toNat_eq
 
   let ⟨x, lt_n⟩ := x
   simp [truncate, zeroExtend]
 
-@[simp]
-theorem zeroExtend_zero (m n : Nat) : zeroExtend m (0#n) = 0#m := by
+@[simp] theorem zeroExtend_zero (m n : Nat) : zeroExtend m (0#n) = 0#m := by
   apply eq_of_toNat_eq
   simp [toNat_zeroExtend]
 
-@[simp]
-theorem truncate_eq (x : BitVec n) : truncate n x = x := zeroExtend_eq x
+@[simp] theorem truncate_eq (x : BitVec n) : truncate n x = x := zeroExtend_eq x
 
-@[simp]
-theorem toNat_truncate (x : BitVec n)
-    : (truncate i x).toNat = x.toNat % 2^i := toNat_zeroExtend i x
+@[simp] theorem toNat_truncate (x : BitVec n) : (truncate i x).toNat = x.toNat % 2^i :=
+  toNat_zeroExtend i x
 
-theorem getLsb_zeroExtend' (ge : m ≥ n) (x : BitVec n) (i : Nat)
-    : getLsb (zeroExtend' ge x) i = getLsb x i := by
+theorem getLsb_zeroExtend' (ge : m ≥ n) (x : BitVec n) (i : Nat) :
+    getLsb (zeroExtend' ge x) i = getLsb x i := by
   simp [getLsb, toNat_zeroExtend']
 
-theorem getLsb_zeroExtend (m : Nat) (x : BitVec n) (i : Nat)
-    : getLsb (zeroExtend m x) i = (decide (i < m) && getLsb x i) := by
+theorem getLsb_zeroExtend (m : Nat) (x : BitVec n) (i : Nat) :
+    getLsb (zeroExtend m x) i = (decide (i < m) && getLsb x i) := by
   simp [getLsb, toNat_zeroExtend, Nat.testBit_mod_two_pow]
 
-theorem getLsb_truncate (m : Nat) (x : BitVec n) (i : Nat)
-    : getLsb (truncate m x) i = (decide (i < m) && getLsb x i) :=
+theorem getLsb_truncate (m : Nat) (x : BitVec n) (i : Nat) :
+    getLsb (truncate m x) i = (decide (i < m) && getLsb x i) :=
   getLsb_zeroExtend m x i
 
-theorem truncate_succ (x : BitVec w)
-    : truncate (i+1) x = cons (getLsb x i) (truncate i x) := by
+theorem truncate_succ (x : BitVec w) :
+    truncate (i+1) x = cons (getLsb x i) (truncate i x) := by
   apply eq_of_getLsb_eq
   intro j
   simp [getLsb_truncate, getLsb_cons, j.isLt]
@@ -183,7 +170,6 @@ Definition of bitvector addition as a nat.
 -/
 theorem toNat_add (x y : BitVec w) : (x + y).toNat = (x.toNat + y.toNat) % 2^w := by rfl
 
-@[simp]
-theorem add_zero (x : BitVec n) : x + (0#n) = x := by
+@[simp] theorem add_zero (x : BitVec n) : x + (0#n) = x := by
   apply eq_of_toNat_eq
   simp [toNat_add, isLt, Nat.mod_eq_of_lt]

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -65,15 +65,15 @@ private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) :
   Nat.lt_of_lt_of_le lt (Nat.pow_le_pow_of_le_right (by trivial : 0 < 2) le)
 
 @[simp] theorem ofNat_toNat (m : Nat) (x : BitVec n) : (BitVec.ofNat m x.toNat) = truncate m x := by
-    let ⟨x, lt_n⟩ := x
-    unfold truncate
-    unfold zeroExtend
-    if h : n ≤ m then
-      unfold zeroExtend'
-      have lt_m : x < 2 ^ m := lt_two_pow_of_le lt_n h
-      simp [h, lt_m, Nat.mod_eq_of_lt, BitVec.toNat, BitVec.ofNat]
-    else
-      simp [h]
+  let ⟨x, lt_n⟩ := x
+  unfold truncate
+  unfold zeroExtend
+  if h : n ≤ m then
+    unfold zeroExtend'
+    have lt_m : x < 2 ^ m := lt_two_pow_of_le lt_n h
+    simp [h, lt_m, Nat.mod_eq_of_lt, BitVec.toNat, BitVec.ofNat]
+  else
+    simp [h]
 
 theorem toNat_append (x : BitVec m) (y : BitVec n) : (x ++ y).toNat = x.toNat <<< n ||| y.toNat :=
   rfl

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -63,10 +63,8 @@ theorem toNat_ofBool (b : Bool) : (ofBool b).toNat = b.toNat := by
 theorem toNat_ofNat (x w : Nat) : (BitVec.ofNat w x).toNat = x % 2^w := by
   simp [BitVec.toNat, BitVec.ofNat]
 
-/--
-Definition of bitvector addition as a nat.
--/
-theorem toNat_add (x y : BitVec w) : (x + y).toNat = (x.toNat + y.toNat) % 2^w := by rfl
+@[simp]
+theorem toNat_zero (n : Nat) : (0#n).toNat = 0 := by trivial
 
 private
 theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) : x < 2 ^ n :=
@@ -144,6 +142,11 @@ theorem zeroExtend_eq (x : BitVec n) : zeroExtend n x = x := by
   simp [truncate, zeroExtend]
 
 @[simp]
+theorem zeroExtend_zero (m n : Nat) : zeroExtend m (0#n) = 0#m := by
+  apply eq_of_toNat_eq
+  simp [toNat_zeroExtend]
+
+@[simp]
 theorem truncate_eq (x : BitVec n) : truncate n x = x := zeroExtend_eq x
 
 @[simp]
@@ -172,3 +175,15 @@ theorem truncate_succ (x : BitVec w)
   else
     have j_lt : j.val < i := Nat.lt_of_le_of_ne (Nat.le_of_succ_le_succ j.isLt) j_eq
     simp [j_eq, j_lt]
+
+/-! ### add -/
+
+/--
+Definition of bitvector addition as a nat.
+-/
+theorem toNat_add (x y : BitVec w) : (x + y).toNat = (x.toNat + y.toNat) % 2^w := by rfl
+
+@[simp]
+theorem add_zero (x : BitVec n) : x + (0#n) = x := by
+  apply eq_of_toNat_eq
+  simp [toNat_add, isLt, Nat.mod_eq_of_lt]

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -162,7 +162,7 @@ theorem getLsb_truncate (m : Nat) (x : BitVec n) (i : Nat)
     : getLsb (truncate m x) i = (decide (i < m) && getLsb x i) :=
   getLsb_zeroExtend m x i
 
-theorem cons_getLsb_truncate (x : BitVec w)
+theorem truncate_succ (x : BitVec w)
     : truncate (i+1) x = cons (getLsb x i) (truncate i x) := by
   apply eq_of_getLsb_eq
   intro j

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -26,12 +26,11 @@ theorem eq_of_getLsb_eq {x y : BitVec w}
   apply eq_of_toNat_eq
   apply Nat.eq_of_testBit_eq
   intro i
-  simp [testBit_toNat]
   if i_lt : i < w then
     exact pred ⟨i, i_lt⟩
   else
     have p : i ≥ w := Nat.le_of_not_gt i_lt
-    simp [getLsb_ge _ _ p]
+    simp [testBit_toNat, getLsb_ge _ _ p]
 
 theorem eq_of_getMsb_eq {x y : BitVec w}
     (pred : ∀(i : Fin w), x.getMsb i = y.getMsb i.val) : x = y := by
@@ -46,7 +45,7 @@ theorem eq_of_getMsb_eq {x y : BitVec w}
       simp [Nat.le_sub_iff_add_le w_pos, Nat.add_succ]
       exact i_lt
     have q_lt : w - 1 - i < w := by
-      simp [Nat.sub_sub]
+      simp only [Nat.sub_sub]
       apply Nat.sub_lt w_pos
       simp [Nat.succ_add]
     have q := pred ⟨w - 1 - i, q_lt⟩
@@ -69,11 +68,10 @@ private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) :
     let ⟨x, lt_n⟩ := x
     unfold truncate
     unfold zeroExtend
-    simp [BitVec.toNat, BitVec.ofNat]
     if h : n ≤ m then
       unfold zeroExtend'
       have lt_m : x < 2 ^ m := lt_two_pow_of_le lt_n h
-      simp [h, lt_m, Nat.mod_eq_of_lt]
+      simp [h, lt_m, Nat.mod_eq_of_lt, BitVec.toNat, BitVec.ofNat]
     else
       simp [h]
 
@@ -90,7 +88,7 @@ theorem toNat_cons (b : Bool) (x : BitVec w) : (cons b x).toNat = (b.toNat <<< w
 
 theorem getLsb_cons (b : Bool) {n} (x : BitVec n) (i : Nat) :
     getLsb (cons b x) i = if i = n then b else getLsb x i := by
-  simp [getLsb, toNat_cons, Nat.testBit_or]
+  simp only [getLsb, toNat_cons, Nat.testBit_or]
   rw [Nat.testBit_shiftLeft]
   rcases Nat.lt_trichotomy i n with i_lt_n | i_eq_n | n_lt_i
   · have i_ge_n := Nat.not_le_of_gt i_lt_n
@@ -150,7 +148,7 @@ theorem truncate_succ (x : BitVec w) :
     truncate (i+1) x = cons (getLsb x i) (truncate i x) := by
   apply eq_of_getLsb_eq
   intro j
-  simp [getLsb_truncate, getLsb_cons, j.isLt]
+  simp only [getLsb_truncate, getLsb_cons, j.isLt, decide_True, Bool.true_and]
   if j_eq : j.val = i then
     simp [j_eq]
   else

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -1,0 +1,177 @@
+import Std.Data.Bool
+import Std.Data.BitVec.Basic
+import Std.Data.Nat.Lemmas
+
+namespace Std.BitVec
+
+/-- Prove equality of bitvectors in terms of nat operations. -/
+theorem eq_of_toNat_eq {n} : ∀ {i j : BitVec n}, i.toNat = j.toNat → i = j
+  | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
+
+theorem toNat_eq (x y : BitVec n) : x = y ↔ x.toNat = y.toNat :=
+  Iff.intro (congrArg BitVec.toNat) eq_of_toNat_eq
+
+theorem testBit_toNat (x : BitVec w) : x.toNat.testBit i = x.getLsb i := rfl
+
+@[simp] theorem getLsb_ge (x : BitVec w) (i : Nat) (ge : i ≥ w) : getLsb x i = false := by
+  let ⟨x, x_lt⟩ := x
+  apply Nat.testBit_lt_two
+  apply Nat.lt_of_lt_of_le x_lt
+  apply Nat.pow_le_pow_of_le_right (by trivial : 0 < 2) ge
+
+theorem eq_of_getLsb_eq
+    {x y : BitVec w}
+    (pred : ∀(i:Fin w), x.getLsb i.val = y.getLsb i.val) : x = y := by
+  apply eq_of_toNat_eq
+  apply Nat.eq_of_testBit_eq
+  intro i
+  simp [testBit_toNat]
+  if i_lt : i < w then
+    exact pred ⟨i, i_lt⟩
+  else
+    have p : i ≥ w := Nat.le_of_not_gt i_lt
+    simp [getLsb_ge _ _ p]
+
+theorem eq_of_getMsb_eq {x y : BitVec w}
+    (pred : ∀(i:Fin w), x.getMsb i = y.getMsb i.val) : x = y := by
+  simp [getMsb] at pred
+  apply eq_of_getLsb_eq
+  intro ⟨i, i_lt⟩
+  if w_zero : w = 0 then
+    simp [w_zero]
+  else
+    have w_pos := Nat.pos_of_ne_zero w_zero
+
+    have r : i ≤ w - 1 := by
+        simp [Nat.le_sub_iff_add_le w_pos, Nat.add_succ]
+        exact i_lt
+
+    have q_lt : w - 1 - i < w := by
+          simp [Nat.sub_sub]
+          apply Nat.sub_lt w_pos
+          simp [Nat.succ_add]
+    have q := pred ⟨w - 1 - i, q_lt⟩
+    simp [q_lt, Nat.sub_sub_self, r] at q
+    exact q
+
+@[simp]
+theorem toNat_ofBool (b : Bool) : (ofBool b).toNat = b.toNat := by
+  cases b <;> rfl
+
+@[simp]
+theorem toNat_ofFin (x : Fin (2^n)) : (BitVec.ofFin x).toNat = x.val := rfl
+
+theorem toNat_ofNat (x w : Nat)
+    : (BitVec.ofNat w x).toNat = x &&& 2^w-1 := rfl
+
+/--
+Definition of bitvector addition as a nat.
+-/
+theorem toNat_add (x y : BitVec w) : (x + y).toNat = (x.toNat + y.toNat) % 2^w := by rfl
+
+private
+theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) : x < 2 ^ n :=
+  Nat.lt_of_lt_of_le lt (Nat.pow_le_pow_of_le_right (by trivial : 0 < 2) le)
+
+@[simp]
+theorem ofNat_toNat (m : Nat) (x : BitVec n)
+    : (BitVec.ofNat m x.toNat) = truncate m x := by
+    let ⟨x, lt_n⟩ := x
+    unfold truncate
+    unfold zeroExtend
+    simp [BitVec.toNat, BitVec.ofNat]
+    if h : n ≤ m then
+      have lt_m : x < 2 ^ m := lt_two_pow_of_le lt_n h
+      simp [h, lt_m, Nat.and_pow_2_is_mod]
+    else
+      simp [h]
+
+theorem toNat_append (x : BitVec m) (y : BitVec n)
+    : (x ++ y).toNat = x.toNat <<< n ||| y.toNat := rfl
+
+@[simp]
+theorem toNat_cast (e:m = n) (x : BitVec m)
+    : (cast e x).toNat = x.toNat := rfl
+
+theorem toNat_cons (b:Bool) (x : BitVec w)
+    : (cons b x).toNat = (b.toNat <<< w) ||| x.toNat := by
+    let ⟨x, _⟩ := x
+    simp [cons, toNat_append, toNat_ofBool,  toNat_ofNat]
+
+/-! ### cons -/
+
+theorem getLsb_cons (b:Bool) {n} (x : BitVec n) (i:Nat)
+    : getLsb (cons b x) i = if i = n then b else getLsb x i := by
+  simp [getLsb, toNat_cons, Nat.testBit_or]
+  rw [Nat.testBit_shiftLeft]
+  match Nat.lt_trichotomy i n with
+  | Or.inl i_lt_n =>
+      have i_ge_n := Nat.not_le_of_gt i_lt_n
+      have not_eq := Nat.ne_of_lt i_lt_n
+      simp [i_ge_n, not_eq]
+  | Or.inr (Or.inl i_eq_n) =>
+     simp [i_eq_n, testBit_toNat]
+     cases b <;> trivial
+  | Or.inr (Or.inr n_lt_i) =>
+    have i_ge_n : n ≤ i := Nat.le_of_lt n_lt_i
+    have not_eq := Nat.ne_of_gt n_lt_i
+    have neq_zero : i - n ≠ 0 := Nat.sub_ne_zero_of_lt n_lt_i
+    simp [i_ge_n, not_eq, Nat.testBit_bool_to_nat, neq_zero]
+
+/-! ### zeroExtend and truncate -/
+
+
+@[simp]
+theorem zeroExtend_eq (x : BitVec n) : zeroExtend n x = x := by
+  let ⟨x, lt_n⟩ := x
+  simp [truncate, zeroExtend]
+
+@[simp]
+theorem truncate_eq (x : BitVec n) : truncate n x = x := zeroExtend_eq x
+
+theorem toNat_zeroExtend (i:Nat) (x : BitVec n)
+  : BitVec.toNat (zeroExtend i x) = x.toNat % 2^i := by
+  let ⟨x, lt_n⟩ := x
+  simp only [zeroExtend]
+
+  if n_le_i : n ≤ i then
+    have x_lt_two_i : x < 2 ^ i := lt_two_pow_of_le lt_n n_le_i
+    simp [n_le_i, Nat.mod_eq_of_lt x_lt_two_i]
+  else
+    simp [n_le_i, Nat.and_pow_2_is_mod, toNat_ofNat]
+
+@[simp]
+theorem toNat_truncate (x : BitVec n)
+    : (truncate i x).toNat = x.toNat % 2^i := toNat_zeroExtend i x
+
+theorem getLsb_zeroExtend {n} (x : BitVec n) (m i:Nat)
+    : getLsb (zeroExtend m x) i = (decide (i < m) && getLsb x i) := by
+  let ⟨x, x_lt_n⟩ := x
+  simp [zeroExtend, getLsb]
+  if i_lt_m : i < m then
+    if n_le_m : n ≤ m then
+      simp [i_lt_m, n_le_m]
+    else
+      simp [i_lt_m, n_le_m, Nat.testBit_and,  toNat_ofNat]
+  else
+    if n_le_m : n ≤ m then
+      have x_lt_i : x < 2 ^ i := lt_two_pow_of_le x_lt_n
+              (Nat.le_trans n_le_m (Nat.le_of_not_lt i_lt_m))
+      simp [i_lt_m, n_le_m, Nat.testBit_lt_two x_lt_i]
+    else
+      simp [i_lt_m, n_le_m, Nat.testBit_and, toNat_ofNat]
+
+theorem getLsb_truncate {n} (x : BitVec n) (m i:Nat)
+    : getLsb (truncate m x) i = (decide (i < m) && getLsb x i) :=
+  getLsb_zeroExtend x m i
+
+theorem cons_getLsb_truncate (x : BitVec w)
+    : truncate (i+1) x = cons (getLsb x i) (truncate i x) := by
+  apply eq_of_getLsb_eq
+  intro j
+  simp [getLsb_truncate, getLsb_cons, j.isLt]
+  if j_eq : j.val = i then
+    simp [j_eq]
+  else
+    have j_lt : j.val < i := Nat.lt_of_le_of_ne (Nat.le_of_succ_le_succ j.isLt) j_eq
+    simp [j_eq, j_lt]

--- a/Std/Data/Bool.lean
+++ b/Std/Data/Bool.lean
@@ -123,6 +123,12 @@ theorem xor_right_comm : ∀ (x y z : Bool), xor (xor x y) z = xor (xor x z) y :
 
 theorem xor_assoc : ∀ (x y z : Bool), xor (xor x y) z = xor x (xor y z) := by decide
 
+@[simp]
+theorem xor_left_inj : ∀ (x y z : Bool), xor x y = xor x z ↔ y = z := by decide
+
+@[simp]
+theorem xor_right_inj : ∀ (x y z : Bool), xor x z = xor y z ↔ x = y := by decide
+
 /-! ### le/lt -/
 
 @[simp] protected theorem le_true : ∀ (x : Bool), x ≤ true := by decide
@@ -189,3 +195,24 @@ theorem and_or_inj_left : ∀ {m x y : Bool}, (m && x) = (m && y) → (m || x) =
 theorem and_or_inj_left_iff :
     ∀ {m x y : Bool}, (m && x) = (m && y) ∧ (m || x) = (m || y) ↔ x = y := by decide
 @[deprecated] alias and_or_inj_left' := and_or_inj_left_iff
+
+@[simp]
+theorem false_eq_decide_iff {p : Prop} [h : Decidable p] : false = decide p ↔ ¬p := by
+  cases h with | _ q => simp [q]
+
+@[simp]
+theorem true_eq_decide_iff {p : Prop} [h : Decidable p] : true = decide p ↔ p := by
+  cases h with | _ q => simp [q]
+
+/-! ## toNat -/
+
+
+/-- convert a `Bool` to a `Nat`, `false -> 0`, `true -> 1` -/
+def toNat (b:Bool) : Nat := cond b 1 0
+
+@[simp] theorem toNat_false : false.toNat = 0 := rfl
+
+@[simp]theorem toNat_true : true.toNat = 1 := rfl
+
+theorem toNat_le_one (c:Bool) : c.toNat ≤ 1 := by
+  cases c <;> trivial

--- a/Std/Data/Bool.lean
+++ b/Std/Data/Bool.lean
@@ -206,7 +206,6 @@ theorem true_eq_decide_iff {p : Prop} [h : Decidable p] : true = decide p ↔ p 
 
 /-! ## toNat -/
 
-
 /-- convert a `Bool` to a `Nat`, `false -> 0`, `true -> 1` -/
 def toNat (b:Bool) : Nat := cond b 1 0
 

--- a/Std/Data/Bool.lean
+++ b/Std/Data/Bool.lean
@@ -196,12 +196,10 @@ theorem and_or_inj_left_iff :
     ∀ {m x y : Bool}, (m && x) = (m && y) ∧ (m || x) = (m || y) ↔ x = y := by decide
 @[deprecated] alias and_or_inj_left' := and_or_inj_left_iff
 
-@[simp]
-theorem false_eq_decide_iff {p : Prop} [h : Decidable p] : false = decide p ↔ ¬p := by
+@[simp] theorem false_eq_decide_iff {p : Prop} [h : Decidable p] : false = decide p ↔ ¬p := by
   cases h with | _ q => simp [q]
 
-@[simp]
-theorem true_eq_decide_iff {p : Prop} [h : Decidable p] : true = decide p ↔ p := by
+@[simp] theorem true_eq_decide_iff {p : Prop} [h : Decidable p] : true = decide p ↔ p := by
   cases h with | _ q => simp [q]
 
 /-! ## toNat -/
@@ -211,7 +209,7 @@ def toNat (b:Bool) : Nat := cond b 1 0
 
 @[simp] theorem toNat_false : false.toNat = 0 := rfl
 
-@[simp]theorem toNat_true : true.toNat = 1 := rfl
+@[simp] theorem toNat_true : true.toNat = 1 := rfl
 
 theorem toNat_le_one (c:Bool) : c.toNat ≤ 1 := by
   cases c <;> trivial

--- a/Std/Data/Fin/Iterate.lean
+++ b/Std/Data/Fin/Iterate.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2023 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joe Hendrix
+-/
+import Std.Logic
+
+namespace Fin
+
+/--
+`hIterate` is a heterogenous iterative operation that applies a
+index-dependent function `f` to a value `init : P start` a total of
+`stop - start` times to produce a value of type `P stop`.
+
+Concretely, `hIterate start stop f init` is equal to
+```lean
+  init |> f start _ |> f (start+1) _ ... |> f (end-1) _
+```
+
+Because it is heterogenous and must return a value of type `P stop`,
+`hIterate` requires proof that `start ≤ stop`.
+
+One can prove properties of `hIterate` using the general theorem
+`hIterate_elim` or other more specialzied theorems.
+ -/
+def hIterate (P : Nat → Sort _)
+             {n : Nat}
+             (init : P 0)
+             (f : ∀(i:Fin n), P i.val → P (i.val+1))
+             : P n :=
+    let rec loop (i : Nat) (ubnd : i ≤ n) (a : P i) : P n :=
+            if g : i < n then
+              loop (i+1) g (f ⟨i, g⟩ a)
+            else
+              have p : i = n := (or_iff_left g).mp (Nat.eq_or_lt_of_le ubnd)
+              cast (congrArg P p) a
+    loop 0 (Nat.zero_le n) init
+  termination_by loop i _ _ => n - i
+
+private theorem hIterate_loop_elim
+    {P : Nat → Sort _}
+    (Q : ∀(i:Nat), P i → Prop)
+    {n  : Nat}
+    (f : ∀(i:Fin n), P i.val → P (i.val+1))
+    {i : Nat}
+    (ubnd : i ≤ n)
+    (s : P i)
+    (init : Q i s)
+    (step : ∀(k:Fin n) (s:P k.val), Q k.val s → Q (k.val+1) (f k s))
+    : Q n (hIterate.loop P f i ubnd s) := by
+  let ⟨j, p⟩ := Nat.le.dest ubnd
+  induction j generalizing i ubnd init with
+  | zero =>
+    unfold hIterate.loop
+    have g : ¬ (i < n) := by simp at p; simp [p]
+    simp [g]
+    have r : Q n (cast (congrArg P p) s) :=
+      @Eq.rec Nat i (fun k eq => Q k (cast (congrArg P eq) s)) init n p
+    exact r
+  | succ j inv =>
+    unfold hIterate.loop
+    have d : Nat.succ i + j = n := by simp [Nat.succ_add]; exact p
+    have g : i < n := Nat.le.intro d
+    simp [g]
+    exact inv _ _ (step ⟨i,g⟩ s init) d
+
+/-
+`hIterate_elim` provides a mechanism for showing that the result of
+`hIterate` satisifies a property `Q stop` by showing that the states
+at the intermediate indices `i : start ≤ i < stop` satisfy `Q i`.
+-/
+theorem hIterate_elim
+    {P : Nat → Sort _}
+    (Q : ∀(i:Nat), P i → Prop)
+    {n : Nat}
+    (f : ∀(i:Fin n), P i.val → P (i.val+1))
+    (s : P 0)
+    (init : Q 0 s)
+    (step : ∀(k:Fin n) (s:P k.val), Q k.val s → Q (k.val+1) (f k s))
+    : Q n (hIterate P s f) := by
+  exact hIterate_loop_elim _ _ _ _ init step
+
+/-
+`hIterate_eq`provides a mechanism for replacing hIterate with another
+function overshowing that the result of
+`hIterate` satisifies a property `Q stop` by showing that the states
+at the intermediate indices `i : start ≤ i < stop` satisfy `Q i`.
+-/
+theorem hIterate_eq
+    {P : Nat → Sort _}
+    (state : ∀(i:Nat), P i)
+    {n : Nat}
+    (f : ∀(i:Fin n), P i.val → P (i.val+1))
+    (s : P 0)
+    (init : s = state 0)
+    (step : ∀(i:Fin n), f i (state i) = state (i+1))
+    : hIterate P s f = state n := by
+  apply hIterate_elim (fun i s => s = state i) f s init
+  intro i s s_eq
+  simp only [s_eq, step]

--- a/Std/Data/Fin/Iterate.lean
+++ b/Std/Data/Fin/Iterate.lean
@@ -37,7 +37,7 @@ Because it is heterogenous and must return a value of type `P stop`,
 `hIterate` requires proof that `start ≤ stop`.
 
 One can prove properties of `hIterate` using the general theorem
-`hIterate_elim` or other more specialzied theorems.
+`hIterate_elim` or other more specialized theorems.
  -/
 def hIterate (P : Nat → Sort _) {n : Nat} (init : P 0) (f : ∀(i : Fin n), P i.val → P (i.val+1)) :
     P n :=

--- a/Std/Data/Fin/Iterate.lean
+++ b/Std/Data/Fin/Iterate.lean
@@ -14,7 +14,7 @@ from `P i`.
 
 See `hIterate` below for more details.
 -/
-def hIterateFrom (P : Nat → Sort _) {n} (f : ∀(i:Fin n), P i.val → P (i.val+1))
+def hIterateFrom (P : Nat → Sort _) {n} (f : ∀(i : Fin n), P i.val → P (i.val+1))
       (i : Nat) (ubnd : i ≤ n) (a : P i) : P n :=
   if g : i < n then
     hIterateFrom P f (i+1) g (f ⟨i, g⟩ a)
@@ -39,24 +39,20 @@ Because it is heterogenous and must return a value of type `P stop`,
 One can prove properties of `hIterate` using the general theorem
 `hIterate_elim` or other more specialzied theorems.
  -/
-def hIterate (P : Nat → Sort _)
-             {n : Nat}
-             (init : P 0)
-             (f : ∀(i:Fin n), P i.val → P (i.val+1))
-             : P n :=
+def hIterate (P : Nat → Sort _) {n : Nat} (init : P 0) (f : ∀(i : Fin n), P i.val → P (i.val+1)) :
+    P n :=
   hIterateFrom P f 0 (Nat.zero_le n) init
 
 private theorem hIterateFrom_elim
     {P : Nat → Sort _}
-    (Q : ∀(i:Nat), P i → Prop)
+    (Q : ∀(i : Nat), P i → Prop)
     {n  : Nat}
-    (f : ∀(i:Fin n), P i.val → P (i.val+1))
-    {i : Nat}
-    (ubnd : i ≤ n)
+    (f : ∀(i : Fin n), P i.val → P (i.val+1))
+    {i : Nat} (ubnd : i ≤ n)
     (s : P i)
     (init : Q i s)
-    (step : ∀(k:Fin n) (s:P k.val), Q k.val s → Q (k.val+1) (f k s))
-    : Q n (hIterateFrom P f i ubnd s) := by
+    (step : ∀(k : Fin n) (s : P k.val), Q k.val s → Q (k.val+1) (f k s)) :
+    Q n (hIterateFrom P f i ubnd s) := by
   let ⟨j, p⟩ := Nat.le.dest ubnd
   induction j generalizing i ubnd init with
   | zero =>
@@ -78,15 +74,10 @@ private theorem hIterateFrom_elim
 `hIterate` satisifies a property `Q stop` by showing that the states
 at the intermediate indices `i : start ≤ i < stop` satisfy `Q i`.
 -/
-theorem hIterate_elim
-    {P : Nat → Sort _}
-    (Q : ∀(i:Nat), P i → Prop)
-    {n : Nat}
-    (f : ∀(i:Fin n), P i.val → P (i.val+1))
-    (s : P 0)
-    (init : Q 0 s)
-    (step : ∀(k:Fin n) (s:P k.val), Q k.val s → Q (k.val+1) (f k s))
-    : Q n (hIterate P s f) := by
+theorem hIterate_elim {P : Nat → Sort _} (Q : ∀(i : Nat), P i → Prop)
+    {n : Nat} (f : ∀(i : Fin n), P i.val → P (i.val+1)) (s : P 0) (init : Q 0 s)
+    (step : ∀(k : Fin n) (s : P k.val), Q k.val s → Q (k.val+1) (f k s)) :
+    Q n (hIterate P s f) := by
   exact hIterateFrom_elim _ _ _ _ init step
 
 /-
@@ -95,15 +86,11 @@ function overshowing that the result of
 `hIterate` satisifies a property `Q stop` by showing that the states
 at the intermediate indices `i : start ≤ i < stop` satisfy `Q i`.
 -/
-theorem hIterate_eq
-    {P : Nat → Sort _}
-    (state : ∀(i:Nat), P i)
-    {n : Nat}
-    (f : ∀(i:Fin n), P i.val → P (i.val+1))
-    (s : P 0)
+theorem hIterate_eq {P : Nat → Sort _}
+    (state : ∀(i : Nat), P i) {n : Nat} (f : ∀(i : Fin n), P i.val → P (i.val+1)) (s : P 0)
     (init : s = state 0)
-    (step : ∀(i:Fin n), f i (state i) = state (i+1))
-    : hIterate P s f = state n := by
+    (step : ∀(i : Fin n), f i (state i) = state (i+1)) :
+    hIterate P s f = state n := by
   apply hIterate_elim (fun i s => s = state i) f s init
   intro i s s_eq
   simp only [s_eq, step]

--- a/Std/Data/Fin/Iterate.lean
+++ b/Std/Data/Fin/Iterate.lean
@@ -80,7 +80,7 @@ theorem hIterate_elim {P : Nat → Sort _} (Q : ∀(i : Nat), P i → Prop)
 /-
 `hIterate_eq`provides a mechanism for replacing hIterate with another
 function overshowing that the result of
-`hIterate` satisifies a property `Q stop` by showing that the states
+`hIterate` satisfies a property `Q stop` by showing that the states
 at the intermediate indices `i : start ≤ i < stop` satisfy `Q i`.
 -/
 theorem hIterate_eq {P : Nat → Sort _}

--- a/Std/Data/Fin/Iterate.lean
+++ b/Std/Data/Fin/Iterate.lean
@@ -78,13 +78,14 @@ theorem hIterate_elim {P : Nat → Sort _} (Q : ∀(i : Nat), P i → Prop)
   exact hIterateFrom_elim _ _ _ _ init step
 
 /-
-`hIterate_eq`provides a mechanism for replacing hIterate with another
-function overshowing that the result of
-`hIterate` satisfies a property `Q stop` by showing that the states
-at the intermediate indices `i : start ≤ i < stop` satisfy `Q i`.
+`hIterate_eq`provides a mechanism for replacing `hIterate P s f` with a
+function `state` showing that matches the steps performed by `hIterate`.
+
+This allows rewriting incremental code using `hIterate` with a
+non-incremental state function.
 -/
-theorem hIterate_eq {P : Nat → Sort _}
-    (state : ∀(i : Nat), P i) {n : Nat} (f : ∀(i : Fin n), P i.val → P (i.val+1)) (s : P 0)
+theorem hIterate_eq {P : Nat → Sort _} (state : ∀(i : Nat), P i)
+    {n : Nat} (f : ∀(i : Fin n), P i.val → P (i.val+1)) (s : P 0)
     (init : s = state 0)
     (step : ∀(i : Fin n), f i (state i) = state (i+1)) :
     hIterate P s f = state n := by

--- a/Std/Data/Fin/Iterate.lean
+++ b/Std/Data/Fin/Iterate.lean
@@ -43,9 +43,7 @@ def hIterate (P : Nat → Sort _) {n : Nat} (init : P 0) (f : ∀(i : Fin n), P 
     P n :=
   hIterateFrom P f 0 (Nat.zero_le n) init
 
-private theorem hIterateFrom_elim
-    {P : Nat → Sort _}
-    (Q : ∀(i : Nat), P i → Prop)
+private theorem hIterateFrom_elim {P : Nat → Sort _}(Q : ∀(i : Nat), P i → Prop)
     {n  : Nat}
     (f : ∀(i : Fin n), P i.val → P (i.val+1))
     {i : Nat} (ubnd : i ≤ n)
@@ -58,15 +56,14 @@ private theorem hIterateFrom_elim
   | zero =>
     unfold hIterateFrom
     have g : ¬ (i < n) := by simp at p; simp [p]
-    simp [g]
     have r : Q n (cast (congrArg P p) s) :=
       @Eq.rec Nat i (fun k eq => Q k (cast (congrArg P eq) s)) init n p
-    exact r
+    simp only [g, r, dite_false]
   | succ j inv =>
     unfold hIterateFrom
     have d : Nat.succ i + j = n := by simp [Nat.succ_add]; exact p
     have g : i < n := Nat.le.intro d
-    simp [g]
+    simp only [g]
     exact inv _ _ (step ⟨i,g⟩ s init) d
 
 /-

--- a/Std/Data/Nat/Basic.lean
+++ b/Std/Data/Nat/Basic.lean
@@ -126,3 +126,12 @@ where
     else
       guess
 termination_by iter guess => guess
+
+/-!
+### testBit
+We define an operation for testing individual bits in the binary representation
+of  a number.
+-/
+
+/-- `testBit m n` returns whether the `(n+1)ˢᵗ` least significant bit is `1` or `0`-/
+def testBit (m n : Nat) : Bool := (m >>> n) &&& 1 ≠ 0

--- a/Std/Data/Nat/Basic.lean
+++ b/Std/Data/Nat/Basic.lean
@@ -133,5 +133,5 @@ We define an operation for testing individual bits in the binary representation
 of a number.
 -/
 
-/-- `testBit m n` returns whether the `(n+1)ˢᵗ` least significant bit is `1` or `0`-/
+/-- `testBit m n` returns whether the `(n+1)` least significant bit is `1` or `0`-/
 def testBit (m n : Nat) : Bool := (m >>> n) &&& 1 != 0

--- a/Std/Data/Nat/Basic.lean
+++ b/Std/Data/Nat/Basic.lean
@@ -130,7 +130,7 @@ termination_by iter guess => guess
 /-!
 ### testBit
 We define an operation for testing individual bits in the binary representation
-of  a number.
+of a number.
 -/
 
 /-- `testBit m n` returns whether the `(n+1)ˢᵗ` least significant bit is `1` or `0`-/

--- a/Std/Data/Nat/Basic.lean
+++ b/Std/Data/Nat/Basic.lean
@@ -134,4 +134,4 @@ of  a number.
 -/
 
 /-- `testBit m n` returns whether the `(n+1)ˢᵗ` least significant bit is `1` or `0`-/
-def testBit (m n : Nat) : Bool := (m >>> n) &&& 1 ≠ 0
+def testBit (m n : Nat) : Bool := (m >>> n) &&& 1 != 0

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -178,10 +178,7 @@ theorem testBit_implies_ge {x : Nat} (p : testBit x i = true) : x ≥ 2^i := by
   simp only [testBit_to_div_mod] at p
   by_contra not_ge
   have x_lt : x < 2^i := Nat.lt_of_not_le not_ge
-  have x_lt_2 : x < 2^i * 2 := by
-        rw [←Nat.mul_one x]
-        apply Nat.mul_lt_mul x_lt (by trivial : 1 ≤ 2) (by trivial : 0 < 1)
-  simp [x_lt_2, mod_eq_of_lt, x_lt, div_eq_of_lt] at p
+  simp [div_eq_of_lt x_lt] at p
 
 theorem testBit_lt_two {x i : Nat} (lt : x < 2^i) : x.testBit i = false := by
   match p : x.testBit i with

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -18,6 +18,7 @@ namespace Nat
 @[local simp]
 private theorem one_div_two : 1/2 = 0 := by trivial
 
+private
 theorem two_pow_succ_sub_one_div : (2 ^ (n+1) - 1) / 2 = 2^n - 1 := by
   apply fun x => (Nat.sub_eq_of_eq_add x).symm
   apply Eq.trans _
@@ -26,6 +27,7 @@ theorem two_pow_succ_sub_one_div : (2 ^ (n+1) - 1) / 2 = 2^n - 1 := by
   rw [ Nat.add_sub_assoc Nat.zero_lt_two ]
   simp [Nat.pow_succ, Nat.mul_comm _ 2, Nat.mul_add_div]
 
+private
 theorem two_mul_sub_one (n:Nat) (n_pos : n > 0) : (2*n - 1) % 2 = 1 := by
   match n with
   | 0 => contradiction
@@ -61,7 +63,7 @@ theorem and_zero (x:Nat) : x &&& 0 = 0 := by
   simp
 
 @[simp]
-theorem and_1_is_mod (x:Nat) : x &&& 1 = x % 2 := by
+theorem and_one_is_mod (x:Nat) : x &&& 1 = x % 2 := by
   if xz : x = 0 then
     simp [xz, zero_and]
   else
@@ -71,8 +73,6 @@ theorem and_1_is_mod (x:Nat) : x &&& 1 = x % 2 := by
     unfold bitwise
     cases mod_two_eq_zero_or_one x with | _ p =>
       simp [xz, p, andz, one_div_two, mod_eq_of_lt]
-
-
 
 /-! ### testBit -/
 

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -186,7 +186,7 @@ theorem lt_pow_two_of_testBit (x : Nat) (p : ∀i, i ≥ n → testBit x i = fal
 
 /-! ### testBit -/
 
-private theorem succ_mod_2 : succ x % 2 = 1 - x % 2 := by
+private theorem succ_mod_two : succ x % 2 = 1 - x % 2 := by
   induction x with
   | zero =>
     trivial
@@ -196,12 +196,12 @@ private theorem succ_mod_2 : succ x % 2 = 1 - x % 2 := by
     cases Nat.mod_two_eq_zero_or_one x with | _ p => simp [p]
 
 private theorem testBit_succ_zero : testBit (x + 1) 0 = not (testBit x 0) := by
-  simp [testBit_to_div_mod, succ_mod_2]
+  simp [testBit_to_div_mod, succ_mod_two]
   cases Nat.mod_two_eq_zero_or_one x with | _ p =>
     simp [p]
 
 theorem testBit_two_pow_add_eq (x i : Nat) : testBit (2^i + x) i = not (testBit x i) := by
-  simp [testBit_to_div_mod, add_div_left, Nat.pow_two_pos, succ_mod_2]
+  simp [testBit_to_div_mod, add_div_left, Nat.pow_two_pos, succ_mod_two]
   cases mod_two_eq_zero_or_one (x / 2 ^ i) with
   | _ p => simp [p]
 
@@ -213,7 +213,7 @@ theorem testBit_mul_two_pow_add_eq (a b i : Nat) :
     simp [Nat.mul_succ, Nat.add_assoc,
           testBit_mul_two_pow_add_eq a,
           testBit_two_pow_add_eq,
-          Nat.succ_mod_2]
+          Nat.succ_mod_two]
     cases mod_two_eq_zero_or_one a with
     | _ p => simp [p]
 
@@ -332,12 +332,12 @@ private theorem zero_lt_pow (n : Nat) : 0 < 2^n := by
     simp [pow_succ]
     exact (Nat.mul_lt_mul_of_pos_right hyp Nat.zero_lt_two : 0 < 2 ^ n * 2)
 
-private theorem div_2_le_of_lt_two {m n : Nat} (p : m < 2 ^ succ n) : m / 2 < 2^n := by
+private theorem div_two_le_of_lt_two {m n : Nat} (p : m < 2 ^ succ n) : m / 2 < 2^n := by
   simp [div_lt_iff_lt_mul Nat.zero_lt_two]
   exact p
 
 /-- This provides a bound on bitwise operations. -/
-theorem bitwise_lt_2_pow (left : x < 2^n) (right : y < 2^n) : (Nat.bitwise f x y) < 2^n := by
+theorem bitwise_lt_two_pow (left : x < 2^n) (right : y < 2^n) : (Nat.bitwise f x y) < 2^n := by
   induction n generalizing x y with
   | zero =>
     simp only [eq_0_of_lt] at left right
@@ -353,7 +353,7 @@ theorem bitwise_lt_2_pow (left : x < 2^n) (right : y < 2^n) : (Nat.bitwise f x y
       by_cases p : f true false = true <;> simp [p, left]
     else
       simp only [x_zero, y_zero, if_false]
-      have hyp1 := hyp (div_2_le_of_lt_two left) (div_2_le_of_lt_two right)
+      have hyp1 := hyp (div_two_le_of_lt_two left) (div_two_le_of_lt_two right)
       by_cases p : f (decide (x % 2 = 1)) (decide (y % 2 = 1)) = true <;>
         simp [p, pow_succ, mul_succ, Nat.add_assoc]
       case pos =>
@@ -368,7 +368,7 @@ theorem bitwise_lt_2_pow (left : x < 2^n) (right : y < 2^n) : (Nat.bitwise f x y
 theorem testBit_and (x y i : Nat) : (x &&& y).testBit i = (x.testBit i && y.testBit i) := by
   simp [HAnd.hAnd, AndOp.and, land, testBit_bitwise ]
 
-theorem and_lt_2_pow (x : Nat) {y n : Nat} (right : y < 2^n) : (x &&& y) < 2^n := by
+theorem and_lt_two_pow (x : Nat) {y n : Nat} (right : y < 2^n) : (x &&& y) < 2^n := by
   apply lt_pow_two_of_testBit
   intro i i_ge_n
   have yf : testBit y i = false := by
@@ -402,16 +402,16 @@ theorem and_pow_two_identity {x : Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
 theorem testBit_or (x y i : Nat) : (x ||| y).testBit i = (x.testBit i || y.testBit i) := by
   simp [HOr.hOr, OrOp.or, lor, testBit_bitwise ]
 
-theorem or_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ||| y < 2^n :=
-  bitwise_lt_2_pow left right
+theorem or_lt_two_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ||| y < 2^n :=
+  bitwise_lt_two_pow left right
 
 /-! ### xor -/
 
 theorem testBit_xor (x y i : Nat) : (x ^^^ y).testBit i = Bool.xor (x.testBit i) (y.testBit i) := by
   simp [HXor.hXor, Xor.xor, xor, testBit_bitwise ]
 
-theorem xor_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ^^^ y < 2^n :=
-  bitwise_lt_2_pow left right
+theorem xor_lt_two_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ^^^ y < 2^n :=
+  bitwise_lt_two_pow left right
 
 /-! ### Arithmetic -/
 

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -78,8 +78,7 @@ theorem and_1_is_mod (x:Nat) : x &&& 1 = x % 2 := by
 
 @[simp]
 theorem zero_testBit (i:Nat) : testBit 0 i = false := by
-  unfold testBit
-  simp [zero_shiftRight]
+  simp only [testBit, zero_shiftRight, zero_and, bne_self_eq_false]
 
 theorem testBit_zero_is_mod2 (x:Nat) : testBit x 0 = decide (x % 2 = 1) := by
   cases mod_two_eq_zero_or_one x with | _ p => simp [testBit, p]
@@ -211,9 +210,9 @@ private theorem succ_mod_2 : succ x % 2 = 1 - x % 2 := by
 
 
 private theorem testBit_succ_zero : testBit (x + 1) 0 = not (testBit x 0) := by
-  simp [testBit, succ_mod_2]
+  simp [testBit_to_div_mod, succ_mod_2]
   cases Nat.mod_two_eq_zero_or_one x with | _ p =>
-    simp [p, (by trivial : 1 != 0)]
+    simp [p]
 
 theorem testBit_two_pow_add_eq (x i : Nat)
     : testBit (2^i + x) i = not (testBit x i) := by
@@ -502,4 +501,4 @@ theorem testBit_shiftLeft (x:Nat) : testBit (x <<< i) j =
   simp [shiftLeft_eq, Nat.mul_comm _ (2^_), testBit_mul_pow_two]
 
 theorem testBit_shiftRight (x:Nat) : testBit (x >>> i) j = testBit x (i+j) := by
-  simp only [testBit, shiftRight_shiftRight]
+  simp [testBit, ←shiftRight_add]

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -51,10 +51,6 @@ noncomputable def div2Induction
       apply hyp
       exact Nat.div_lt_self n_pos (Nat.le_refl _)
 
-/--
-These theorems are needed for basic lemmas to equate proving properties of natural
-numbers with testBit.
--/
 @[simp]
 theorem and_zero (x:Nat) : x &&& 0 = 0 := by
   simp [HAnd.hAnd, AndOp.and, land]
@@ -71,6 +67,8 @@ theorem and_1_is_mod (x:Nat) : x &&& 1 = x % 2 := by
     simp [HAnd.hAnd, AndOp.and, land]
     unfold bitwise
     cases mod_two_eq_zero_or_one x with | _ p => simp [xz, p, andz, one_div_two]
+
+/-! ### testBit -/
 
 @[simp]
 theorem zero_testBit (i:Nat) : testBit 0 i = false := by
@@ -92,19 +90,6 @@ theorem testBit_to_div_mod {x : Nat} : testBit x i = decide (x / 2^i % 2 = 1) :=
   | succ i hyp =>
     simp [testBit_succ_div2, hyp,
           Nat.div_div_eq_div_mul, Nat.pow_succ, Nat.mul_comm 2]
-
-/-
-theorem testBit_to_div_mod {x : Nat} : testBit x i = decide (x / 2^i % 2 = 1) := by
-  induction i generalizing x with
-  | zero =>
-    unfold testBit
-    cases mod_two_eq_zero_or_one x with | _ xz => simp [xz]
-  | succ i hyp =>
-    simp [testBit_succ_div2, hyp,
-          Nat.div_div_eq_div_mul, Nat.pow_succ, Nat.mul_comm 2]
--/
-
-/-! ### testBit Principals -/
 
 theorem ne_zero_implies_bit_true {x : Nat} (xnz : x ≠ 0) : ∃ i, testBit x i := by
   induction x using div2Induction with
@@ -404,16 +389,16 @@ theorem and_lt_2_pow (x : Nat) {y n : Nat} (right : y < 2^n) : (x &&& y) < 2^n :
           exact pow_le_pow_of_le_right Nat.zero_lt_two i_ge_n
   simp [testBit_and, yf]
 
-theorem and_pow_2_is_mod (x n : Nat) : x &&& (2^n-1) = x % 2^n := by
+@[simp]
+theorem and_pow_two_is_mod (x n : Nat) : x &&& (2^n-1) = x % 2^n := by
   apply eq_of_testBit_eq
   intro i
   simp [testBit_and, testBit_mod_two_pow]
   cases testBit x i <;> simp
 
-@[simp]
-theorem and_pow_2_identity {x:Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
-  rw [and_pow_2_is_mod]
-  apply (Nat.mod_eq_of_lt lt)
+theorem and_pow_two_identity {x:Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
+  rw [and_pow_two_is_mod]
+  apply Nat.mod_eq_of_lt lt
 
 /-! ### lor -/
 

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -12,6 +12,7 @@ It is primarily intended to support the bitvector library.
 -/
 import Std.Data.Bool
 import Std.Data.Nat.Lemmas
+import Std.Tactic.RCases
 
 namespace Nat
 
@@ -237,20 +238,16 @@ theorem testBit_mod_two_pow (x j i : Nat) :
   induction x using Nat.strongInductionOn generalizing j i with
   | ind x hyp =>
     rw [mod_eq]
-    cases Nat.lt_or_ge x (2^j) with
-    | inl x_lt_j =>
-      have not_j_le_x := Nat.not_le_of_gt x_lt_j
+    rcases Nat.lt_or_ge x (2^j) with x_lt_j | x_ge_j
+    · have not_j_le_x := Nat.not_le_of_gt x_lt_j
       simp [not_j_le_x]
-      cases Nat.lt_or_ge i j with
-      | inl i_lt_j =>
-        simp [i_lt_j]
-      | inr i_ge_j =>
-      have x_lt : x < 2^i :=
-          calc x < 2^j := x_lt_j
-               _ ≤ 2^i := Nat.pow_le_pow_of_le_right Nat.zero_lt_two i_ge_j
-      simp [Nat.testBit_lt_two x_lt]
-    | inr x_ge_j =>
-      generalize y_eq : x - 2^j = y
+      rcases Nat.lt_or_ge i j with i_lt_j | i_ge_j
+      · simp [i_lt_j]
+      · have x_lt : x < 2^i :=
+            calc x < 2^j := x_lt_j
+                _ ≤ 2^i := Nat.pow_le_pow_of_le_right Nat.zero_lt_two i_ge_j
+        simp [Nat.testBit_lt_two x_lt]
+    · generalize y_eq : x - 2^j = y
       have x_eq : x = y + 2^j := Nat.eq_add_of_sub_eq x_ge_j y_eq
       simp [x_eq, Nat.le_add_left, Nat.pow_two_pos]
       have y_lt_x : y < x := by

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -52,7 +52,7 @@ noncomputable def div2Induction {motive : Nat → Sort u}
 @[simp] theorem zero_and (x : Nat) : 0 &&& x = 0 := by rfl
 
 @[simp] theorem and_zero (x : Nat) : x &&& 0 = 0 := by
-  simp [HAnd.hAnd, AndOp.and, land]
+  simp only [HAnd.hAnd, AndOp.and, land]
   unfold bitwise
   simp
 
@@ -61,8 +61,8 @@ noncomputable def div2Induction {motive : Nat → Sort u}
     simp [xz, zero_and]
   else
     have andz := and_zero (x/2)
-    simp [HAnd.hAnd, AndOp.and, land] at andz
-    simp [HAnd.hAnd, AndOp.and, land]
+    simp only [HAnd.hAnd, AndOp.and, land] at andz
+    simp only [HAnd.hAnd, AndOp.and, land]
     unfold bitwise
     cases mod_two_eq_zero_or_one x with | _ p =>
       simp [xz, p, andz, one_div_two, mod_eq_of_lt]
@@ -95,7 +95,7 @@ theorem ne_zero_implies_bit_true {x : Nat} (xnz : x ≠ 0) : ∃ i, testBit x i 
     match mod_two_eq_zero_or_one x with
     | Or.inl mod2_eq =>
       rw [←div_add_mod x 2] at xnz
-      simp [mod2_eq, mul_eq_zero] at xnz
+      simp only [mod2_eq, ne_eq, Nat.mul_eq_zero, Nat.add_zero, false_or] at xnz
       have ⟨d, dif⟩   := hyp x_pos xnz
       apply Exists.intro (d+1)
       simp [testBit_succ_div2, dif]
@@ -109,24 +109,22 @@ theorem ne_implies_bit_diff {x y : Nat} (p : x ≠ y) : ∃ i, testBit x i ≠ t
     cases Nat.eq_zero_or_pos y with
     | inl yz =>
       simp only [yz, Nat.zero_testBit, Bool.eq_false_iff]
-      simp [yz] at p
+      simp only [yz] at p
       have ⟨i,ip⟩  := ne_zero_implies_bit_true p
       apply Exists.intro i
       simp [ip]
     | inr ypos =>
       if lsb_diff : x % 2 = y % 2 then
         rw [←Nat.div_add_mod x 2, ←Nat.div_add_mod y 2] at p
-        simp [lsb_diff,
-              Nat.add_right_cancel_iff,
-              Nat.mul_left_cancel_iff]
-          at p
+        simp only [ne_eq, lsb_diff, Nat.add_right_cancel_iff,
+          Nat.zero_lt_succ, Nat.mul_left_cancel_iff] at p
         have ⟨i, ieq⟩  := hyp ypos p
         apply Exists.intro (i+1)
         simp [testBit_succ_div2]
         exact ieq
       else
         apply Exists.intro 0
-        simp [testBit_zero_is_mod2]
+        simp only [testBit_zero_is_mod2]
         revert lsb_diff
         cases mod_two_eq_zero_or_one x with | _ p =>
           cases mod_two_eq_zero_or_one y with | _ q =>
@@ -223,7 +221,7 @@ theorem testBit_two_pow_add_gt {i j : Nat} (j_lt_i : j < i) (x : Nat) :
     testBit (2^i + x) j = testBit x j := by
   have i_def : i = j + (i-j) := (Nat.add_sub_cancel' (Nat.le_of_lt j_lt_i)).symm
   rw [i_def]
-  simp [testBit_to_div_mod, Nat.pow_add,
+  simp only [testBit_to_div_mod, Nat.pow_add,
         Nat.add_comm x, Nat.mul_add_div (Nat.pow_two_pos _)]
   match i_sub_j_eq : i - j with
   | 0 =>
@@ -249,11 +247,11 @@ theorem testBit_mod_two_pow (x j i : Nat) :
         simp [Nat.testBit_lt_two x_lt]
     · generalize y_eq : x - 2^j = y
       have x_eq : x = y + 2^j := Nat.eq_add_of_sub_eq x_ge_j y_eq
-      simp [x_eq, Nat.le_add_left, Nat.pow_two_pos]
+      simp only [Nat.pow_two_pos, x_eq, Nat.le_add_left, true_and, ite_true]
       have y_lt_x : y < x := by
             simp [x_eq]
             exact Nat.lt_add_of_pos_right (Nat.pow_two_pos j)
-      simp [hyp y y_lt_x]
+      simp only [hyp y y_lt_x]
       if i_lt_j : i < j then
         rw [ Nat.add_comm _ (2^_), testBit_two_pow_add_gt i_lt_j]
       else
@@ -303,7 +301,7 @@ theorem testBit_bitwise
         cases xi : testBit x i <;>
           simp [p, xi, false_false_axiom]
     else
-      simp [x_zero, y_zero, ←Nat.two_mul]
+      simp only [x_zero, y_zero, ←Nat.two_mul]
       cases i with
       | zero =>
         cases p : f (decide (x % 2 = 1)) (decide (y % 2 = 1)) <;>
@@ -382,7 +380,7 @@ theorem and_lt_2_pow (x : Nat) {y n : Nat} (right : y < 2^n) : (x &&& y) < 2^n :
 @[simp] theorem and_pow_two_is_mod (x n : Nat) : x &&& (2^n-1) = x % 2^n := by
   apply eq_of_testBit_eq
   intro i
-  simp [testBit_and, testBit_mod_two_pow]
+  simp only [testBit_and, testBit_mod_two_pow]
   cases testBit x i <;> simp
 
 theorem and_pow_two_identity {x : Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
@@ -392,12 +390,12 @@ theorem and_pow_two_identity {x : Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
 /-! ### lor -/
 
 @[simp] theorem or_zero (x : Nat) : 0 ||| x = x := by
-  simp [HOr.hOr, OrOp.or, lor]
+  simp only [HOr.hOr, OrOp.or, lor]
   unfold bitwise
   simp [@eq_comm _ 0]
 
 @[simp] theorem zero_or (x : Nat) : x ||| 0 = x := by
-  simp [HOr.hOr, OrOp.or, lor]
+  simp only [HOr.hOr, OrOp.or, lor]
   unfold bitwise
   simp [@eq_comm _ 0]
 
@@ -425,7 +423,7 @@ theorem testBit_mul_pow_two_add (a : Nat) {b i : Nat} (b_lt : b < 2^i) (j : Nat)
         testBit a (j - i) := by
   cases Nat.lt_or_ge j i with
   | inl j_lt =>
-    simp [j_lt]
+    simp only [j_lt]
     have i_ge := Nat.le_of_lt j_lt
     have i_sub_j_nez : i-j ≠ 0 := Nat.sub_ne_zero_of_lt j_lt
     have i_def : i = j + succ (pred (i-j)) :=
@@ -460,7 +458,7 @@ theorem testBit_mul_pow_two :
 theorem mul_add_lt_is_or {b : Nat} (b_lt : b < 2^i) (a : Nat) : 2^i * a + b = 2^i * a ||| b := by
   apply eq_of_testBit_eq
   intro j
-  simp [testBit_mul_pow_two_add _ b_lt,
+  simp only [testBit_mul_pow_two_add _ b_lt,
         testBit_or, testBit_mul_pow_two]
   if j_lt : j < i then
     simp [Nat.not_le_of_lt, j_lt]
@@ -474,7 +472,7 @@ theorem mul_add_lt_is_or {b : Nat} (b_lt : b < 2^i) (a : Nat) : 2^i * a + b = 2^
 /-! ### shiftLeft and shiftRight -/
 
 theorem testBit_shiftLeft (x : Nat) : testBit (x <<< i) j =
-  (decide (j ≥ i) && testBit x (j-i)) := by
+    (decide (j ≥ i) && testBit x (j-i)) := by
   simp [shiftLeft_eq, Nat.mul_comm _ (2^_), testBit_mul_pow_two]
 
 theorem testBit_shiftRight (x : Nat) : testBit (x >>> i) j = testBit x (i+j) := by

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -18,8 +18,7 @@ namespace Nat
 @[local simp]
 private theorem one_div_two : 1/2 = 0 := by trivial
 
-private
-theorem two_pow_succ_sub_one_div : (2 ^ (n+1) - 1) / 2 = 2^n - 1 := by
+private theorem two_pow_succ_sub_one_div : (2 ^ (n+1) - 1) / 2 = 2^n - 1 := by
   apply fun x => (Nat.sub_eq_of_eq_add x).symm
   apply Eq.trans _
   apply Nat.add_mul_div_left _ _ Nat.zero_lt_two
@@ -27,8 +26,7 @@ theorem two_pow_succ_sub_one_div : (2 ^ (n+1) - 1) / 2 = 2^n - 1 := by
   rw [ Nat.add_sub_assoc Nat.zero_lt_two ]
   simp [Nat.pow_succ, Nat.mul_comm _ 2, Nat.mul_add_div]
 
-private
-theorem two_mul_sub_one (n:Nat) (n_pos : n > 0) : (2*n - 1) % 2 = 1 := by
+private theorem two_mul_sub_one {n : Nat} (n_pos : n > 0) : (2*n - 1) % 2 = 1 := by
   match n with
   | 0 => contradiction
   | n + 1 => simp [Nat.mul_succ, Nat.mul_add_mod, mod_eq_of_lt]
@@ -38,11 +36,8 @@ theorem two_mul_sub_one (n:Nat) (n_pos : n > 0) : (2*n - 1) % 2 = 1 := by
 /--
 An induction principal that works on divison by two.
 -/
-noncomputable def div2Induction
-    {motive : Nat → Sort u}
-    (n : Nat)
-    (ind : ∀(n:Nat), (n > 0 → motive (n/2)) → motive n)
-    : motive n := by
+noncomputable def div2Induction {motive : Nat → Sort u}
+    (n : Nat) (ind : ∀(n : Nat), (n > 0 → motive (n/2)) → motive n) : motive n := by
   induction n using Nat.strongInductionOn with
   | ind n hyp =>
     apply ind
@@ -53,17 +48,14 @@ noncomputable def div2Induction
       apply hyp
       exact Nat.div_lt_self n_pos (Nat.le_refl _)
 
-@[simp]
-theorem zero_and (x:Nat) : 0 &&& x = 0 := by rfl
+@[simp] theorem zero_and (x : Nat) : 0 &&& x = 0 := by rfl
 
-@[simp]
-theorem and_zero (x:Nat) : x &&& 0 = 0 := by
+@[simp] theorem and_zero (x : Nat) : x &&& 0 = 0 := by
   simp [HAnd.hAnd, AndOp.and, land]
   unfold bitwise
   simp
 
-@[simp]
-theorem and_one_is_mod (x:Nat) : x &&& 1 = x % 2 := by
+@[simp] theorem and_one_is_mod (x : Nat) : x &&& 1 = x % 2 := by
   if xz : x = 0 then
     simp [xz, zero_and]
   else
@@ -76,14 +68,13 @@ theorem and_one_is_mod (x:Nat) : x &&& 1 = x % 2 := by
 
 /-! ### testBit -/
 
-@[simp]
-theorem zero_testBit (i:Nat) : testBit 0 i = false := by
+@[simp] theorem zero_testBit (i : Nat) : testBit 0 i = false := by
   simp only [testBit, zero_shiftRight, zero_and, bne_self_eq_false]
 
-theorem testBit_zero_is_mod2 (x:Nat) : testBit x 0 = decide (x % 2 = 1) := by
+theorem testBit_zero_is_mod2 (x : Nat) : testBit x 0 = decide (x % 2 = 1) := by
   cases mod_two_eq_zero_or_one x with | _ p => simp [testBit, p]
 
-theorem testBit_succ_div2 (x i :Nat) : testBit x (succ i) = testBit (x/2) i := by
+theorem testBit_succ_div2 (x i : Nat) : testBit x (succ i) = testBit (x/2) i := by
   unfold testBit
   simp [shiftRight_succ_inside]
 
@@ -187,7 +178,7 @@ theorem testBit_lt_two {x i : Nat} (lt : x < 2^i) : x.testBit i = false := by
     exfalso
     exact Nat.not_le_of_gt lt (testBit_implies_ge p)
 
-theorem lt_pow_two_of_testBit (x:Nat) (p : ∀i, i ≥ n → testBit x i = false) : x < 2^n := by
+theorem lt_pow_two_of_testBit (x : Nat) (p : ∀i, i ≥ n → testBit x i = false) : x < 2^n := by
   by_contra not_lt
   have x_ge_n := Nat.ge_of_not_lt not_lt
   have ⟨i, ⟨i_ge_n, test_true⟩⟩ := ge_two_pow_implies_high_bit_true x_ge_n
@@ -210,14 +201,13 @@ private theorem testBit_succ_zero : testBit (x + 1) 0 = not (testBit x 0) := by
   cases Nat.mod_two_eq_zero_or_one x with | _ p =>
     simp [p]
 
-theorem testBit_two_pow_add_eq (x i : Nat)
-    : testBit (2^i + x) i = not (testBit x i) := by
+theorem testBit_two_pow_add_eq (x i : Nat) : testBit (2^i + x) i = not (testBit x i) := by
   simp [testBit_to_div_mod, add_div_left, Nat.pow_two_pos, succ_mod_2]
   cases mod_two_eq_zero_or_one (x / 2 ^ i) with
   | _ p => simp [p]
 
-theorem testBit_mul_two_pow_add_eq (a b i : Nat)
-    : testBit (2^i*a + b) i = Bool.xor (a%2 = 1) (testBit b i) := by
+theorem testBit_mul_two_pow_add_eq (a b i : Nat) :
+    testBit (2^i*a + b) i = Bool.xor (a%2 = 1) (testBit b i) := by
   match a with
   | 0 => simp
   | a+1 =>
@@ -228,8 +218,8 @@ theorem testBit_mul_two_pow_add_eq (a b i : Nat)
     cases mod_two_eq_zero_or_one a with
     | _ p => simp [p]
 
-theorem testBit_two_pow_add_gt {i j : Nat} (j_lt_i : j < i) (x : Nat)
-    : testBit (2^i + x) j = testBit x j := by
+theorem testBit_two_pow_add_gt {i j : Nat} (j_lt_i : j < i) (x : Nat) :
+    testBit (2^i + x) j = testBit x j := by
   have i_def : i = j + (i-j) := (Nat.add_sub_cancel' (Nat.le_of_lt j_lt_i)).symm
   rw [i_def]
   simp [testBit_to_div_mod, Nat.pow_add,
@@ -274,8 +264,7 @@ theorem testBit_mod_two_pow (x j i : Nat) :
 
 private theorem testBit_one_zero : testBit 1 0 = true := by trivial
 
-@[simp]
-theorem testBit_two_pow_sub_one (n i : Nat) : testBit (2^n-1) i = decide (i < n) := by
+@[simp] theorem testBit_two_pow_sub_one (n i : Nat) : testBit (2^n-1) i = decide (i < n) := by
   induction i generalizing n with
   | zero =>
     simp [testBit_zero_is_mod2]
@@ -292,8 +281,8 @@ theorem testBit_two_pow_sub_one (n i : Nat) : testBit (2^n-1) i = decide (i < n)
     | n+1 =>
       simp [two_pow_succ_sub_one_div, hyp, Nat.succ_lt_succ_iff]
 
-theorem testBit_bool_to_nat (b : Bool) (i : Nat)
-    : testBit (Bool.toNat b) i = (decide (i = 0) && b) := by
+theorem testBit_bool_to_nat (b : Bool) (i : Nat) :
+    testBit (Bool.toNat b) i = (decide (i = 0) && b) := by
   cases b <;> cases i <;>
   simp [testBit_to_div_mod, Nat.pow_succ, Nat.mul_comm _ 2,
         ←Nat.div_div_eq_div_mul _ 2, one_div_two,
@@ -330,7 +319,7 @@ theorem testBit_bitwise
 /-! ### bitwise -/
 
 @[local simp]
-private theorem eq_0_of_lt_one (x:Nat) : x < 1 ↔ x = 0 :=
+private theorem eq_0_of_lt_one (x : Nat) : x < 1 ↔ x = 0 :=
   Iff.intro
     (fun p =>
       match x with
@@ -338,18 +327,17 @@ private theorem eq_0_of_lt_one (x:Nat) : x < 1 ↔ x = 0 :=
       | _+1 => False.elim (not_lt_zero _ (Nat.lt_of_succ_lt_succ p)))
     (fun p => by simp [p, Nat.zero_lt_succ])
 
-private theorem eq_0_of_lt (x:Nat) : x < 2^ 0 ↔ x = 0 := eq_0_of_lt_one x
+private theorem eq_0_of_lt (x : Nat) : x < 2^ 0 ↔ x = 0 := eq_0_of_lt_one x
 
 @[local simp]
-private theorem zero_lt_pow (n:Nat) : 0 < 2^n := by
+private theorem zero_lt_pow (n : Nat) : 0 < 2^n := by
   induction n
   case zero => simp [eq_0_of_lt]
   case succ n hyp =>
     simp [pow_succ]
     exact (Nat.mul_lt_mul_of_pos_right hyp Nat.zero_lt_two : 0 < 2 ^ n * 2)
 
-private
-theorem div_2_le_of_lt_two {m n : Nat} (p : m < 2 ^ succ n) : m / 2 < 2^n := by
+private theorem div_2_le_of_lt_two {m n : Nat} (p : m < 2 ^ succ n) : m / 2 < 2^n := by
   simp [div_lt_iff_lt_mul Nat.zero_lt_two]
   exact p
 
@@ -394,27 +382,24 @@ theorem and_lt_2_pow (x : Nat) {y n : Nat} (right : y < 2^n) : (x &&& y) < 2^n :
           exact pow_le_pow_of_le_right Nat.zero_lt_two i_ge_n
   simp [testBit_and, yf]
 
-@[simp]
-theorem and_pow_two_is_mod (x n : Nat) : x &&& (2^n-1) = x % 2^n := by
+@[simp] theorem and_pow_two_is_mod (x n : Nat) : x &&& (2^n-1) = x % 2^n := by
   apply eq_of_testBit_eq
   intro i
   simp [testBit_and, testBit_mod_two_pow]
   cases testBit x i <;> simp
 
-theorem and_pow_two_identity {x:Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
+theorem and_pow_two_identity {x : Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
   rw [and_pow_two_is_mod]
   apply Nat.mod_eq_of_lt lt
 
 /-! ### lor -/
 
-@[simp]
-theorem or_zero (x:Nat) : 0 ||| x = x := by
+@[simp] theorem or_zero (x : Nat) : 0 ||| x = x := by
   simp [HOr.hOr, OrOp.or, lor]
   unfold bitwise
   simp [@eq_comm _ 0]
 
-@[simp]
-theorem zero_or (x:Nat) : x ||| 0 = x := by
+@[simp] theorem zero_or (x : Nat) : x ||| 0 = x := by
   simp [HOr.hOr, OrOp.or, lor]
   unfold bitwise
   simp [@eq_comm _ 0]
@@ -435,12 +420,12 @@ theorem xor_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ^^^ y 
 
 /-! ### Arithmetic -/
 
-theorem testBit_mul_pow_two_add (a:Nat) {b i:Nat} (b_lt : b < 2^i) (j:Nat)
-  : testBit (2 ^ i * a + b) j =
-    if j < i then
-      testBit b j
-    else
-      testBit a (j - i) := by
+theorem testBit_mul_pow_two_add (a : Nat) {b i : Nat} (b_lt : b < 2^i) (j : Nat) :
+    testBit (2 ^ i * a + b) j =
+      if j < i then
+        testBit b j
+      else
+        testBit a (j - i) := by
   cases Nat.lt_or_ge j i with
   | inl j_lt =>
     simp [j_lt]
@@ -467,16 +452,15 @@ theorem testBit_mul_pow_two_add (a:Nat) {b i:Nat} (b_lt : b < 2^i) (j:Nat)
           Nat.div_eq_of_lt b_lt,
           Nat.pow_two_pos i]
 
-theorem testBit_mul_pow_two
-  : testBit (2 ^ i * a) j = (decide (j ≥ i) && testBit a (j-i)) := by
+theorem testBit_mul_pow_two :
+    testBit (2 ^ i * a) j = (decide (j ≥ i) && testBit a (j-i)) := by
   have gen := testBit_mul_pow_two_add a (Nat.pow_two_pos i) j
   simp at gen
   rw [gen]
   cases Nat.lt_or_ge j i with
   | _ p => simp [p, Nat.not_le_of_lt, Nat.not_lt_of_le]
 
-theorem mul_add_lt_is_or {b:Nat} (b_lt : b < 2^i) (a:Nat)
-  : 2^i * a + b = 2^i * a ||| b := by
+theorem mul_add_lt_is_or {b : Nat} (b_lt : b < 2^i) (a : Nat) : 2^i * a + b = 2^i * a ||| b := by
   apply eq_of_testBit_eq
   intro j
   simp [testBit_mul_pow_two_add _ b_lt,
@@ -492,9 +476,9 @@ theorem mul_add_lt_is_or {b:Nat} (b_lt : b < 2^i) (a:Nat)
 
 /-! ### shiftLeft and shiftRight -/
 
-theorem testBit_shiftLeft (x:Nat) : testBit (x <<< i) j =
+theorem testBit_shiftLeft (x : Nat) : testBit (x <<< i) j =
   (decide (j ≥ i) && testBit x (j-i)) := by
   simp [shiftLeft_eq, Nat.mul_comm _ (2^_), testBit_mul_pow_two]
 
-theorem testBit_shiftRight (x:Nat) : testBit (x >>> i) j = testBit x (i+j) := by
+theorem testBit_shiftRight (x : Nat) : testBit (x >>> i) j = testBit x (i+j) := by
   simp [testBit, ←shiftRight_add]

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2023 Lean FRO. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joe Hendrix
+-/
+
+/-
+This module defines properties of the bitwise operations on Natural numbers.
+
+It is primarily intended to support the bitvector library.
+-/
+import Std.Data.Nat.Lemmas
+
+namespace Nat
+
+@[local simp]
+private theorem eq_0_of_lt_one (x:Nat) : x < 1 ↔ x = 0 :=
+  Iff.intro
+    (fun p =>
+      match x with
+      | 0 => Eq.refl 0
+      | _+1 => False.elim (not_lt_zero _ (Nat.lt_of_succ_lt_succ p)))
+    (fun p => by simp [p, Nat.zero_lt_succ])
+
+private theorem eq_0_of_lt (x:Nat) : x < 2^ 0 ↔ x = 0 := eq_0_of_lt_one x
+
+@[local simp]
+private theorem zero_lt_pow (n:Nat) : 0 < 2^n := by
+  induction n
+  case zero => simp [eq_0_of_lt]
+  case succ n hyp =>
+    simp [pow_succ]
+    exact (Nat.mul_lt_mul_of_pos_right hyp (by trivial : 2 > 0) : 0 < 2 ^ n * 2)
+
+/-- This provides a bound on bitwise operations. -/
+theorem bitwise_lt_2_pow (left : x < 2^n) (right : y < 2^n) : (Nat.bitwise f x y) < 2^n := by
+  induction n generalizing x y with
+  | zero =>
+    simp only [eq_0_of_lt] at left right
+    unfold bitwise
+    simp [left, right]
+  | succ n hyp =>
+    unfold bitwise
+    if x_zero : x = 0 then
+      simp only [x_zero, if_true]
+      by_cases p : f false true = true <;> simp [p, right]
+    else if y_zero : y = 0 then
+      simp only [x_zero, y_zero, if_false, if_true]
+      by_cases p : f true false = true <;> simp [p, left]
+    else
+      simp only [x_zero, y_zero, if_false]
+      have lt : 0 < 2 := by trivial
+      have xlb : x / 2 < 2^n := by simp [div_lt_iff_lt_mul lt]; exact left
+      have ylb : y / 2 < 2^n := by simp [div_lt_iff_lt_mul lt]; exact right
+      have hyp1 := hyp xlb ylb
+      by_cases p : f (decide (x % 2 = 1)) (decide (y % 2 = 1)) = true <;>
+        simp [p, pow_succ, mul_succ, Nat.add_assoc]
+      case pos =>
+        apply lt_of_succ_le
+        simp only [← Nat.succ_add]
+        apply Nat.add_le_add <;> exact hyp1
+      case neg =>
+        apply Nat.add_lt_add <;> exact hyp1
+
+theorem lor_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : (x ||| y) < 2^n :=
+  bitwise_lt_2_pow left right
+
+theorem land_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : (x &&& y) < 2^n :=
+  bitwise_lt_2_pow left right
+
+theorem xor_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : (x ^^^ y) < 2^n :=
+  bitwise_lt_2_pow left right
+
+theorem shiftLeft_lt_2_pow {x m n : Nat} (bound : x < 2^(n-m)) : (x <<< m) < 2^n := by
+  induction m generalizing x n with
+  | zero => exact bound
+  | succ m hyp =>
+    simp [shiftLeft_succ_inside]
+    apply hyp
+    revert bound
+    rw [Nat.sub_succ]
+    match n - m with
+    | 0 =>
+      intro bound
+      simp [eq_0_of_lt_one] at bound
+      simp [bound]
+    | d + 1 =>
+      intro bound
+      simp [Nat.pow_succ, Nat.mul_comm _ 2]
+      exact Nat.mul_lt_mul_of_pos_left bound (by trivial : 0 < 2)
+
+end Nat

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -208,7 +208,6 @@ private theorem succ_mod_2 : succ x % 2 = 1 - x % 2 := by
     simp [Nat.mod_eq (x+2) 2, p, hyp]
     cases Nat.mod_two_eq_zero_or_one x with | _ p => simp [p]
 
-
 private theorem testBit_succ_zero : testBit (x + 1) 0 = not (testBit x 0) := by
   simp [testBit_to_div_mod, succ_mod_2]
   cases Nat.mod_two_eq_zero_or_one x with | _ p =>
@@ -246,8 +245,8 @@ theorem testBit_two_pow_add_gt {i j : Nat} (j_lt_i : j < i) (x : Nat)
   | d+1 =>
     simp [pow_succ, Nat.mul_comm _ 2,  Nat.mul_add_mod]
 
-
-theorem testBit_mod_two_pow (x j i : Nat) : testBit (x % 2^j) i = (decide (i < j) && testBit x i) := by
+theorem testBit_mod_two_pow (x j i : Nat) :
+    testBit (x % 2^j) i = (decide (i < j) && testBit x i) := by
   induction x using Nat.strongInductionOn generalizing j i with
   | ind x hyp =>
     rw [mod_eq]
@@ -411,7 +410,6 @@ theorem and_pow_two_identity {x:Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
 
 /-! ### lor -/
 
-
 @[simp]
 theorem or_zero (x:Nat) : 0 ||| x = x := by
   simp [HOr.hOr, OrOp.or, lor]
@@ -429,7 +427,6 @@ theorem testBit_or (x y i : Nat) : (x ||| y).testBit i = (x.testBit i || y.testB
 
 theorem or_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ||| y < 2^n :=
   bitwise_lt_2_pow left right
-
 
 /-! ### xor -/
 
@@ -491,7 +488,9 @@ theorem mul_add_lt_is_or {b:Nat} (b_lt : b < 2^i) (a:Nat)
     simp [Nat.not_le_of_lt, j_lt]
   else
     have i_le : i ≤ j := Nat.le_of_not_lt j_lt
-    have b_lt_j : b < 2 ^ j := Nat.lt_of_lt_of_le b_lt (Nat.pow_le_pow_of_le_right Nat.zero_lt_two i_le)
+    have b_lt_j :=
+            calc b < 2 ^ i := b_lt
+                 _ ≤ 2 ^ j := Nat.pow_le_pow_of_le_right Nat.zero_lt_two i_le
     simp [i_le, j_lt, testBit_lt_two, b_lt_j]
 
 /-! ### shiftLeft and shiftRight -/

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -14,6 +14,112 @@ import Std.Data.Nat.Lemmas
 
 namespace Nat
 
+/-! ### Utility -/
+
+/--
+An induction principal that works on divison by two.
+-/
+theorem div2InductionOn
+    {motive : Nat → Sort u}
+    (n : Nat)
+    (base : motive 0)
+    (induct : ∀(n:Nat), 0 < n → motive (n/2) → motive n)
+    : motive n := by
+  induction n using Nat.strongInductionOn with
+  | ind x ind =>
+    if x_eq : x = 0 then
+      simp [x_eq]; exact base
+    else
+      have x_pos : x > 0 := Nat.zero_lt_of_ne_zero x_eq
+      have p : x/2 < x := Nat.div_lt_self x_pos (Nat.le_refl _)
+      apply induct _ x_pos (ind _ p)
+
+
+/-! ### testBit -/
+
+theorem zero_testBit (i:Nat) : testBit 0 i = false := by
+  unfold testBit
+  simp [zero_shiftRight]
+
+theorem testBit_succ (x:Nat) : testBit x (succ i) = testBit (x >>> 1) i := by
+  unfold testBit
+  simp [shiftRight_succ_inside]
+
+theorem land_zero (x:Nat) : x &&& 0 = 0 := by
+  simp [HAnd.hAnd, AndOp.and, land]
+  unfold bitwise
+  simp
+
+theorem testBit_zero_is_mod2 (x:Nat) : testBit x 0 = decide (x % 2 = 1) := by
+  rw [←div_add_mod x 2]
+  simp [testBit]
+  simp [HAnd.hAnd, AndOp.and, land]
+  unfold bitwise
+  have one_div_2 : 1 / 2 = 0 := by trivial
+  have elim_and := fun x => land_zero x
+  simp [HAnd.hAnd, AndOp.and, land] at elim_and
+  simp [one_div_2, elim_and]
+  simp [Nat.add_comm (2 * _) _]
+  intro x_mod
+  simp [x_mod, Nat.succ_add]
+
+theorem ne_zero_implies_bit_true {x : Nat} (p : x ≠ 0) : ∃ i, testBit x i := by
+  induction x using div2InductionOn with
+  | base =>
+    trivial
+  | induct x _ ind =>
+    match mod_two_eq_zero_or_one x with
+    | Or.inl mod2_eq =>
+      rw [←div_add_mod x 2] at p
+      simp [mod2_eq, mul_eq_zero] at p
+      have ⟨d, dif⟩   := ind (p : x / 2 ≠ 0)
+      apply Exists.intro (d+1)
+      simp [testBit_succ]
+      exact dif
+    | Or.inr mod2_eq =>
+      apply Exists.intro 0
+      simp [testBit_zero_is_mod2, mod2_eq]
+
+theorem ne_implies_bit_diff {x y : Nat} (p : x ≠ y) : ∃ i, testBit x i ≠ testBit y i := by
+  induction y using Nat.div2InductionOn generalizing x with
+  | base =>
+    simp only [Nat.zero_testBit, Bool.eq_false_iff]
+    have ⟨i,ip⟩  := ne_zero_implies_bit_true p
+    apply Exists.intro i
+    simp [ip]
+  | induct y _y_pos ind_y =>
+    if lsb_diff : x % 2 = y % 2 then
+      rw [←Nat.div_add_mod x 2, ←Nat.div_add_mod y 2] at p
+      simp [lsb_diff,
+            Nat.add_right_cancel_iff,
+            Nat.mul_left_cancel_iff]
+        at p
+      have ⟨i, ieq⟩  := ind_y p
+      apply Exists.intro (i+1)
+      simp [testBit_succ]
+      exact ieq
+    else
+      apply Exists.intro 0
+      simp [testBit_zero_is_mod2]
+      revert lsb_diff
+      cases mod_two_eq_zero_or_one x with | _ p =>
+        cases mod_two_eq_zero_or_one y with | _ q =>
+          simp [p,q]
+
+/--
+`eq_of_testBit_eq` allows proving two natural numbers are equal
+if their bits are all equal.
+-/
+theorem eq_of_testBit_eq {x y : Nat} (pred : ∀i, testBit x i = testBit y i) : x = y := by
+  if h : x = y then
+    exact h
+  else
+    let ⟨i,eq⟩ := ne_implies_bit_diff h
+    have p := pred i
+    contradiction
+
+/-! ### bitwise and related -/
+
 @[local simp]
 private theorem eq_0_of_lt_one (x:Nat) : x < 1 ↔ x = 0 :=
   Iff.intro
@@ -89,5 +195,3 @@ theorem shiftLeft_lt_2_pow {x m n : Nat} (bound : x < 2^(n-m)) : (x <<< m) < 2^n
       intro bound
       simp [Nat.pow_succ, Nat.mul_comm _ 2]
       exact Nat.mul_lt_mul_of_pos_left bound (by trivial : 0 < 2)
-
-end Nat

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -1,5 +1,6 @@
 /-
-Copyright (c) 2023 Lean FRO. All rights reserved.
+Copyright (c) 2023 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joe Hendrix
 -/

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -10,29 +10,332 @@ This module defines properties of the bitwise operations on Natural numbers.
 
 It is primarily intended to support the bitvector library.
 -/
+import Std.Data.Bool
 import Std.Data.Nat.Lemmas
 
 namespace Nat
 
-/-! ### Utility -/
+@[local simp]
+private theorem one_div_two : 1/2 = 0 := by trivial
+
+theorem two_pow_succ_sub_one_div : (2 ^ (n+1) - 1) / 2 = 2^n - 1 := by
+  apply fun x => (Nat.sub_eq_of_eq_add x).symm
+  apply Eq.trans _
+  apply Nat.add_mul_div_left _ _ Nat.zero_lt_two
+  rw [Nat.mul_one, ←Nat.sub_add_comm (Nat.pow_two_pos _)]
+  rw [ Nat.add_sub_assoc Nat.zero_lt_two ]
+  simp [Nat.pow_succ, Nat.mul_comm _ 2, Nat.mul_add_div]
+
+theorem two_mul_sub_one (n:Nat) (n_pos : n > 0) : (2*n - 1) % 2 = 1 := by
+  match n with
+  | 0 => contradiction
+  | n + 1 => simp [Nat.mul_succ, Nat.mul_add_mod]
+
+/-! ### Preliminaries -/
 
 /--
 An induction principal that works on divison by two.
 -/
-noncomputable def div2InductionOn
+noncomputable def div2Induction
     {motive : Nat → Sort u}
     (n : Nat)
-    (base : motive 0)
-    (induct : ∀(n:Nat), 0 < n → motive (n/2) → motive n)
+    (ind : ∀(n:Nat), (n > 0 → motive (n/2)) → motive n)
     : motive n := by
   induction n using Nat.strongInductionOn with
-  | ind x ind =>
-    if x_eq : x = 0 then
-      simp [x_eq]; exact base
+  | ind n hyp =>
+    apply ind
+    intro n_pos
+    if n_eq : n = 0 then
+      simp [n_eq] at n_pos
     else
-      have x_pos : x > 0 := Nat.zero_lt_of_ne_zero x_eq
-      have p : x/2 < x := Nat.div_lt_self x_pos (Nat.le_refl _)
-      apply induct _ x_pos (ind _ p)
+      apply hyp
+      exact Nat.div_lt_self n_pos (Nat.le_refl _)
+
+/--
+These theorems are needed for basic lemmas to equate proving properties of natural
+numbers with testBit.
+-/
+@[simp]
+theorem and_zero (x:Nat) : x &&& 0 = 0 := by
+  simp [HAnd.hAnd, AndOp.and, land]
+  unfold bitwise
+  simp
+
+@[simp]
+theorem and_1_is_mod (x:Nat) : x &&& 1 = x % 2 := by
+  if xz : x = 0 then
+    simp [xz]
+  else
+    have andz := and_zero (x/2)
+    simp [HAnd.hAnd, AndOp.and, land] at andz
+    simp [HAnd.hAnd, AndOp.and, land]
+    unfold bitwise
+    cases mod_two_eq_zero_or_one x with | _ p => simp [xz, p, andz, one_div_two]
+
+@[simp]
+theorem zero_testBit (i:Nat) : testBit 0 i = false := by
+  unfold testBit
+  simp [zero_shiftRight]
+
+theorem testBit_zero_is_mod2 (x:Nat) : testBit x 0 = decide (x % 2 = 1) := by
+  cases mod_two_eq_zero_or_one x with | _ p => simp [testBit, p]
+
+theorem testBit_succ_div2 (x i :Nat) : testBit x (succ i) = testBit (x/2) i := by
+  unfold testBit
+  simp [shiftRight_succ_inside]
+
+theorem testBit_to_div_mod {x : Nat} : testBit x i = decide (x / 2^i % 2 = 1) := by
+  induction i generalizing x with
+  | zero =>
+    unfold testBit
+    cases mod_two_eq_zero_or_one x with | _ xz => simp [xz]
+  | succ i hyp =>
+    simp [testBit_succ_div2, hyp,
+          Nat.div_div_eq_div_mul, Nat.pow_succ, Nat.mul_comm 2]
+
+/-
+theorem testBit_to_div_mod {x : Nat} : testBit x i = decide (x / 2^i % 2 = 1) := by
+  induction i generalizing x with
+  | zero =>
+    unfold testBit
+    cases mod_two_eq_zero_or_one x with | _ xz => simp [xz]
+  | succ i hyp =>
+    simp [testBit_succ_div2, hyp,
+          Nat.div_div_eq_div_mul, Nat.pow_succ, Nat.mul_comm 2]
+-/
+
+/-! ### testBit Principals -/
+
+theorem ne_zero_implies_bit_true {x : Nat} (xnz : x ≠ 0) : ∃ i, testBit x i := by
+  induction x using div2Induction with
+  | ind x hyp =>
+    have x_pos : x > 0 := Nat.pos_of_ne_zero xnz
+    match mod_two_eq_zero_or_one x with
+    | Or.inl mod2_eq =>
+      rw [←div_add_mod x 2] at xnz
+      simp [mod2_eq, mul_eq_zero] at xnz
+      have ⟨d, dif⟩   := hyp x_pos xnz
+      apply Exists.intro (d+1)
+      simp [testBit_succ_div2, dif]
+    | Or.inr mod2_eq =>
+      apply Exists.intro 0
+      simp [testBit_zero_is_mod2, mod2_eq]
+
+theorem ne_implies_bit_diff {x y : Nat} (p : x ≠ y) : ∃ i, testBit x i ≠ testBit y i := by
+  induction y using Nat.div2Induction generalizing x with
+  | ind y hyp =>
+    cases Nat.eq_zero_or_pos y with
+    | inl yz =>
+      simp only [yz, Nat.zero_testBit, Bool.eq_false_iff]
+      simp [yz] at p
+      have ⟨i,ip⟩  := ne_zero_implies_bit_true p
+      apply Exists.intro i
+      simp [ip]
+    | inr ypos =>
+      if lsb_diff : x % 2 = y % 2 then
+        rw [←Nat.div_add_mod x 2, ←Nat.div_add_mod y 2] at p
+        simp [lsb_diff,
+              Nat.add_right_cancel_iff,
+              Nat.mul_left_cancel_iff]
+          at p
+        have ⟨i, ieq⟩  := hyp ypos p
+        apply Exists.intro (i+1)
+        simp [testBit_succ_div2]
+        exact ieq
+      else
+        apply Exists.intro 0
+        simp [testBit_zero_is_mod2]
+        revert lsb_diff
+        cases mod_two_eq_zero_or_one x with | _ p =>
+          cases mod_two_eq_zero_or_one y with | _ q =>
+            simp [p,q]
+
+/--
+`eq_of_testBit_eq` allows proving two natural numbers are equal
+if their bits are all equal.
+-/
+theorem eq_of_testBit_eq {x y : Nat} (pred : ∀i, testBit x i = testBit y i) : x = y := by
+  if h : x = y then
+    exact h
+  else
+    let ⟨i,eq⟩ := ne_implies_bit_diff h
+    have p := pred i
+    contradiction
+
+theorem ge_two_pow_implies_high_bit_true {x : Nat} (p : x ≥ 2^n) : ∃ i, i ≥ n ∧ testBit x i := by
+  induction x using div2Induction generalizing n with
+  | ind x hyp =>
+    have x_pos : x > 0 := Nat.lt_of_lt_of_le (Nat.pow_two_pos n) p
+    have x_ne_zero : x ≠ 0 := Nat.ne_of_gt x_pos
+    match n with
+    | zero =>
+      let ⟨j, jp⟩ := ne_zero_implies_bit_true x_ne_zero
+      exact Exists.intro j (And.intro (Nat.zero_le _) jp)
+    | succ n =>
+      have x_ge_n : x / 2 ≥ 2 ^ n := by
+          simp [le_div_iff_mul_le, ← Nat.pow_succ']
+          exact p
+      have ⟨j, jp⟩ := @hyp x_pos n x_ge_n
+      apply Exists.intro (j+1)
+      apply And.intro
+      case left =>
+        exact (Nat.succ_le_succ jp.left)
+      case right =>
+        simp [testBit_succ_div2 _ j]
+        exact jp.right
+
+theorem testBit_implies_ge {x : Nat} (p : testBit x i = true) : x ≥ 2^i := by
+  simp only [testBit_to_div_mod] at p
+  by_contra not_ge
+  have x_lt : x < 2^i := Nat.lt_of_not_le not_ge
+  have x_lt_2 : x < 2^i * 2 := by
+        rw [←Nat.mul_one x]
+        apply Nat.mul_lt_mul x_lt (by trivial : 1 ≤ 2) (by trivial : 0 < 1)
+  simp [x_lt_2, mod_eq_of_lt, x_lt, div_eq_of_lt] at p
+
+theorem testBit_lt_two {x i : Nat} (lt : x < 2^i) : x.testBit i = false := by
+  match p : x.testBit i with
+  | false => trivial
+  | true =>
+    exfalso
+    exact Nat.not_le_of_gt lt (testBit_implies_ge p)
+
+theorem lt_pow_two_of_testBit (x:Nat) (p : ∀i, i ≥ n → testBit x i = false) : x < 2^n := by
+  by_contra not_lt
+  have x_ge_n := Nat.ge_of_not_lt not_lt
+  have ⟨i, ⟨i_ge_n, test_true⟩⟩ := ge_two_pow_implies_high_bit_true x_ge_n
+  have test_false := p _ i_ge_n
+  simp only [test_true] at test_false
+
+/-! ### testBit -/
+
+private theorem succ_mod_2 : succ x % 2 = 1 - x % 2 := by
+  induction x with
+  | zero =>
+    trivial
+  | succ x hyp =>
+    have p : 2 ≤ x + 2 := Nat.le_add_left _ _
+    simp [Nat.mod_eq (x+2) 2, p, hyp]
+    cases Nat.mod_two_eq_zero_or_one x with | _ p => simp [p]
+
+
+private theorem testBit_succ_zero : testBit (x + 1) 0 = not (testBit x 0) := by
+  simp [testBit, succ_mod_2]
+  cases Nat.mod_two_eq_zero_or_one x with | _ p => simp [p]
+
+theorem testBit_two_pow_add_eq (x i : Nat)
+    : testBit (2^i + x) i = not (testBit x i) := by
+  simp [testBit_to_div_mod, add_div_left, Nat.pow_two_pos, succ_mod_2]
+  cases mod_two_eq_zero_or_one (x / 2 ^ i) with
+  | _ p => simp [p]
+
+theorem testBit_mul_two_pow_add_eq (a b i : Nat)
+    : testBit (2^i*a + b) i = Bool.xor (a%2 = 1) (testBit b i) := by
+  match a with
+  | 0 => simp
+  | a+1 =>
+    simp [Nat.mul_succ, Nat.add_assoc,
+          testBit_mul_two_pow_add_eq a,
+          testBit_two_pow_add_eq,
+          Nat.succ_mod_2]
+    cases mod_two_eq_zero_or_one a with
+    | _ p => simp [p]
+
+theorem testBit_two_pow_add_gt {i j : Nat} (j_lt_i : j < i) (x : Nat)
+    : testBit (2^i + x) j = testBit x j := by
+  have i_def : i = j + (i-j) := (Nat.add_sub_cancel' (Nat.le_of_lt j_lt_i)).symm
+  rw [i_def]
+  simp [testBit_to_div_mod, Nat.pow_add,
+        Nat.add_comm x, Nat.mul_add_div (Nat.pow_two_pos _)]
+  match i_sub_j_eq : i - j with
+  | 0 =>
+    exfalso
+    rw [Nat.sub_eq_zero_iff_le] at i_sub_j_eq
+    exact Nat.not_le_of_gt j_lt_i i_sub_j_eq
+  | d+1 =>
+    simp [pow_succ, Nat.mul_comm _ 2,  Nat.mul_add_mod]
+
+
+theorem testBit_mod_two_pow (x j i : Nat) : testBit (x % 2^j) i = (decide (i < j) && testBit x i) := by
+  induction x using Nat.strongInductionOn generalizing j i with
+  | ind x hyp =>
+    rw [mod_eq]
+    cases Nat.lt_or_ge x (2^j) with
+    | inl x_lt_j =>
+      have not_j_le_x := Nat.not_le_of_gt x_lt_j
+      simp [not_j_le_x]
+      cases Nat.lt_or_ge i j with
+      | inl i_lt_j =>
+        simp [i_lt_j]
+      | inr i_ge_j =>
+      have x_lt : x < 2^i :=
+          calc x < 2^j := x_lt_j
+               _ ≤ 2^i := Nat.pow_le_pow_of_le_right Nat.zero_lt_two i_ge_j
+      simp [Nat.testBit_lt_two x_lt]
+    | inr x_ge_j =>
+      generalize y_eq : x - 2^j = y
+      have x_eq : x = y + 2^j := Nat.eq_add_of_sub_eq x_ge_j y_eq
+      simp [x_eq, Nat.le_add_left, Nat.pow_two_pos]
+      have y_lt_x : y < x := by
+            simp [x_eq]
+            exact Nat.lt_add_of_pos_right (Nat.pow_two_pos j)
+      simp [hyp y y_lt_x]
+      if i_lt_j : i < j then
+        rw [ Nat.add_comm _ (2^_), testBit_two_pow_add_gt i_lt_j]
+      else
+        simp [i_lt_j]
+
+private theorem testBit_one_zero : testBit 1 0 = true := by trivial
+
+@[simp]
+theorem testBit_two_pow_sub_one (n i : Nat) : testBit (2^n-1) i = decide (i < n) := by
+  induction i generalizing n with
+  | zero =>
+    simp [testBit_zero_is_mod2]
+    match n with
+    | 0 =>
+      simp
+    | n+1 =>
+      simp [Nat.pow_succ, Nat.mul_comm _ 2, two_mul_sub_one, Nat.pow_two_pos]
+  | succ i hyp =>
+    simp [testBit_succ_div2]
+    match n with
+    | 0 =>
+      simp [pow_zero]
+    | n+1 =>
+      simp [two_pow_succ_sub_one_div, hyp, Nat.succ_lt_succ_iff]
+
+theorem testBit_bool_to_nat (b : Bool) (i : Nat) : testBit (Bool.toNat b) i = (decide (i = 0) && b) := by
+  cases b <;> cases i <;>
+  simp [testBit_to_div_mod, Nat.pow_succ, Nat.mul_comm _ 2, ←Nat.div_div_eq_div_mul _ 2, one_div_two]
+
+/-! ### bitwise -/
+
+theorem testBit_bitwise
+  (false_false_axiom : f false false = false) (x y i : Nat)
+: (bitwise f x y).testBit i = f (x.testBit i) (y.testBit i) := by
+  induction i using Nat.strongInductionOn generalizing x y with
+  | ind i hyp =>
+    unfold bitwise
+    if x_zero : x = 0 then
+      cases p : f false true <;>
+        cases yi : testBit y i <;>
+          simp [x_zero, p, yi, false_false_axiom]
+    else if y_zero : y = 0 then
+      simp [x_zero, y_zero]
+      cases p : f true false <;>
+        cases xi : testBit x i <;>
+          simp [p, xi, false_false_axiom]
+    else
+      simp [x_zero, y_zero, ←Nat.two_mul]
+      cases i with
+      | zero =>
+        cases p : f (decide (x % 2 = 1)) (decide (y % 2 = 1)) <;>
+          simp [p, testBit_zero_is_mod2, Nat.mul_add_mod]
+      | succ i =>
+        have hyp_i := hyp i (Nat.le_refl (i+1))
+        cases p : f (decide (x % 2 = 1)) (decide (y % 2 = 1)) <;>
+          simp [p, testBit_succ_div2, one_div_two, hyp_i, Nat.mul_add_div]
 
 /-! ### bitwise -/
 
@@ -53,11 +356,11 @@ private theorem zero_lt_pow (n:Nat) : 0 < 2^n := by
   case zero => simp [eq_0_of_lt]
   case succ n hyp =>
     simp [pow_succ]
-    exact (Nat.mul_lt_mul_of_pos_right hyp (by trivial : 2 > 0) : 0 < 2 ^ n * 2)
+    exact (Nat.mul_lt_mul_of_pos_right hyp Nat.zero_lt_two : 0 < 2 ^ n * 2)
 
 private
 theorem div_2_le_of_lt_two {m n : Nat} (p : m < 2 ^ succ n) : m / 2 < 2^n := by
-  simp [div_lt_iff_lt_mul (by trivial : 0 < 2)]
+  simp [div_lt_iff_lt_mul Nat.zero_lt_two]
   exact p
 
 /-- This provides a bound on bitwise operations. -/
@@ -87,142 +390,136 @@ theorem bitwise_lt_2_pow (left : x < 2^n) (right : y < 2^n) : (Nat.bitwise f x y
       case neg =>
         apply Nat.add_lt_add <;> exact hyp1
 
-/-! ### land -/
+/-! ### and -/
+
+theorem testBit_and (x y i : Nat) : (x &&& y).testBit i = (x.testBit i && y.testBit i) := by
+  simp [HAnd.hAnd, AndOp.and, land, testBit_bitwise ]
+
+theorem and_lt_2_pow (x : Nat) {y n : Nat} (right : y < 2^n) : (x &&& y) < 2^n := by
+  apply lt_pow_two_of_testBit
+  intro i i_ge_n
+  have yf : testBit y i = false := by
+          apply Nat.testBit_lt_two
+          apply Nat.lt_of_lt_of_le right
+          exact pow_le_pow_of_le_right Nat.zero_lt_two i_ge_n
+  simp [testBit_and, yf]
+
+theorem and_pow_2_is_mod (x n : Nat) : x &&& (2^n-1) = x % 2^n := by
+  apply eq_of_testBit_eq
+  intro i
+  simp [testBit_and, testBit_mod_two_pow]
+  cases testBit x i <;> simp
 
 @[simp]
-theorem land_zero (x:Nat) : x &&& 0 = 0 := by
-  simp [HAnd.hAnd, AndOp.and, land]
-  unfold bitwise
-  simp
-
-theorem land_lt_2_pow (x : Nat) {y n : Nat} (right : y < 2^n) : (x &&& y) < 2^n := by
-  induction n generalizing x y with
-  | zero =>
-    simp only [eq_0_of_lt] at right
-    simp [right]
-  | succ n hyp =>
-    simp [HAnd.hAnd, AndOp.and, land]
-    unfold bitwise
-    if x_zero : x = 0 then
-      simp [x_zero, if_true, if_false]
-    else if y_zero : y = 0 then
-      simp [x_zero, y_zero, if_false, if_true]
-    else
-      simp only [x_zero, y_zero, if_false]
-      have hyp1 := hyp (x / 2) (div_2_le_of_lt_two right)
-      by_cases p : decide (x % 2 = 1) && decide (y % 2 = 1) <;>
-        simp [p, pow_succ, mul_succ, Nat.add_assoc]
-      case pos =>
-        apply lt_of_succ_le
-        simp only [← Nat.succ_add]
-        apply Nat.add_le_add <;> exact hyp1
-      case neg =>
-        apply Nat.add_lt_add <;> exact hyp1
+theorem and_pow_2_identity {x:Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
+  rw [and_pow_2_is_mod]
+  apply (Nat.mod_eq_of_lt lt)
 
 /-! ### lor -/
 
-theorem lor_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : (x ||| y) < 2^n :=
+
+@[simp]
+theorem or_zero (x:Nat) : 0 ||| x = x := by
+  simp [HOr.hOr, OrOp.or, lor]
+  unfold bitwise
+  simp [@eq_comm _ 0]
+
+@[simp]
+theorem zero_or (x:Nat) : x ||| 0 = x := by
+  simp [HOr.hOr, OrOp.or, lor]
+  unfold bitwise
+  simp [@eq_comm _ 0]
+
+theorem testBit_or (x y i : Nat) : (x ||| y).testBit i = (x.testBit i || y.testBit i) := by
+  simp [HOr.hOr, OrOp.or, lor, testBit_bitwise ]
+
+theorem or_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ||| y < 2^n :=
   bitwise_lt_2_pow left right
+
 
 /-! ### xor -/
 
-theorem xor_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : (x ^^^ y) < 2^n :=
+theorem testBit_xor (x y i : Nat) : (x ^^^ y).testBit i = Bool.xor (x.testBit i) (y.testBit i) := by
+  simp [HXor.hXor, Xor.xor, xor, testBit_bitwise ]
+
+theorem xor_lt_2_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ^^^ y < 2^n :=
   bitwise_lt_2_pow left right
 
-/-! ### shiftLeft -/
+/-! ### shiftLeft and shiftRight -/
 
-theorem shiftLeft_lt_2_pow {x m n : Nat} (bound : x < 2^(n-m)) : (x <<< m) < 2^n := by
-  induction m generalizing x n with
-  | zero => exact bound
-  | succ m hyp =>
-    simp [shiftLeft_succ_inside]
-    apply hyp
-    revert bound
-    rw [Nat.sub_succ]
-    match n - m with
-    | 0 =>
-      intro bound
-      simp [eq_0_of_lt_one] at bound
-      simp [bound]
-    | d + 1 =>
-      intro bound
-      simp [Nat.pow_succ, Nat.mul_comm _ 2]
-      exact Nat.mul_lt_mul_of_pos_left bound (by trivial : 0 < 2)
-
-/-! ### testBit -/
-
-theorem testBit_zero_is_mod2 (x:Nat) : testBit x 0 = decide (x % 2 = 1) := by
-  simp [testBit]
-  rw [←div_add_mod x 2]
-  simp [HAnd.hAnd, AndOp.and, land]
-  unfold bitwise
-  have one_div_2 : 1 / 2 = 0 := by trivial
-  have elim_and := fun x => land_zero x
-  simp [HAnd.hAnd, AndOp.and, land] at elim_and
-  simp [one_div_2, elim_and]
-  simp [Nat.add_comm (2 * _) _]
-  intro x_mod
-  simp [x_mod, Nat.succ_add]
-
-theorem zero_testBit (i:Nat) : testBit 0 i = false := by
-  unfold testBit
-  simp [zero_shiftRight]
-
-theorem testBit_succ (x:Nat) : testBit x (succ i) = testBit (x >>> 1) i := by
-  unfold testBit
-  simp [shiftRight_succ_inside]
-
-theorem ne_zero_implies_bit_true {x : Nat} (p : x ≠ 0) : ∃ i, testBit x i := by
-  induction x using div2InductionOn with
-  | base =>
-    trivial
-  | induct x _ ind =>
-    match mod_two_eq_zero_or_one x with
-    | Or.inl mod2_eq =>
-      rw [←div_add_mod x 2] at p
-      simp [mod2_eq, mul_eq_zero] at p
-      have ⟨d, dif⟩   := ind (p : x / 2 ≠ 0)
-      apply Exists.intro (d+1)
-      simp [testBit_succ]
-      exact dif
-    | Or.inr mod2_eq =>
-      apply Exists.intro 0
-      simp [testBit_zero_is_mod2, mod2_eq]
-
-theorem ne_implies_bit_diff {x y : Nat} (p : x ≠ y) : ∃ i, testBit x i ≠ testBit y i := by
-  induction y using Nat.div2InductionOn generalizing x with
-  | base =>
-    simp only [Nat.zero_testBit, Bool.eq_false_iff]
-    have ⟨i,ip⟩  := ne_zero_implies_bit_true p
-    apply Exists.intro i
-    simp [ip]
-  | induct y _y_pos ind_y =>
-    if lsb_diff : x % 2 = y % 2 then
-      rw [←Nat.div_add_mod x 2, ←Nat.div_add_mod y 2] at p
-      simp [lsb_diff,
-            Nat.add_right_cancel_iff,
-            Nat.mul_left_cancel_iff]
-        at p
-      have ⟨i, ieq⟩  := ind_y p
-      apply Exists.intro (i+1)
-      simp [testBit_succ]
-      exact ieq
-    else
-      apply Exists.intro 0
-      simp [testBit_zero_is_mod2]
-      revert lsb_diff
-      cases mod_two_eq_zero_or_one x with | _ p =>
-        cases mod_two_eq_zero_or_one y with | _ q =>
-          simp [p,q]
-
-/--
-`eq_of_testBit_eq` allows proving two natural numbers are equal
-if their bits are all equal.
--/
-theorem eq_of_testBit_eq {x y : Nat} (pred : ∀i, testBit x i = testBit y i) : x = y := by
-  if h : x = y then
-    exact h
+theorem testBit_shiftLeft (x:Nat) : testBit (x <<< i) j =
+  (decide (j ≥ i) && testBit x (j-i)) := by
+  if j_ge_i : j ≥ i then
+    simp [testBit, Nat.shiftLeft_shiftRight_le, j_ge_i]
   else
-    let ⟨i,eq⟩ := ne_implies_bit_diff h
-    have p := pred i
-    contradiction
+    simp [testBit, j_ge_i]
+    simp only [Nat.shiftLeft_shiftRight_ge, Nat.le_of_not_ge, j_ge_i]
+    match k_def : i - j with
+    | 0 =>
+      have p : j < i := Nat.lt_of_not_ge j_ge_i
+      have q : i - j > 0 := Nat.sub_pos_of_lt p
+      rw [k_def] at q
+      contradiction
+    | k + 1 =>
+      simp [Nat.shiftLeft_succ]
+
+theorem testBit_shiftRight (x:Nat) : testBit (x >>> i) j = testBit x (i+j) := by
+  simp only [testBit, shiftRight_shiftRight]
+
+theorem testBit_mul_pow_two_add_lt {b:Nat} (a i : Nat)
+  : testBit (2 ^(i+1) * a + b) i = testBit b i := by
+  simp only [testBit_to_div_mod, Nat.pow_succ, Nat.mul_assoc]
+  simp [Nat.mul_add_div (Nat.pow_two_pos i), Nat.mul_add_mod]
+
+theorem testBit_mul_pow_two_add (a:Nat) {b i:Nat} (b_lt : b < 2^i) (j:Nat)
+  : testBit (2 ^ i * a + b) j =
+    if j < i then
+      testBit b j
+    else
+      testBit a (j - i) := by
+  cases Nat.lt_or_ge j i with
+  | inl j_lt =>
+    simp [j_lt]
+    have i_ge := Nat.le_of_lt j_lt
+    have i_sub_j_nez : i-j ≠ 0 := Nat.sub_ne_zero_of_lt j_lt
+    have i_def : i = j + succ (pred (i-j)) :=
+          calc i = j + (i-j) := (Nat.add_sub_cancel' i_ge).symm
+               _ = j + succ (pred (i-j)) := by
+                 rw [← congrArg (j+·) (Nat.succ_pred i_sub_j_nez)]
+    rw [i_def]
+    simp only [testBit_to_div_mod, Nat.pow_add, Nat.mul_assoc]
+    simp only [Nat.mul_add_div (Nat.pow_two_pos _), Nat.mul_add_mod]
+    simp [Nat.pow_succ, Nat.mul_comm _ 2, Nat.mul_assoc, Nat.mul_add_mod]
+  | inr j_ge =>
+    have j_def : j = i + (j-i) := (Nat.add_sub_cancel' j_ge).symm
+    simp only [
+        testBit_to_div_mod,
+        Nat.not_lt_of_le,
+        j_ge,
+        ite_false]
+    simp [congrArg (2^·) j_def, Nat.pow_add,
+          ←Nat.div_div_eq_div_mul,
+          Nat.mul_add_div,
+          Nat.div_eq_of_lt b_lt,
+          Nat.pow_two_pos i]
+
+theorem testBit_mul_pow_two
+  : testBit (2 ^ i * a) j = (decide (j ≥ i) && testBit a (j-i)) := by
+  have gen := testBit_mul_pow_two_add a (Nat.pow_two_pos i) j
+  simp at gen
+  rw [gen]
+  cases Nat.lt_or_ge j i with
+  | _ p => simp [p, Nat.not_le_of_lt, Nat.not_lt_of_le]
+
+theorem mul_add_lt_is_or {b:Nat} (b_lt : b < 2^i) (a:Nat)
+  : 2^i * a + b = 2^i * a ||| b := by
+  apply eq_of_testBit_eq
+  intro j
+  simp [testBit_mul_pow_two_add _ b_lt,
+        testBit_or, testBit_mul_pow_two]
+  if j_lt : j < i then
+    simp [Nat.not_le_of_lt, j_lt]
+  else
+    have i_le : i ≤ j := Nat.le_of_not_lt j_lt
+    have b_lt_j : b < 2 ^ j := Nat.lt_of_lt_of_le b_lt (Nat.pow_le_pow_of_le_right Nat.zero_lt_two i_le)
+    simp [i_le, j_lt, testBit_lt_two, b_lt_j]

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -767,6 +767,26 @@ protected theorem mul_self_sub_mul_self_eq (a b : Nat) : a * a - b * b = (a + b)
   rw [Nat.mul_sub_left_distrib, Nat.right_distrib, Nat.right_distrib,
       Nat.mul_comm b a, Nat.add_comm (a*a) (a*b), Nat.add_sub_add_left]
 
+protected theorem mul_left_cancel {n m k : Nat} (np : 0 < n) (h:n * m = n * k) : m = k := by
+  match Nat.lt_trichotomy m k with
+  | Or.inl p =>
+    have r : n * m < n * k := Nat.mul_lt_mul_of_pos_left p np
+    simp [h] at r
+  | Or.inr (Or.inl p) => exact p
+  | Or.inr (Or.inr p) =>
+    have r : n * k < n * m := Nat.mul_lt_mul_of_pos_left p np
+    simp [h] at r
+
+protected theorem mul_right_cancel {n m k : Nat} (mp : 0 < m) (h:n * m = k * m) : n = k := by
+  simp [Nat.mul_comm _ m] at h
+  apply Nat.mul_left_cancel mp h
+
+protected theorem mul_left_cancel_iff {n m k : Nat} (p : 0 < n) : n * m = n * k ↔ m = k :=
+  ⟨Nat.mul_left_cancel p, fun | rfl => rfl⟩
+
+protected theorem mul_right_cancel_iff {n m k : Nat} (p : 0 < m) : n * m = k * m ↔ n = k :=
+  ⟨Nat.mul_right_cancel p, fun | rfl => rfl⟩
+
 /-! ## div/mod -/
 
 -- TODO mod_core_congr, mod_def

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -1245,7 +1245,7 @@ theorem shiftLeft_succ : ∀(m n), m <<< (n + 1) = 2 * (m <<< n)
 
 theorem shiftRight_succ (m n) : m >>> (n + 1) = (m >>> n) / 2 := rfl
 
-/-- Shiftleft on successor with division moved inside. -/
+/-- Shiftright on successor with division moved inside. -/
 theorem shiftRight_succ_inside : ∀m n, m >>> (n+1) = (m/2) >>> n
 | m, 0 => rfl
 | m, k + 1 => by

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -1290,8 +1290,7 @@ theorem mul_add_mod (m x y : Nat) : (m * x + y) % m = y % m := by
   | x + 1 =>
     simp [Nat.mul_succ, Nat.add_assoc _ m, mul_add_mod _ x]
 
-@[simp]
-theorem mod_div_self (m n : Nat) : m % n / n = 0 := by
+@[simp] theorem mod_div_self (m n : Nat) : m % n / n = 0 := by
   cases n
   · exact (m % 0).div_zero
   · case succ n => exact Nat.div_eq_of_lt (m.mod_lt n.succ_pos)

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -739,24 +739,30 @@ theorem mul_eq_zero {n m : Nat} : n * m = 0 ↔ n = 0 ∨ m = 0 :=
     | n+1, m, h => by rw [succ_mul] at h; exact .inr (Nat.eq_zero_of_add_eq_zero_left h),
    fun | .inl h | .inr h => by simp [h]⟩
 
-theorem zero_eq_mul {n m : Nat} : 0 = n * m ↔ n = 0 ∨ m = 0 := by
-  simp only [eq_comm, Nat.mul_eq_zero]
-
 protected theorem mul_ne_zero_iff : n * m ≠ 0 ↔ n ≠ 0 ∧ m ≠ 0 := by simp [mul_eq_zero, not_or]
 
 protected theorem mul_ne_zero (n0 : n ≠ 0) (m0 : m ≠ 0) : n * m ≠ 0 :=
   Nat.mul_ne_zero_iff.2 ⟨n0, m0⟩
 
-theorem mul_eq_one (x y : Nat) : x * y = 1 ↔ x = 1 ∧ y = 1 := by
-  match x, y with
-  | 0, _ => simp
-  | 1, _ => simp
-  | _, 0 => simp
-  | Nat.succ (Nat.succ x), Nat.succ y =>
-    simp [Nat.succ_mul, Nat.add_succ, Nat.succ_add]
+protected theorem mul_left_cancel {n m k : Nat} (np : 0 < n) (h : n * m = n * k) : m = k := by
+  match Nat.lt_trichotomy m k with
+  | Or.inl p =>
+    have r : n * m < n * k := Nat.mul_lt_mul_of_pos_left p np
+    simp [h] at r
+  | Or.inr (Or.inl p) => exact p
+  | Or.inr (Or.inr p) =>
+    have r : n * k < n * m := Nat.mul_lt_mul_of_pos_left p np
+    simp [h] at r
 
-theorem one_eq_mul (x y : Nat) : 1 = x * y ↔ x = 1 ∧ y = 1 := by
-  simp only [eq_comm, Nat.mul_eq_one]
+protected theorem mul_right_cancel {n m k : Nat} (mp : 0 < m) (h : n * m = k * m) : n = k := by
+  simp [Nat.mul_comm _ m] at h
+  apply Nat.mul_left_cancel mp h
+
+protected theorem mul_left_cancel_iff {n: Nat} (p : 0 < n) (m k : Nat) : n * m = n * k ↔ m = k :=
+  ⟨Nat.mul_left_cancel p, fun | rfl => rfl⟩
+
+protected theorem mul_right_cancel_iff {m : Nat} (p : 0 < m) (n k : Nat) : n * m = k * m ↔ n = k :=
+  ⟨Nat.mul_right_cancel p, fun | rfl => rfl⟩
 
 protected theorem mul_le_mul_of_nonneg_left {a b c : Nat} (h₁ : a ≤ b) : c * a ≤ c * b := by
   if hba : b ≤ a then simp [Nat.le_antisymm hba h₁] else
@@ -774,39 +780,19 @@ protected theorem mul_lt_mul (hac : a < c) (hbd : b ≤ d) (pos_b : 0 < b) : a *
 protected theorem mul_lt_mul' (h1 : a ≤ c) (h2 : b < d) (h3 : 0 < c) : a * b < c * d :=
   Nat.lt_of_le_of_lt (Nat.mul_le_mul_of_nonneg_right h1) (Nat.mul_lt_mul_of_pos_left h2 h3)
 
-theorem succ_mul_succ_eq (a b : Nat) : succ a * succ b = a * b + a + b + 1 := by
-  rw [mul_succ, succ_mul, Nat.add_right_comm _ a]; rfl
-
-protected theorem mul_self_sub_mul_self_eq (a b : Nat) : a * a - b * b = (a + b) * (a - b) := by
-  rw [Nat.mul_sub_left_distrib, Nat.right_distrib, Nat.right_distrib,
-      Nat.mul_comm b a, Nat.add_comm (a*a) (a*b), Nat.add_sub_add_left]
-
-protected theorem mul_left_cancel {n m k : Nat} (np : 0 < n) (h:n * m = n * k) : m = k := by
-  match Nat.lt_trichotomy m k with
-  | Or.inl p =>
-    have r : n * m < n * k := Nat.mul_lt_mul_of_pos_left p np
-    simp [h] at r
-  | Or.inr (Or.inl p) => exact p
-  | Or.inr (Or.inr p) =>
-    have r : n * k < n * m := Nat.mul_lt_mul_of_pos_left p np
-    simp [h] at r
-
-protected theorem mul_right_cancel {n m k : Nat} (mp : 0 < m) (h:n * m = k * m) : n = k := by
-  simp [Nat.mul_comm _ m] at h
-  apply Nat.mul_left_cancel mp h
-
-protected theorem mul_left_cancel_iff {n m k : Nat} (p : 0 < n) : n * m = n * k ↔ m = k :=
-  ⟨Nat.mul_left_cancel p, fun | rfl => rfl⟩
-
-protected theorem mul_right_cancel_iff {n m k : Nat} (p : 0 < m) : n * m = k * m ↔ n = k :=
-  ⟨Nat.mul_right_cancel p, fun | rfl => rfl⟩
-
 theorem mul_le_add_right (m k n : Nat) : k * m ≤ m + n ↔ (k-1) * m ≤ n := by
   match k with
   | 0 =>
     simp
   | succ k =>
     simp [succ_mul, Nat.add_comm _ m, Nat.add_le_add_iff_left]
+
+theorem succ_mul_succ_eq (a b : Nat) : succ a * succ b = a * b + a + b + 1 := by
+  rw [mul_succ, succ_mul, Nat.add_right_comm _ a]; rfl
+
+protected theorem mul_self_sub_mul_self_eq (a b : Nat) : a * a - b * b = (a + b) * (a - b) := by
+  rw [Nat.mul_sub_left_distrib, Nat.right_distrib, Nat.right_distrib,
+      Nat.mul_comm b a, Nat.add_comm (a*a) (a*b), Nat.add_sub_add_left]
 
 /-! ## div/mod -/
 
@@ -1119,19 +1105,9 @@ theorem lt_log2_self (h : n ≠ 0) : n < 2 ^ (n.log2 + 1) := (log2_lt h).1 (Nat.
 
 /-! ### dvd -/
 
-@[simp]
 protected theorem dvd_refl (a : Nat) : a ∣ a := ⟨1, by simp⟩
 
-@[simp]
 protected theorem dvd_zero (a : Nat) : a ∣ 0 := ⟨0, by simp⟩
-
-@[simp]
-protected theorem one_dvd (n:Nat) : 1 ∣ n := Exists.intro n (Nat.one_mul n).symm
-
-@[simp]
-protected theorem dvd_one (a : Nat) : a ∣ 1 ↔ a = 1 :=
-  Iff.intro (fun ⟨n,eq⟩  => by simp [Nat.one_eq_mul] at eq; exact eq.left)
-            (fun e => by simp only [e, Nat.one_dvd])
 
 protected theorem dvd_mul_left (a b : Nat) : a ∣ b * a := ⟨b, Nat.mul_comm b a⟩
 
@@ -1144,10 +1120,6 @@ protected theorem dvd_trans {a b c : Nat} (h₁ : a ∣ b) (h₂ : b ∣ c) : a 
 
 protected theorem eq_zero_of_zero_dvd {a : Nat} (h : 0 ∣ a) : a = 0 :=
   let ⟨c, H'⟩ := h; H'.trans c.zero_mul
-
-@[simp]
-protected theorem zero_dvd_eq (n:Nat) : 0 ∣ n ↔ n = 0 :=
-  Iff.intro Nat.eq_zero_of_zero_dvd (fun d => by simp only [d, Nat.dvd_zero 0])
 
 protected theorem dvd_add {a b c : Nat} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
   let ⟨d, hd⟩ := h₁; let ⟨e, he⟩ := h₂; ⟨d + e, by simp [Nat.left_distrib, hd, he]⟩

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -1260,39 +1260,19 @@ theorem shiftRight_succ_inside : ∀m n, m >>> (n+1) = (m/2) >>> n
   | 0 => by simp [shiftRight]
   | n + 1 => by simp [shiftRight, zero_shiftRight, shiftRight_succ]
 
+theorem shiftRight_add (m n : Nat) : ∀ k, m >>> (n + k) = (m >>> n) >>> k
+  | 0 => rfl
+  | k + 1 => by simp [add_succ, shiftRight_add, shiftRight_succ]
+
 theorem shiftLeft_shiftLeft (m n : Nat) : ∀ k, (m <<< n) <<< k = m <<< (n + k)
   | 0 => rfl
   | k + 1 => by simp [add_succ, shiftLeft_shiftLeft _ _ k, shiftLeft_succ]
 
-theorem shiftLeft_shiftRight_ge
-      (m : Nat) {n k : Nat} (ge : n ≥ k) : (m <<< n) >>> k = m <<< (n - k) := by
-  induction n generalizing k with
-  | zero =>
-    have k_eq : k = 0 := Nat.eq_zero_of_le_zero ge
-    simp [k_eq]
-  | succ n hyp =>
-    match k with
-    | 0 => simp
-    | succ k =>
-      have n_ge_k : n ≥ k := Nat.le_of_succ_le_succ ge
-      simp [shiftLeft_succ, shiftRight_succ_inside, hyp n_ge_k]
-
-theorem shiftLeft_shiftRight_le
-      {n k : Nat} (le : n ≤ k) (m : Nat) : (m <<< n) >>> k = m >>> (k - n) := by
-  induction n generalizing k with
-  | zero =>
-    simp
-  | succ n hyp =>
-    match k with
-    | 0 =>
-      contradiction
-    | succ k =>
-      have n_le_k : n ≤ k := Nat.le_of_succ_le_succ le
-      simp [shiftLeft_succ, shiftRight_succ_inside, hyp n_le_k]
-
-theorem shiftRight_shiftRight (m n : Nat) : ∀ k, (m >>> n) >>> k = m >>> (n + k)
-  | 0 => rfl
-  | k + 1 => by simp [add_succ, shiftRight_shiftRight, shiftRight_succ]
+theorem shiftRight_eq_div_pow (m : Nat) : ∀ n, m >>> n = m / 2 ^ n
+  | 0 => (Nat.div_one _).symm
+  | k + 1 => by
+    rw [shiftRight_add, shiftRight_eq_div_pow m k]
+    simp [Nat.div_div_eq_div_mul, ← Nat.pow_succ, shiftRight_succ]
 
 theorem mul_add_div {m : Nat} (m_pos : m > 0) (x y : Nat) : (m * x + y) / m = x + y / m := by
   match x with

--- a/Std/Logic.lean
+++ b/Std/Logic.lean
@@ -696,8 +696,7 @@ The left-to-right direction, double negation elimination (DNE),
 is classically true but not constructively. -/
 @[scoped simp] theorem not_not : ¬¬a ↔ a := Decidable.not_not
 
-@[simp]
-theorem not_forall {p : α → Prop} : (¬∀ x, p x) ↔ ∃ x, ¬p x :=
+@[simp] theorem not_forall {p : α → Prop} : (¬∀ x, p x) ↔ ∃ x, ¬p x :=
   Decidable.not_forall
 
 alias ⟨exists_not_of_not_forall, _⟩ := not_forall


### PR DESCRIPTION
This is a large PR that has operations for working with Nat and BitVec as functions from indices to Bool.  In particular it builds upon work in #314 and #358