### PR TITLE
refactor: specialize `Acc.rec` and `WellFounded.fix`

### DIFF
--- a/Std/WF.lean
+++ b/Std/WF.lean
@@ -46,8 +46,7 @@ private local instance wfRel {r : α → α → Prop} : WellFoundedRelation { va
   wf  := ⟨fun ac => InvImage.accessible _ ac.2⟩
 
 /-- A computable version of `Acc.rec`. Workaround until Lean has native support for this. -/
-@[specialize, elab_as_elim]
-private def recC {motive : (a : α) → Acc r a → Sort v}
+@[specialize, elab_as_elim] private def recC {motive : (a : α) → Acc r a → Sort v}
     (intro : (x : α) → (h : ∀ (y : α), r y x → Acc r y) →
      ((y : α) → (hr : r y x) → motive y (h y hr)) → motive x (intro x h))
     {a : α} (t : Acc r a) : motive a t :=
@@ -61,8 +60,7 @@ private theorem recC_intro {motive : (a : α) → Acc r a → Sort v}
     recC intro (Acc.intro _ h) = intro a h (fun y hr => recC intro (h y hr)) :=
   rfl
 
-@[csimp]
-private theorem rec_eq_recC : @Acc.rec = @Acc.recC := by
+@[csimp] private theorem rec_eq_recC : @Acc.rec = @Acc.recC := by
   funext α r motive intro a t
   induction t with
   | intro x h ih =>
@@ -70,25 +68,21 @@ private theorem rec_eq_recC : @Acc.rec = @Acc.recC := by
     congr; funext y hr; exact ih _ hr
 
 /-- A computable version of `Acc.ndrec`. Workaround until Lean has native support for this. -/
-@[inline]
-private abbrev ndrecC {C : α → Sort v}
+@[inline] private abbrev ndrecC {C : α → Sort v}
     (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → (a : r y x) → C y) → C x)
     {a : α} (n : Acc r a) : C a :=
   n.recC m
 
-@[csimp]
-private theorem ndrec_eq_ndrecC : @Acc.ndrec = @Acc.ndrecC := by
+@[csimp] private theorem ndrec_eq_ndrecC : @Acc.ndrec = @Acc.ndrecC := by
   funext α r motive intro a t
   rw [Acc.ndrec, rec_eq_recC, Acc.ndrecC]
 
 /-- A computable version of `Acc.ndrecOn`. Workaround until Lean has native support for this. -/
-@[inline]
-private abbrev ndrecOnC {C : α → Sort v} {a : α} (n : Acc r a)
+@[inline] private abbrev ndrecOnC {C : α → Sort v} {a : α} (n : Acc r a)
     (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → r y x → C y) → C x) : C a :=
   n.recC m
 
-@[csimp]
-private theorem ndrecOn_eq_ndrecOnC : @Acc.ndrecOn = @Acc.ndrecOnC := by
+@[csimp] private theorem ndrecOn_eq_ndrecOnC : @Acc.ndrecOn = @Acc.ndrecOnC := by
   funext α r motive intro a t
   rw [Acc.ndrecOn, rec_eq_recC, Acc.ndrecOnC]
 
@@ -98,26 +92,21 @@ namespace WellFounded
 
 /-- A computable version of `WellFounded.fixF`.
 Workaround until Lean has native support for this. -/
-@[inline]
-private def fixFC {α : Sort u} {r : α → α → Prop}
+@[inline] private def fixFC {α : Sort u} {r : α → α → Prop}
     {C : α → Sort v} (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) (a : Acc r x) : C x := by
   induction a using Acc.recC with
   | intro x₁ _ ih => exact F x₁ ih
 
-@[csimp]
-private theorem fixF_eq_fixFC : @fixF = @fixFC := by
+@[csimp] private theorem fixF_eq_fixFC : @fixF = @fixFC := by
   funext α r C F x a
   rw [fixF, Acc.rec_eq_recC, fixFC]
 
 /-- A computable version of `fix`. Workaround until Lean has native support for this. -/
-@[specialize]
-private def fixC {α : Sort u} {C : α → Sort v} {r : α → α → Prop} (hwf : WellFounded r)
-    (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) : C x :=
+@[specialize] private def fixC {α : Sort u} {C : α → Sort v} {r : α → α → Prop}
+    (hwf : WellFounded r) (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) : C x :=
   F x (fun y _ => fixC hwf F y)
 termination_by' ⟨r, hwf⟩
 
-@[csimp]
-private theorem fix_eq_fixC : @fix = @fixC :=
-  rfl
+@[csimp] private theorem fix_eq_fixC : @fix = @fixC := rfl
 
 end WellFounded

