### PR TITLE
chore: moreServerOptions instead of moreServerArgs

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -3,14 +3,14 @@ import Lake
 open Lake DSL
 
 package std where
-  moreLeanArgs := moreServerArgs.push "-DwarningAsError=true"
-  moreServerArgs := moreServerArgs
+  moreLeanArgs := moreServerOptions.map (·.asCliArg) |>.push "-DwarningAsError=true"
+  moreServerOptions := moreServerOptions
 where
-  moreServerArgs := Id.run do
-    let mut moreServerArgs := #["-Dlinter.missingDocs=true"]
+  moreServerOptions := Id.run do
+    let mut moreServerOptions := #[⟨`linter.missingDocs, true⟩]
     if get_config? disable_new_compiler |>.isSome then
-      moreServerArgs := moreServerArgs.push "-Dcompiler.enableNew=false"
-    moreServerArgs
+      moreServerOptions := moreServerOptions.push ⟨`compiler.enableNew, false⟩
+    moreServerOptions
 
 @[default_target]
 lean_lib Std

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-11-28
+leanprover/lean4:nightly-2023-11-29

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-11-25
+leanprover/lean4:nightly-2023-11-28


### PR DESCRIPTION
This is a PR to the `bump/v4.4.0`, updating the `lakefile.lean` to account for a deprecated option.

It is slightly clunky that we need the `.map (·.asCliArg)` step to translate from `moreServerOptions` to `moreLeanArgs`.