### PR TITLE
fix: DiscrTreeCache.mk init argument should be lazy

### DIFF
--- a/Std/Util/Cache.lean
+++ b/Std/Util/Cache.lean
@@ -128,7 +128,7 @@ from a function that returns a collection of keys and values for each declaratio
 def DiscrTreeCache.mk [BEq α] (profilingName : String)
     (processDecl : Name → ConstantInfo → MetaM (Array (Array DiscrTree.Key × α)))
     (post? : Option (Array α → Array α) := none)
-    (init : Option (DiscrTree α) := none) :
+    (init : Option (MetaM (DiscrTree α)) := none) :
     IO (DiscrTreeCache α) :=
   let updateTree := fun name constInfo tree => do
     return (← processDecl name constInfo).foldl (init := tree) fun t (k, v) =>
@@ -141,7 +141,7 @@ def DiscrTreeCache.mk [BEq α] (profilingName : String)
   | some f => fun (T₁, T₂) => return (T₁, T₂.mapArrays f)
   | none => fun T => pure T
   match init with
-  | some t => return ⟨← Cache.mk (pure ({}, t)), addDecl, addLibraryDecl⟩
+  | some t => return ⟨← Cache.mk (return ({}, ← t)), addDecl, addLibraryDecl⟩
   | none => DeclCache.mk profilingName ({}, {}) addDecl addLibraryDecl (post := post)
 
 /--

--- a/Std/Util/Cache.lean
+++ b/Std/Util/Cache.lean
@@ -106,6 +106,10 @@ def DeclCache.mk (profilingName : String) (pre : Option (MetaM α)) (empty : α)
     (post : α → MetaM α := fun a => pure a) : IO (DeclCache α) := do
   let cache ← Cache.mk do
     try
+      -- We allow arbitrary failures in the `pre` tactic,
+      -- and fall back on folding over the entire environment.
+      -- In practice the `pre` tactic may be unpickling an `.olean`,
+      -- and may fail after leanprover/lean4#2766 because the embedded hash is incorrect.
       match pre with
       | none => failure
       | some r => r


### PR DESCRIPTION
This is causing a terrible problem at Mathlib: the `exact?` and `rw?` caches are being memory mapped at every single file that imports these tactics, rather than just the ones that use these tactics.

Moreover, after nightly-2023-11-29, this causes a build failure on every file if that memory mapped cache has the wrong git hash. The "rebuild-on-failure" mode in this PR means that in the event a memory mapped cache is rejected as invalid, we (silently) rebuilt the cache.

