### PR TITLE
feat: avoid termination_by', introduce WellFounded.wrap

### DIFF
--- a/Std/WF.lean
+++ b/Std/WF.lean
@@ -41,7 +41,7 @@ def log2p1 : Nat → Nat := -- works!
 
 namespace Acc
 
-private local instance wfRel {r : α → α → Prop} : WellFoundedRelation { val // Acc r val } where
+instance wfRel {r : α → α → Prop} : WellFoundedRelation { val // Acc r val } where
   rel := InvImage r (·.1)
   wf  := ⟨fun ac => InvImage.accessible _ ac.2⟩
 
@@ -90,23 +90,18 @@ end Acc
 
 namespace WellFounded
 
-/-- A wrapper type with an `WellFoundedRelation` instance that allows you to explicitly
-indicate the `WellFounded` relation to use in a `termination_by` clause. See `WellFounded.wrap` -/
-def Wrapped {α : Sort u} {r : α → α → Prop} (_h : WellFounded r) := α
+/-- Attaches to `x` the proof that `x` is accessible in the given well-founded relation.
+This can be used in recursive function definitions to explicitly use a differerent relation
+than the one inferred by default:
 
-instance : WellFoundedRelation (Wrapped h) := invImage id ⟨_, h⟩
-
-/-- Wraps a value in `WellFounded.Wrapper` to indicate that this `WellFounded` relation
-should be used.
-
-Example usage:
 ```
 def otherWF : WellFounded Nat := …
 def foo (n : Nat) := …
 termination_by foo n => otherWF.wrap n
 ```
 -/
-def wrap {α : Sort u} {r : α → α → Prop} (h : WellFounded r) (x : α) : h.Wrapped := x
+def wrap {α : Sort u} {r : α → α → Prop} (h : WellFounded r) (x : α) : {x : α // Acc r x} :=
+  ⟨_, h.apply x⟩
 
 /-- A computable version of `WellFounded.fixF`.
 Workaround until Lean has native support for this. -/

--- a/Std/WF.lean
+++ b/Std/WF.lean
@@ -90,6 +90,24 @@ end Acc
 
 namespace WellFounded
 
+/-- A wrapper type with an `WellFoundedRelation` instance that allows you to explicitly
+indicate the `WellFounded` relation to use in a `termination_by` clause. See `WellFounded.wrap` -/
+def Wrapped {α : Sort u} {r : α → α → Prop} (_h : WellFounded r) := α
+
+instance : WellFoundedRelation (Wrapped h) := invImage id ⟨_, h⟩
+
+/-- Wraps a value in `WellFounded.Wrapper` to indicate that this `WellFounded` relation
+should be used.
+
+Example usage:
+```
+def otherWF : WellFounded Nat := …
+def foo (n : Nat) := …
+termination_by foo n => otherWF.wrap n
+```
+-/
+def wrap {α : Sort u} {r : α → α → Prop} (h : WellFounded r) (x : α) : h.Wrapped := x
+
 /-- A computable version of `WellFounded.fixF`.
 Workaround until Lean has native support for this. -/
 @[inline] private def fixFC {α : Sort u} {r : α → α → Prop}
@@ -105,7 +123,7 @@ Workaround until Lean has native support for this. -/
 @[specialize] private def fixC {α : Sort u} {C : α → Sort v} {r : α → α → Prop}
     (hwf : WellFounded r) (F : ∀ x, (∀ y, r y x → C y) → C x) (x : α) : C x :=
   F x (fun y _ => fixC hwf F y)
-termination_by' ⟨r, hwf⟩
+termination_by _ x => hwf.wrap x
 
 @[csimp] private theorem fix_eq_fixC : @fix = @fixC := rfl
 


### PR DESCRIPTION
I’d like to remove support for the `termination_by'` annotation. Until
https://github.com/leanprover/std4/pull/371 it wasn't used anywhere else in
lean, std, mathlib, so this PR removes the single use of it.

It does so using the pattern that can be used to replace uses of
`termination_by'`: Using `WellFounded.wrap` one can indicate an explicit
`WellFounded` relation to use.

This also un-privates the `wfRel` instance for `WellFoundedRelation { val // Acc r val }`
which looks useful enough.

So this PR uses that pattern to avoid the use of `termination_by'` here,
and at the same time provides the necessary definitions for others, so
when Lean drops support for `termination_by'`
(https://github.com/leanprover/lean4/pull/3033), we can tell users how
migrate.
