### PR TITLE
chore: Port constName and getAppFnArgs from Mathlib

### DIFF
--- a/Std/Lean/Expr.lean
+++ b/Std/Lean/Expr.lean
@@ -127,3 +127,11 @@ def isAppOf' (e : Expr) (n : Name) : Bool :=
   match e.getAppFn' with
   | const c .. => c == n
   | _ => false
+
+/-- If the expression is a constant, return that name. Otherwise return `Name.anonymous`. -/
+def constName (e : Expr) : Name :=
+  e.constName?.getD Name.anonymous
+
+/-- Return the function (name) and arguments of an application. -/
+def getAppFnArgs (e : Expr) : Name × Array Expr :=
+  withApp e λ e a => (e.constName, a)


### PR DESCRIPTION
This is needed by both #343 and #347, so I put it into its own commit so we aren't blocking either.