### PR TITLE
fix: Use `MLList.uncons?` to avoid stack overflow

### DIFF
--- a/Std/Data/MLList/Basic.lean
+++ b/Std/Data/MLList/Basic.lean
@@ -24,6 +24,7 @@ private structure Spec (m : Type u → Type u) where
   thunk : (Unit → listM α) → listM α
   squash : (Unit → m (listM α)) → listM α
   uncons : [Monad m] → listM α → m (Option (α × listM α))
+  uncons? : listM α → Option (Option (α × listM α))
 
 instance : Nonempty (Spec m) := .intro
   { listM := fun _ => PUnit
@@ -31,7 +32,8 @@ instance : Nonempty (Spec m) := .intro
     cons := fun _ _ => ⟨⟩
     thunk := fun _ => ⟨⟩
     squash := fun _ => ⟨⟩
-    uncons := fun _ => pure none }
+    uncons := fun _ => pure none
+    uncons? := fun _ => none }
 
 private unsafe inductive MLListImpl (m : Type u → Type u) (α : Type u) : Type u
   | nil : MLListImpl m α
@@ -46,6 +48,11 @@ private unsafe def unconsImpl {m : Type u → Type u} [Monad m] :
   | .squash t => t () >>= unconsImpl
   | .cons x xs => return (x, xs)
 
+private unsafe def uncons?Impl : MLListImpl m α → Option (Option (α × MLListImpl m α))
+  | .nil => pure none
+  | .cons x xs => pure (x, xs)
+  | _ => none
+
 @[inline] private unsafe def specImpl (m) : Spec m where
   listM := MLListImpl m
   nil := .nil
@@ -53,6 +60,7 @@ private unsafe def unconsImpl {m : Type u → Type u} [Monad m] :
   thunk f := .thunk (.mk f)
   squash := .squash
   uncons := unconsImpl
+  uncons? := uncons?Impl
 
 @[implemented_by specImpl]
 private opaque spec (m) : MLList.Spec m
@@ -82,6 +90,11 @@ def squash : (Unit → m (MLList m α)) → MLList m α := (MLList.spec m).squas
 representing the head and tail of the list. -/
 @[inline] def uncons [Monad m] : MLList.{u} m α → m (Option (α × MLList m α)) :=
   (MLList.spec m).uncons
+
+/-- Try to deconstruct a `MLList`, returning an optional pair `α × MLList m α`
+representing the head and tail of the list if it is already evaluated, and `none` otherwise. -/
+@[inline] def uncons? : MLList.{u} m α → Option (Option (α × MLList m α)) :=
+  (MLList.spec m).uncons?
 
 instance : EmptyCollection (MLList m α) := ⟨nil⟩
 instance : Inhabited (MLList m α) := ⟨nil⟩
@@ -178,7 +191,10 @@ Performs a case distinction on a `MLList` when the motive is a `MLList` as well.
 @[specialize]
 def cases [Monad m] (xs : MLList m α)
     (hnil : Unit → MLList m β) (hcons : α → MLList m α → MLList m β) : MLList m β :=
-  xs.casesM (fun _ => return hnil ()) (fun x xs => return hcons x xs)
+  match xs.uncons? with
+  | none => xs.casesM (fun _ => return hnil ()) (fun x xs => return hcons x xs)
+  | some none => thunk hnil
+  | some (some (x, xs)) => thunk fun _ => hcons x xs
 
 /-- Gives the monadic lazy list consisting all of folds of a function on a given initial element.
 Thus `[a₀, a₁, ...].foldsM f b` will give `[b, ← f b a₀, ← f (← f b a₀) a₁, ...]`. -/
@@ -320,7 +336,10 @@ partial def zip [Monad m] (L : MLList m α) (M : MLList m β) : MLList.{u} m (α
 /-- Apply a function returning a monadic lazy list to each element of a monadic lazy list,
 joining the results. -/
 partial def bind [Monad m] (xs : MLList m α) (f : α → MLList m β) : MLList m β :=
-  xs.cases (fun _ => nil) fun x xs => append (f x) (fun _ => bind xs f)
+  xs.cases (fun _ => nil) fun x xs =>
+    match xs.uncons? with
+    | some none => f x
+    | _ => append (f x) (fun _ => bind xs f)
 
 /-- Convert any value in the monad to the singleton monadic lazy list. -/
 def monadLift [Monad m] (x : m α) : MLList m α :=

--- a/test/MLList.lean
+++ b/test/MLList.lean
@@ -1,0 +1,15 @@
+import Std.Data.MLList.Basic
+import Std.Tactic.GuardMsgs
+
+set_option linter.missingDocs false
+
+def g (n : Nat) : MLList Lean.Meta.MetaM Nat := do
+  for _ in [:n] do
+    if true then
+      continue
+  return n
+
+/-- info: #[3000] -/
+-- This used to fail before add the `uncons?` field to the implementation of `MLList`.
+#guard_msgs in
+#eval MLList.asArray $ (g 3000)


### PR DESCRIPTION
Fixes an issue [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/MLList.20crash/near/404755610).