### PR TITLE
refactor: make `BitVec` indexing more consistent with `List` indexing

### DIFF
--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -74,6 +74,23 @@ protected def toNat (a : BitVec n) : Nat := a.toFin.val
 /-- Return least-significant bit in bitvector, or `false` if the bitvector is empty. -/
 @[inline] protected def lsbD (x : BitVec n) : Bool := getLsbD x 0
 
+theorem getLsb_eq_getLsbD (x : BitVec w) (i : Fin w) :
+    x.getLsb i = x.getLsbD i.val :=
+  rfl
+
+theorem getLsbD_eq_getLsb (x : BitVec w) (i : Nat) (h : i < w) :
+    x.getLsbD i = x.getLsb ⟨i, h⟩ :=
+  rfl
+
+theorem getMsb_eq_getMsbD (x : BitVec w) (i : Fin w) :
+    x.getMsb i = x.getMsbD i.val := by
+  simp only [getMsb, Fin.rev, getLsb_eq_getLsbD, getMsbD, i.2, decide_True, Bool.true_and]
+  rw [Nat.add_comm, Nat.sub_add_eq]
+
+theorem getMsbD_eq_getMsb (x : BitVec w) (i : Nat) (h : i < w) :
+    x.getMsbD i = x.getMsb ⟨i, h⟩ := by
+  rw [getMsb_eq_getMsbD]
+
 /-- The `BitVec` with value `(2^n + (i mod 2^n)) mod 2^n`.  -/
 protected def ofInt (n : Nat) (i : Int) : BitVec n :=
   match i with

--- a/test/bitvec.lean
+++ b/test/bitvec.lean
@@ -78,17 +78,17 @@ open Std.BitVec
 
 -- get/extract
 
-#guard !getMsb 0b0101#4 0
-#guard getMsb 0b0101#4 1
-#guard !getMsb 0b0101#4 2
-#guard getMsb 0b0101#4 3
-#guard !getMsb 0b1111#4 4
+#guard !getMsbD 0b0101#4 0
+#guard getMsbD 0b0101#4 1
+#guard !getMsbD 0b0101#4 2
+#guard getMsbD 0b0101#4 3
+#guard !getMsbD 0b1111#4 4
 
-#guard getLsb 0b0101#4 0
-#guard !getLsb 0b0101#4 1
-#guard getLsb 0b0101#4 2
-#guard !getLsb 0b0101#4 3
-#guard !getLsb 0b1111#4 4
+#guard getLsbD 0b0101#4 0
+#guard !getLsbD 0b0101#4 1
+#guard getLsbD 0b0101#4 2
+#guard !getLsbD 0b0101#4 3
+#guard !getLsbD 0b1111#4 4
 
 #guard extractLsb 3 0 0x1234#16 = 4
 #guard extractLsb 7 4 0x1234#16 = 3


### PR DESCRIPTION
The current `BitVec.getLsb`/`getMsb` functions index bitvectors with `Nat`s, returning `false` for out-of-bounds indexes.
I propose to rename these functions to `getLsbD`/`getMsbD` (`D` for default value), in line with `List.getD`.
This frees up the `getLsb` /`getMsb` name for indexing with a guaranteed in-bounds `i : Fin _`, just like `List.get`.

Similarly, rename `msb` (which might index out-of-bounds for an empty bitvector) to `msbD`, and add a new `msb` taking a known non-empty bitvector (i.e., `BitVec (n+1)`), c.f. `List.headD`/`List.head`. And add short-hands `lsb`/`lsbD` to get the least-significant bit for symmetry.

The comparison is not perfect: `List.getD` allows the caller to specify a default value for out-of-bounds indices, whereas the newly added `BitVec.getLsbD` assumes `false` as the default value. An indexing function which returns `true` for out-of-bounds indices does not seem necessary to me, but I am curious to hear other opinions on this.
