### PR TITLE
chore: DiscrTreeCache.mk uses insertCore not insertIfSpecific

### DIFF
--- a/Std/Util/Cache.lean
+++ b/Std/Util/Cache.lean
@@ -132,7 +132,7 @@ def DiscrTreeCache.mk [BEq α] (profilingName : String)
     IO (DiscrTreeCache α) :=
   let updateTree := fun name constInfo tree => do
     return (← processDecl name constInfo).foldl (init := tree) fun t (k, v) =>
-      t.insertIfSpecific k v config
+      t.insertCore k v config
   let addDecl := fun name constInfo (tree₁, tree₂) =>
     return (← updateTree name constInfo tree₁, tree₂)
   let addLibraryDecl := fun name constInfo (tree₁, tree₂) =>


### PR DESCRIPTION
This code was inappropriately opinionated about ensuring that the keys being inserted into a `DiscrTree` were "specific". The function `processDecl` being passed can do that itself.