--- a/Std/WF.lean
+++ b/Std/WF.lean
@@ -46,7 +46,8 @@ private local instance wfRel {r : α → α → Prop} : WellFoundedRelation { va
   wf  := ⟨fun ac => InvImage.accessible _ ac.2⟩
 
 /-- A computable version of `Acc.rec`. Workaround until Lean has native support for this. -/
-@[elab_as_elim] private def recC {motive : (a : α) → Acc r a → Sort v}
+@[specialize, elab_as_elim]
+private def recC {motive : (a : α) → Acc r a → Sort v}
     (intro : (x : α) → (h : ∀ (y : α), r y x → Acc r y) →
      ((y : α) → (hr : r y x) → motive y (h y hr)) → motive x (intro x h))
     {a : α} (t : Acc r a) : motive a t :=
@@ -60,7 +61,8 @@ private theorem recC_intro {motive : (a : α) → Acc r a → Sort v}
     recC intro (Acc.intro _ h) = intro a h (fun y hr => recC intro (h y hr)) :=
   rfl
 
-@[csimp] private theorem rec_eq_recC : @Acc.rec = @Acc.recC := by
+@[csimp]
+private theorem rec_eq_recC : @Acc.rec = @Acc.recC := by
   funext α r motive intro a t
   induction t with
   | intro x h ih =>
@@ -68,21 +70,25 @@ private theorem recC_intro {motive : (a : α) → Acc r a → Sort v}
     congr; funext y hr; exact ih _ hr
 
 /-- A computable version of `Acc.ndrec`. Workaround until Lean has native support for this. -/
+@[inline]
 private abbrev ndrecC {C : α → Sort v}
     (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → (a : r y x) → C y) → C x)
     {a : α} (n : Acc r a) : C a :=
   n.recC m
 
-@[csimp] private theorem ndrec_eq_ndrecC : @Acc.ndrec = @Acc.ndrecC := by
+@[csimp]
+private theorem ndrec_eq_ndrecC : @Acc.ndrec = @Acc.ndrecC := by
   funext α r motive intro a t
   rw [Acc.ndrec, rec_eq_recC, Acc.ndrecC]
 
 /-- A computable version of `Acc.ndrecOn`. Workaround until Lean has native support for this. -/
+@[inline]
 private abbrev ndrecOnC {C : α → Sort v} {a : α} (n : Acc r a)
     (m : (x : α) → ((y : α) → r y x → Acc r y) → ((y : α) → r y x → C y) → C x) : C a :=
   n.recC m
 
-@[csimp] private theorem ndrecOn_eq_ndrecOnC : @Acc.ndrecOn = @Acc.ndrecOnC := by
+@[csimp]
+private theorem ndrecOn_eq_ndrecOnC : @Acc.ndrecOn = @Acc.ndrecOnC := by
   funext α r motive intro a t
   rw [Acc.ndrecOn, rec_eq_recC, Acc.ndrecOnC]
 
@@ -92,22 +98,26 @@ namespace WellFounded
 
 /-- A computable version of `WellFounded.fixF`.
 Workaround until Lean has native support for this. -/
+@[inline]
 private def fixFC {α : Sort u} {r : α → α → Prop}
     {C : α → Sort v} (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) (a : Acc r x) : C x := by
   induction a using Acc.recC with
   | intro x₁ _ ih => exact F x₁ ih
 
-@[csimp] private theorem fixF_eq_fixFC : @fixF = @fixFC := by
+@[csimp]
+private theorem fixF_eq_fixFC : @fixF = @fixFC := by
   funext α r C F x a
   rw [fixF, Acc.rec_eq_recC, fixFC]
 
 /-- A computable version of `fix`. Workaround until Lean has native support for this. -/
+@[specialize]
 private def fixC {α : Sort u} {C : α → Sort v} {r : α → α → Prop} (hwf : WellFounded r)
     (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) : C x :=
-  fixFC F x (apply hwf x)
+  F x (fun y _ => fixC hwf F y)
+termination_by' ⟨r, hwf⟩
 
-@[csimp] private theorem fix_eq_fixC : @fix = @fixC := by
-  funext α C r hwf F x
-  rw [fix, fixF_eq_fixFC, fixC]
+@[csimp]
+private theorem fix_eq_fixC : @fix = @fixC :=
+  rfl
 
 end WellFounded


### PR DESCRIPTION
Sometimes, a function using `Acc.rec` causes a stack overflow because the function is not specialized.
This PR specializes `Acc.rec` and `WellFounded.fix`, and inline functions depending this.