### PR TITLE
Incremental Library Search

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -143,6 +143,7 @@ import Std.Tactic.HaveI
 import Std.Tactic.Instances
 import Std.Tactic.LabelAttr
 import Std.Tactic.LeftRight
+import Std.Tactic.LibrarySearch
 import Std.Tactic.Lint
 import Std.Tactic.Lint.Basic
 import Std.Tactic.Lint.Frontend

--- a/Std.lean
+++ b/Std.lean
@@ -105,7 +105,7 @@ import Std.Lean.Meta.DiscrTree
 import Std.Lean.Meta.Expr
 import Std.Lean.Meta.Inaccessible
 import Std.Lean.Meta.InstantiateMVars
---import Std.Lean.Meta.LazyDiscrTree
+import Std.Lean.Meta.LazyDiscrTree
 import Std.Lean.Meta.SavedState
 import Std.Lean.Meta.Simp
 import Std.Lean.Meta.UnusedNames
@@ -144,7 +144,7 @@ import Std.Tactic.HaveI
 import Std.Tactic.Instances
 import Std.Tactic.LabelAttr
 import Std.Tactic.LeftRight
---import Std.Tactic.LibrarySearch
+import Std.Tactic.LibrarySearch
 import Std.Tactic.Lint
 import Std.Tactic.Lint.Basic
 import Std.Tactic.Lint.Frontend

--- a/Std.lean
+++ b/Std.lean
@@ -105,6 +105,7 @@ import Std.Lean.Meta.DiscrTree
 import Std.Lean.Meta.Expr
 import Std.Lean.Meta.Inaccessible
 import Std.Lean.Meta.InstantiateMVars
+import Std.Lean.Meta.LazyDiscrTree
 import Std.Lean.Meta.SavedState
 import Std.Lean.Meta.Simp
 import Std.Lean.Meta.UnusedNames

--- a/Std.lean
+++ b/Std.lean
@@ -105,7 +105,7 @@ import Std.Lean.Meta.DiscrTree
 import Std.Lean.Meta.Expr
 import Std.Lean.Meta.Inaccessible
 import Std.Lean.Meta.InstantiateMVars
-import Std.Lean.Meta.LazyDiscrTree
+--import Std.Lean.Meta.LazyDiscrTree
 import Std.Lean.Meta.SavedState
 import Std.Lean.Meta.Simp
 import Std.Lean.Meta.UnusedNames
@@ -144,7 +144,7 @@ import Std.Tactic.HaveI
 import Std.Tactic.Instances
 import Std.Tactic.LabelAttr
 import Std.Tactic.LeftRight
-import Std.Tactic.LibrarySearch
+--import Std.Tactic.LibrarySearch
 import Std.Tactic.Lint
 import Std.Tactic.Lint.Basic
 import Std.Tactic.Lint.Frontend

--- a/Std/Lean/Meta/Basic.lean
+++ b/Std/Lean/Meta/Basic.lean
@@ -458,11 +458,6 @@ def getLocalHyps [Monad m] [MonadLCtx m] : m (Array Expr) := do
     if !d.isImplementationDetail then hs := hs.push d.toExpr
   return hs
 
-/-- Count how many local hypotheses appear in an expression. -/
-def countLocalHypsUsed [Monad m] [MonadLCtx m] [MonadMCtx m] (e : Expr) : m Nat := do
-  let e' ← instantiateMVars e
-  return (← getLocalHyps).foldr (init := 0) fun h n => if h.occurs e' then n + 1 else n
-
 /--
 Given a monadic function `F` that takes a type and a term of that type and produces a new term,
 lifts this to the monadic function that opens a `∀` telescope, applies `F` to the body,

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -312,7 +312,7 @@ end MatchClone
 export MatchClone (Key Key.const)
 
 /--
-An unprocessed entry in the lazy discriminator tree.
+An unprocessed entry in the lazy discrimination tree.
 -/
 private abbrev LazyEntry α := Array Expr × ((LocalContext × LocalInstances) × α)
 

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -16,7 +16,7 @@ lazy initialization strategy.
 
 The discrimination tree can be created through
 `createImportedEnvironment`. This creates a discrimination tree from all
-imported modules in an environment using a callback that proviees the
+imported modules in an environment using a callback that provides the
 entries as `InitEntry` values.
 
 The function `getMatch` can be used to get the values that match the

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2023 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joe Hendrix, Scott Morrison
+-/
+
 import Lean.Meta.DiscrTree
 import Std.Data.Nat.Init.Lemmas
 

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -788,7 +788,7 @@ private def createImportedEnvironmentSeq (env : Environment)
               toFlat d tree
   termination_by go _ idx stop => stop - idx
 
-/-- Get the rests of each task and merge using combining function -/
+/-- Get the results of each task and merge using combining function -/
 private def combineGet [Append α] (z : α) (tasks : Array (Task α)) : α :=
   tasks.foldl (fun x t => x ++ t.get) (init := z)
 

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -605,7 +605,7 @@ private def modifyAt (d : PreDiscrTree α) (k : Key)
   | .some i =>
     { roots, tries := tries.modify i f }
 
-/-- Add an entries to the pre-discrimination tree.-/
+/-- Add an entry to the pre-discrimination tree.-/
 private def push (d : PreDiscrTree α) (k : Key) (e : LazyEntry α) : PreDiscrTree α :=
   d.modifyAt k (·.push e)
 

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -7,6 +7,22 @@ Authors: Joe Hendrix, Scott Morrison
 import Lean.Meta.DiscrTree
 import Std.Data.Nat.Init.Lemmas
 
+/-!
+# Lazy Discrimination Tree
+
+This file defines a new type of discrimination tree optimized for
+rapidly population of imported modules for use in tactics.  It uses a
+lazy initialization strategy.
+
+The discrimination tree can be created through
+`createImportedEnvironment`. This creates a discrimination tree from all
+imported modules in an environment using a callback that proviees the
+entries as `InitEntry` values.
+
+The function `getMatch` can be used to get the values that match the
+expression as well as an updated lazy discrimination tree that has
+elaborated additional parts of the tree.
+-/
 namespace Lean.Meta.LazyDiscrTree
 
 -- This namespace contains definitions copied from Lean.Meta.DiscrTree.

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -589,7 +589,7 @@ of elements using concurrent functions for generating entries.
 private structure PreDiscrTree (α : Type) where
   /-- Maps keys to index in tries array. -/
   roots : HashMap Key Nat := {}
-  /-- Lazy entries for root of treie-/
+  /-- Lazy entries for root of trie. -/
   tries : Array (Array (LazyEntry α)) := #[]
   deriving Inhabited
 

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -616,13 +616,13 @@ def toLazy (d : PreDiscrTree α) (config : WhnfCoreConfig := {}) : LazyDiscrTree
 
 /-- Merge two discrimination trees. -/
 protected def append (x y : PreDiscrTree α) : PreDiscrTree α :=
-  if x.roots.size ≥ y.roots.size then
-    aux x y (fun y x => x ++ y)
-  else
-    aux y x (fun x y => y ++ x)
-  where aux x y (f : Array (LazyEntry α) → Array (LazyEntry α) → Array (LazyEntry α)) :=
-    let { roots := yk, tries := ya } := y
-    yk.fold (init := x) fun d k yi => d.modifyAt k (f ya[yi]!)
+  let (x, y, f) :=
+        if x.roots.size ≥ y.roots.size then
+          (x, y, fun y x => x ++ y)
+        else
+          (y, x, fun x y => x ++ y)
+  let { roots := yk, tries := ya } := y
+  yk.fold (init := x) fun d k yi => d.modifyAt k (f ya[yi]!)
 
 instance : Append (PreDiscrTree α) where
   append := PreDiscrTree.append

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -1,0 +1,579 @@
+import Lean.Meta.DiscrTree
+import Std.Data.Nat.Init.Lemmas
+
+namespace Lean.Meta
+
+namespace LazyDiscrTree
+
+namespace MatchClone
+open DiscrTree
+
+private def tmpMVarId : MVarId := { name := `_discr_tree_tmp }
+private def tmpStar := mkMVar tmpMVarId
+
+/--
+  Return true iff the argument should be treated as a "wildcard" by the discrimination tree.
+
+  - We ignore proofs because of proof irrelevance. It doesn't make sense to try to
+    index their structure.
+
+  - We ignore instance implicit arguments (e.g., `[Add α]`) because they are "morally" canonical.
+    Moreover, we may have many definitionally equal terms floating around.
+    Example: `Ring.hasAdd Int Int.isRing` and `Int.hasAdd`.
+
+  - We considered ignoring implicit arguments (e.g., `{α : Type}`) since users don't "see" them,
+    and may not even understand why some simplification rule is not firing.
+    However, in type class resolution, we have instance such as `Decidable (@Eq Nat x y)`,
+    where `Nat` is an implicit argument. Thus, we would add the path
+    ```
+    Decidable -> Eq -> * -> * -> * -> [Nat.decEq]
+    ```
+    to the discrimination tree IF we ignored the implicit `Nat` argument.
+    This would be BAD since **ALL** decidable equality instances would be in the same path.
+    So, we index implicit arguments if they are types.
+    This setting seems sensible for simplification theorems such as:
+    ```
+    forall (x y : Unit), (@Eq Unit x y) = true
+    ```
+    If we ignore the implicit argument `Unit`, the `DiscrTree` will say it is a candidate
+    simplification theorem for any equality in our goal.
+
+  Remark: if users have problems with the solution above, we may provide a `noIndexing` annotation,
+  and `ignoreArg` would return true for any term of the form `noIndexing t`.
+-/
+private def ignoreArg (a : Expr) (i : Nat) (infos : Array ParamInfo) : MetaM Bool := do
+  if h : i < infos.size then
+    let info := infos.get ⟨i, h⟩
+    if info.isInstImplicit then
+      return true
+    else if info.isImplicit || info.isStrictImplicit then
+      return not (← isType a)
+    else
+      isProof a
+  else
+    isProof a
+
+private partial def pushArgsAux (infos : Array ParamInfo) : Nat → Expr → Array Expr → MetaM (Array Expr)
+  | i, .app f a, todo => do
+    if (← ignoreArg a i infos) then
+      pushArgsAux infos (i-1) f (todo.push tmpStar)
+    else
+      pushArgsAux infos (i-1) f (todo.push a)
+  | _, _, todo => return todo
+
+/--
+  Return true if `e` is one of the following
+  - A nat literal (numeral)
+  - `Nat.zero`
+  - `Nat.succ x` where `isNumeral x`
+  - `OfNat.ofNat _ x _` where `isNumeral x` -/
+private partial def isNumeral (e : Expr) : Bool :=
+  if e.isNatLit then true
+  else
+    let f := e.getAppFn
+    if !f.isConst then false
+    else
+      let fName := f.constName!
+      if fName == ``Nat.succ && e.getAppNumArgs == 1 then isNumeral e.appArg!
+      else if fName == ``OfNat.ofNat && e.getAppNumArgs == 3 then isNumeral (e.getArg! 1)
+      else if fName == ``Nat.zero && e.getAppNumArgs == 0 then true
+      else false
+
+private partial def toNatLit? (e : Expr) : Option Literal :=
+  if isNumeral e then
+    if let some n := loop e then
+      some (.natVal n)
+    else
+      none
+  else
+    none
+where
+  loop (e : Expr) : OptionT Id Nat := do
+    let f := e.getAppFn
+    match f with
+    | .lit (.natVal n) => return n
+    | .const fName .. =>
+      if fName == ``Nat.succ && e.getAppNumArgs == 1 then
+        let r ← loop e.appArg!
+        return r+1
+      else if fName == ``OfNat.ofNat && e.getAppNumArgs == 3 then
+        loop (e.getArg! 1)
+      else if fName == ``Nat.zero && e.getAppNumArgs == 0 then
+        return 0
+      else
+        failure
+    | _ => failure
+
+private def isNatType (e : Expr) : MetaM Bool :=
+  return (← whnf e).isConstOf ``Nat
+
+/--
+  Return true if `e` is one of the following
+  - `Nat.add _ k` where `isNumeral k`
+  - `Add.add Nat _ _ k` where `isNumeral k`
+  - `HAdd.hAdd _ Nat _ _ k` where `isNumeral k`
+  - `Nat.succ _`
+  This function assumes `e.isAppOf fName`
+-/
+private def isOffset (fName : Name) (e : Expr) : MetaM Bool := do
+  if fName == ``Nat.add && e.getAppNumArgs == 2 then
+    return isNumeral e.appArg!
+  else if fName == ``Add.add && e.getAppNumArgs == 4 then
+    if (← isNatType (e.getArg! 0)) then return isNumeral e.appArg! else return false
+  else if fName == ``HAdd.hAdd && e.getAppNumArgs == 6 then
+    if (← isNatType (e.getArg! 1)) then return isNumeral e.appArg! else return false
+  else
+    return fName == ``Nat.succ && e.getAppNumArgs == 1
+
+/--
+  TODO: add hook for users adding their own functions for controlling `shouldAddAsStar`
+  Different `DiscrTree` users may populate this set using, for example, attributes.
+
+  Remark: we currently tag "offset" terms as star to avoid having to add special
+  support for offset terms.
+  Example, suppose the discrimination tree contains the entry
+  `Nat.succ ?m |-> v`, and we are trying to retrieve the matches for `Expr.lit (Literal.natVal 1) _`.
+  In this scenario, we want to retrieve `Nat.succ ?m |-> v`
+-/
+private def shouldAddAsStar (fName : Name) (e : Expr) : MetaM Bool := do
+  isOffset fName e
+
+
+/--
+  Try to eliminate loose bound variables by performing beta-reduction.
+  We use this method when processing terms in discrimination trees.
+  These trees distinguish dependent arrows from nondependent ones.
+  Recall that dependent arrows are indexed as `.other`, but nondependent arrows as `.arrow ..`.
+  Motivation: we want to "discriminate" implications and simple arrows in our index.
+
+  Now suppose we add the term `Foo (Nat → Nat)` to our index. The nested arrow appears as
+  `.arrow ..`. Then, suppose we want to check whether the index contains
+  `(x : Nat) → (fun _ => Nat) x`, but it will fail to retrieve `Foo (Nat → Nat)` because
+  it assumes the nested arrow is a dependent one and uses `.other`.
+
+  We use this method to address this issue by beta-reducing terms containing loose bound variables.
+  See issue #2232.
+
+  Remark: we expect the performance impact will be minimal.
+-/
+private def elimLooseBVarsByBeta (e : Expr) : CoreM Expr :=
+  Core.transform e
+    (pre := fun e => do
+      if !e.hasLooseBVars then
+        return .done e
+      else if e.isHeadBetaTarget then
+        return .visit e.headBeta
+      else
+        return .continue)
+
+private def getKeyArgs (e : Expr) (isMatch root : Bool) (config : WhnfCoreConfig) : MetaM (Key × Array Expr) := do
+  let e ← reduceDT e root config
+  unless root do
+    -- See pushArgs
+    if let some v := toNatLit? e then
+      return (.lit v, #[])
+  match e.getAppFn with
+  | .lit v         => return (.lit v, #[])
+  | .const c _     =>
+    if (← getConfig).isDefEqStuckEx && e.hasExprMVar then
+      if (← isReducible c) then
+        /- `e` is a term `c ...` s.t. `c` is reducible and `e` has metavariables, but it was not unfolded.
+           This can happen if the metavariables in `e` are "blocking" smart unfolding.
+           If `isDefEqStuckEx` is enabled, then we must throw the `isDefEqStuck` exception to postpone TC resolution.
+           Here is an example. Suppose we have
+           ```
+            inductive Ty where
+              | bool | fn (a ty : Ty)
+
+
+            @[reducible] def Ty.interp : Ty → Type
+              | bool   => Bool
+              | fn a b => a.interp → b.interp
+           ```
+           and we are trying to synthesize `BEq (Ty.interp ?m)`
+        -/
+        Meta.throwIsDefEqStuck
+      else if let some matcherInfo := isMatcherAppCore? (← getEnv) e then
+        -- A matcher application is stuck is one of the discriminants has a metavariable
+        let args := e.getAppArgs
+        for arg in args[matcherInfo.getFirstDiscrPos: matcherInfo.getFirstDiscrPos + matcherInfo.numDiscrs] do
+          if arg.hasExprMVar then
+            Meta.throwIsDefEqStuck
+      else if (← isRec c) then
+        /- Similar to the previous case, but for `match` and recursor applications. It may be stuck (i.e., did not reduce)
+           because of metavariables. -/
+        Meta.throwIsDefEqStuck
+    let nargs := e.getAppNumArgs
+    return (.const c nargs, e.getAppRevArgs)
+  | .fvar fvarId   =>
+    let nargs := e.getAppNumArgs
+    return (.fvar fvarId nargs, e.getAppRevArgs)
+  | .mvar mvarId   =>
+    if isMatch then
+      return (.other, #[])
+    else do
+      let ctx ← read
+      if ctx.config.isDefEqStuckEx then
+        /-
+          When the configuration flag `isDefEqStuckEx` is set to true,
+          we want `isDefEq` to throw an exception whenever it tries to assign
+          a read-only metavariable.
+          This feature is useful for type class resolution where
+          we may want to notify the caller that the TC problem may be solvable
+          later after it assigns `?m`.
+          The method `DiscrTree.getUnify e` returns candidates `c` that may "unify" with `e`.
+          That is, `isDefEq c e` may return true. Now, consider `DiscrTree.getUnify d (Add ?m)`
+          where `?m` is a read-only metavariable, and the discrimination tree contains the keys
+          `HadAdd Nat` and `Add Int`. If `isDefEqStuckEx` is set to true, we must treat `?m` as
+          a regular metavariable here, otherwise we return the empty set of candidates.
+          This is incorrect because it is equivalent to saying that there is no solution even if
+          the caller assigns `?m` and try again. -/
+        return (.star, #[])
+      else if (← mvarId.isReadOnlyOrSyntheticOpaque) then
+        return (.other, #[])
+      else
+        return (.star, #[])
+  | .proj s i a .. =>
+    let nargs := e.getAppNumArgs
+    return (.proj s i nargs, #[a] ++ e.getAppRevArgs)
+  | .forallE _ d b _ =>
+    -- See comment at elimLooseBVarsByBeta
+    let b ← if b.hasLooseBVars then elimLooseBVarsByBeta b else pure b
+    if b.hasLooseBVars then
+      return (.other, #[])
+    else
+      return (.arrow, #[d, b])
+  | _ =>
+    return (.other, #[])
+
+/- Copy of Lean.Meta.DiscrTree.getMatchKeyArgs -/
+private abbrev getMatchKeyArgs (e : Expr) (root : Bool) (config : WhnfCoreConfig) : MetaM (Key × Array Expr) :=
+  getKeyArgs e (isMatch := true) (root := root) (config := config)
+
+end MatchClone
+
+export DiscrTree (Key)
+
+/--
+Stack of subexpressions to process to generate key.
+-/
+def ExprRest := Array Expr
+
+/--
+An unprocessed entry in the lazy discriminator tree.
+-/
+abbrev LazyEntry α := ExprRest × ((LocalContext × LocalInstances) × α)
+
+/--
+Index identifying trie in a discriminator tree.
+-/
+@[reducible]
+def TrieIndex := Nat
+
+/--
+Discrimination tree trie. See `LazyDiscrTree`.
+-/
+structure Trie (α : Type) where
+  node ::
+    /-- Values for matches ending at this trie. -/
+    values : Array α
+    /-- Index of trie matching star. -/
+    star : TrieIndex
+    /-- Following matches based on key of trie. -/
+    children : HashMap Key TrieIndex
+    /-- Lazy entries at this trie that are not processed. -/
+    pending : Array (LazyEntry α)
+  deriving Inhabited
+
+private def Trie.pushPending : Trie α  → LazyEntry α → Trie α
+| .node vs star cs p, e => .node vs star cs (p.push e)
+
+end LazyDiscrTree
+
+/--
+`LazyDiscrTree` is a variant of the discriminator tree datatype
+`DiscrTree` in Lean core that is designed to be efficiently
+initializable with a large number of patterns.  This is useful
+in contexts such as searching an entire Lean environment for
+expressions that match a pattern.
+
+Lazy discriminator trees achieve good performance by minimizing
+the amount of work that is done up front to build the discriminator
+tree.  When first adding patterns to the tree, only the root
+discriminator key is computed and processing the remaining
+terms is deferred until demanded by a match.
+-/
+structure LazyDiscrTree (α : Type) where
+  /-- Configuration for normalization. -/
+  config : Lean.Meta.WhnfCoreConfig := {}
+  /-- Backing array of trie entries.  Should be owned by this trie. -/
+  array : Array (LazyDiscrTree.Trie α) := #[default]
+  /-- Map from disriminator trie roots to the index. -/
+  root : Lean.HashMap LazyDiscrTree.Key LazyDiscrTree.TrieIndex := {}
+
+namespace LazyDiscrTree
+
+open Lean Elab Meta
+
+instance : Inhabited (LazyDiscrTree α) where
+  default := {}
+
+/-- Return true if trie is empty. -/
+def isEmpty (t:LazyDiscrTree α) : Bool := t.array.size ≤ 1
+
+open Lean.Meta.DiscrTree (mkNoindexAnnotation hasNoindexAnnotation reduceDT)
+
+/--
+Specialization of Lean.Meta.DiscrTree.pushArgs
+-/
+private def pushArgs (root : Bool) (todo : ExprRest) (e : Expr) (config : WhnfCoreConfig) :
+    MetaM (Key × ExprRest) := do
+  if hasNoindexAnnotation e then
+    return (.star, todo)
+  else
+    let e ← reduceDT e root config
+    let fn := e.getAppFn
+    let push (k : Key) (nargs : Nat) (todo : ExprRest) : MetaM (Key × ExprRest) := do
+      let info ← getFunInfoNArgs fn nargs
+      let todo ← MatchClone.pushArgsAux info.paramInfo (nargs-1) e todo
+      return (k, todo)
+    match fn with
+    | .lit v     =>
+      return (.lit v, todo)
+    | .const c _ =>
+      unless root do
+        if let some v := MatchClone.toNatLit? e then
+          return (.lit v, todo)
+        if (← MatchClone.shouldAddAsStar c e) then
+          return (.star, todo)
+      let nargs := e.getAppNumArgs
+      push (.const c nargs) nargs todo
+    | .proj s i a =>
+      /-
+      If `s` is a class, then `a` is an instance. Thus, we annotate `a` with `no_index` since we do not
+      index instances. This should only happen if users mark a class projection function as `[reducible]`.
+
+      TODO: add better support for projections that are functions
+      -/
+      let a := if isClass (← getEnv) s then mkNoindexAnnotation a else a
+      let nargs := e.getAppNumArgs
+      push (.proj s i nargs) nargs (todo.push a)
+    | .fvar _fvarId   =>
+--      let bi ← fvarId.getBinderInfo
+--      if bi.isInstImplicit then
+--        return (.other, todo)
+--      else
+      return (.star, todo)
+    | .mvar mvarId   =>
+      if mvarId == MatchClone.tmpMVarId then
+        -- We use `tmp to mark implicit arguments and proofs
+        return (.star, todo)
+      else
+        failure
+    | .forallE _ d b _ =>
+      -- See comment at elimLooseBVarsByBeta
+      let b ← if b.hasLooseBVars then MatchClone.elimLooseBVarsByBeta b else pure b
+      if b.hasLooseBVars then
+        return (.other, todo)
+      else
+        return (.arrow, (todo.push d).push b)
+    | _ =>
+      return (.other, todo)
+
+/-- Initial capacity for key and todo vector. -/
+private def initCapacity := 8
+
+/--
+Adds an association between the given expression (which should use free variables
+-/
+def addEntry : LazyDiscrTree α → LocalContext × LocalInstances → Expr → α → MetaM (LazyDiscrTree α)
+| { config := c, array := a, root := r }, lctx, type, v => withReducible $ do
+  let todo := Array.mkEmpty initCapacity
+  let (k, todo) ← withLCtx lctx.1 lctx.2 $ pushArgs true todo type c
+  let rest := (todo, lctx, v)
+  match r.find? k with
+  | none =>
+    let r := r.insert k a.size
+    let a := a.push (.node #[] 0 {} #[rest])
+    pure { config := c, array := a, root := r }
+  | some idx =>
+    let a := a.modify idx fun t => t.pushPending rest
+    pure { config := c, array := a, root := r }
+
+private partial def mkPathAux (root : Bool) (todo : Array Expr) (keys : Array Key) (config : WhnfCoreConfig) : MetaM (Array Key) := do
+  if todo.isEmpty then
+    return keys
+  else
+    let e    := todo.back
+    let todo := todo.pop
+    let (k, todo) ← pushArgs root todo e config
+    mkPathAux false todo (keys.push k) config
+
+/--
+Create a path from an expression.
+
+This differs from Lean.Meta.DiscrTree.mkPath in that the expression
+should uses free variables rather than meta-variables for holes.
+-/
+def mkPath (e : Expr) (config : WhnfCoreConfig) : MetaM (Array Key) := do
+  let todo : Array Expr := .mkEmpty initCapacity
+  let keys : Array Key := .mkEmpty initCapacity
+  mkPathAux (root := true) (todo.push e) keys config
+
+/- Monad for finding matches while resolving deferred patterns. -/
+@[reducible]
+private def MatchM α := ReaderT WhnfCoreConfig (StateRefT (Array (Trie α)) MetaM)
+
+private def runMatch (m : MatchM α β) (d : LazyDiscrTree α) : MetaM (β × LazyDiscrTree α) := do
+  let { config := c, array := a, root := r } := d
+  let (result, a) ← withReducible $ (m.run c).run a
+  pure (result, { config := c, array := a, root := r})
+
+private def setTrie (i : TrieIndex) (v : Trie α) : MatchM α Unit :=
+  modify (·.set! i v)
+
+private def modifyTrie (i:TrieIndex) (e : LazyEntry α) : MatchM α Unit :=
+  modify (·.modify i (·.pushPending e))
+
+private def newTrie [Monad m] [MonadState (Array (Trie α)) m] (e : LazyEntry α) : m TrieIndex := do
+  modifyGet fun a => let sz := a.size; (sz, a.push (.node #[] 0 {} #[e]))
+
+private partial def processEntries (config : WhnfCoreConfig)
+    (values : Array α)
+    (starIdx : TrieIndex)
+    (children : HashMap Key TrieIndex)
+    (entries : Array (LazyEntry α)) :
+    MatchM α (Array α × TrieIndex × HashMap Key TrieIndex) := do
+  if h : entries.size = 0 then
+    pure (values, starIdx, children)
+  else
+    let p : entries.size - 1 < entries.size := Nat.sub_lt (Nat.pos_of_ne_zero h) (Nat.le_refl _)
+    let (todo, lctx, v) := entries[entries.size - 1]
+    let entries := entries.pop
+    if todo.isEmpty then
+      let values := values.push v
+      processEntries config values starIdx children entries
+    else
+      let e    := todo.back
+      let todo := todo.pop
+      let (k, todo) ← withLCtx lctx.1 lctx.2 $ pushArgs false todo e config
+      if k == .star then
+        if starIdx = 0 then
+          let starIdx ← newTrie (todo, lctx, v)
+          processEntries config values starIdx children entries
+        else
+          modifyTrie starIdx (todo, lctx, v)
+          processEntries config values starIdx children entries
+      else
+        match children.find? k with
+        | none =>
+          let children := children.insert k (← newTrie (todo, lctx, v))
+          processEntries config values starIdx children entries
+        | some idx =>
+          modifyTrie idx (todo, lctx, v)
+          processEntries config values starIdx children entries
+
+private def evalNode (c : TrieIndex) :
+    MatchM α (Array α × TrieIndex × HashMap Key TrieIndex) := do
+  let .node vs star cs pending := (←get).get! c
+  if pending.size = 0 then
+    pure (vs, star, cs)
+  else
+    let config ← read
+    setTrie c default
+    let (vs, star, cs) ← processEntries config vs star cs pending
+    setTrie c <| .node vs star cs #[]
+    pure (vs, star, cs)
+
+/--
+Return the information about the trie at the given idnex.
+
+Used for internal debugging purposes.
+-/
+def getTrie (d : LazyDiscrTree α) (idx : TrieIndex) :
+    MetaM ((Array α × TrieIndex × HashMap Key TrieIndex) × LazyDiscrTree α) :=
+  runMatch (evalNode idx) d
+
+private structure MatchResult (α : Type) where
+  elts : Array (Array α) := #[]
+
+private def MatchResult.push (r : MatchResult α) (a : Array α) : MatchResult α :=
+  if a.isEmpty then r else ⟨r.elts.push a⟩
+
+private partial def MatchResult.toArrayRev (mr : MatchResult α) : Array α :=
+    loop (Array.mkEmpty n) mr.elts
+  where n := mr.elts.foldl (fun n a => n + a.size) 0
+        loop (r : Array α) a :=
+          if a.isEmpty then
+            r
+          else
+            loop (r ++ a.back) a.pop
+
+private partial def getMatchLoop (todo : Array Expr) (c : TrieIndex) (result : MatchResult α) :
+    MatchM α (MatchResult α) := do
+  let (vs, star, cs) ← evalNode c
+  if todo.isEmpty then
+    return result.push vs
+  else if star == 0 && cs.isEmpty then
+    return result
+  else
+    let e     := todo.back
+    let todo  := todo.pop
+    let (k, args) ← MatchClone.getMatchKeyArgs e (root := false) (←read)
+    /- We must always visit `Key.star` edges since they are wildcards.
+        Thus, `todo` is not used linearly when there is `Key.star` edge
+        and there is an edge for `k` and `k != Key.star`. -/
+    let visitStar (result : MatchResult α) : MatchM α (MatchResult α) :=
+      if star != 0 then
+        getMatchLoop todo star result
+      else
+        return result
+    let visitNonStar (k : Key) (args : Array Expr) (result : MatchResult α) :=
+      match cs.find? k with
+      | none   => return result
+      | some c => getMatchLoop (todo ++ args) c result
+    let result ← visitStar result
+    match k with
+    | .star  => return result
+    /-
+      Note: dep-arrow vs arrow
+      Recall that dependent arrows are `(Key.other, #[])`, and non-dependent arrows are `(Key.arrow, #[a, b])`.
+      A non-dependent arrow may be an instance of a dependent arrow (stored at `DiscrTree`). Thus, we also visit the `Key.other` child.
+    -/
+    | .arrow => visitNonStar .other #[] (← visitNonStar k args result)
+    | _      => visitNonStar k args result
+
+private def getStarResult (root : Lean.HashMap Key TrieIndex) : MatchM α (MatchResult α) :=
+  match root.find? .star with
+  | none =>
+    pure <| {}
+  | some idx => do
+    let (vs, _) ← evalNode idx
+    pure <| ({} : MatchResult α).push vs
+
+private def getMatchRoot (r : Lean.HashMap Key TrieIndex) (k : Key) (args : Array Expr)
+    (result : MatchResult α) : MatchM α (MatchResult α) :=
+  match r.find? k with
+  | none => pure result
+  | some c => getMatchLoop args c result
+
+/--
+  Find values that match `e` in `d`.
+-/
+def getMatchCore (root : Lean.HashMap Key TrieIndex) (e : Expr) : MatchM α (MatchResult α) :=
+  withReducible do
+    let result ← getStarResult root
+    let (k, args) ← MatchClone.getMatchKeyArgs e (root := true) (←read)
+    match k with
+    | .star  => return result
+    /- See note about "dep-arrow vs arrow" at `getMatchLoop` -/
+    | .arrow =>
+      getMatchRoot root k args (←getMatchRoot root .other #[] result)
+    | _ =>
+      getMatchRoot root k args result
+
+/--
+  Find values that match `e` in `d`.
+-/
+def getMatch (d : LazyDiscrTree α) (e : Expr) : MetaM (Array α × LazyDiscrTree α) :=
+  runMatch (MatchResult.toArrayRev <$> getMatchCore d.root e) d

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -482,7 +482,7 @@ private def addLazyEntryToTrie (i:TrieIndex) (e : LazyEntry α) : MatchM α Unit
   modify (·.modify i (·.pushPending e))
 
 /--
-This evaluates all lazy entries in a trie and adds updates values starIdx and children
+This evaluates all lazy entries in a trie and updates `values`, `starIdx`, and `children`
 accordingly.
 -/
 private partial def evalLazyEntries (config : WhnfCoreConfig)

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -570,8 +570,8 @@ private partial def MatchResult.toArray (mr : MatchResult α) : Array α :=
           else
             loop (a.back.foldl (init := r) (fun r a => r ++ a)) a.pop
 
-private partial def getMatchLoop (todo : Array Expr) (score : Nat) (c : TrieIndex) (result : MatchResult α) :
-    MatchM α (MatchResult α) := do
+private partial def getMatchLoop (todo : Array Expr) (score : Nat) (c : TrieIndex)
+    (result : MatchResult α) : MatchM α (MatchResult α) := do
   let (vs, star, cs) ← evalNode c
   if todo.isEmpty then
     return result.push score vs

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -317,7 +317,7 @@ structure LazyDiscrTree (α : Type) where
   config : Lean.Meta.WhnfCoreConfig := {}
   /-- Backing array of trie entries.  Should be owned by this trie. -/
   tries : Array (LazyDiscrTree.Trie α) := #[default]
-  /-- Map from disriminator trie roots to the index. -/
+  /-- Map from discriminator trie roots to the index. -/
   roots : Lean.HashMap LazyDiscrTree.Key LazyDiscrTree.TrieIndex := {}
 
 namespace LazyDiscrTree

--- a/Std/Lean/Meta/LazyDiscrTree.lean
+++ b/Std/Lean/Meta/LazyDiscrTree.lean
@@ -315,7 +315,7 @@ An unprocessed entry in the lazy discriminator tree.
 private abbrev LazyEntry α := Array Expr × ((LocalContext × LocalInstances) × α)
 
 /--
-Index identifying trie in a discriminator tree.
+Index identifying trie in a discrimination tree.
 -/
 @[reducible]
 private def TrieIndex := Nat

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -186,7 +186,7 @@ private unsafe def mkImportFinder : IO CandidateFinder := do
 
 
 /--
-Retrieve the current current of lemmas.
+The preferred candidate finding function.
 -/
 initialize defaultCandidateFinder : IO.Ref CandidateFinder ← unsafe do
   IO.mkRef (←mkImportFinder)

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -158,8 +158,8 @@ private def libSearchContext : Meta.Context := {
     config := { transparency := .reducible }
   }
 
-private def pushEntry (r : IO.Ref (PreDiscrTree α)) (lctx : LocalContext × LocalInstances) (type : Expr)
-    (v : α) : MetaM Unit := do
+private def pushEntry (r : IO.Ref (PreDiscrTree α)) (lctx : LocalContext × LocalInstances)
+    (type : Expr) (v : α) : MetaM Unit := do
   let (k, todo) ← LazyDiscrTree.rootKey' {} type
   r.modify (·.push k (todo, lctx, v))
 
@@ -363,7 +363,8 @@ then try to close subsequent goals using `solveByElim`.
 If `solveByElim` succeeds, we return `[]` as the list of new subgoals,
 otherwise the full list of subgoals.
 -/
-def librarySearchLemma (act : List MVarId → MetaM (List MVarId)) (allowFailure : Bool) (goal : MVarId) (lem : Expr) : MetaM (List MVarId) := do
+def librarySearchLemma (act : List MVarId → MetaM (List MVarId)) (allowFailure : Bool)
+    (goal : MVarId) (lem : Expr) : MetaM (List MVarId) := do
   withTraceNode `Tactic.librarySearch (return m!"{emoji ·} trying {lem}") do
     let newGoals ← goal.apply lem { allowSynthFailures := true }
     try

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -411,7 +411,7 @@ Try to solve the goal either by:
 * or applying a library lemma then calling `solveByElim` on the resulting goals.
 
 If it successfully closes the goal, returns `none`.
-Otherwise, it returns `some a`, where `a : Array (MetavarContext × List MVarId)`,
+Otherwise, it returns `some a`, where `a : Array (List MVarId × MetavarContext)`,
 with an entry for each library lemma which was successfully applied,
 containing the metavariable context after the application, and a list of the subsidiary goals.
 

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -335,7 +335,7 @@ If this list is empty, then no variables remain to be solved, and `tryOnEach` re
 `none` with the environment set so each goal is resolved.
 
 If the action throws an internal exception with the `abortSpeculationId` id then
-further computation is stoped and intermediate results returned. If any other
+further computation is stopped and intermediate results returned. If any other
 exception is thrown, then it is silently discarded.
 -/
 def tryOnEach

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -418,8 +418,11 @@ private def librarySearch' (goal : MVarId)
 
 /--
 Try to solve the goal either by:
-* calling `solveByElim`
-* or applying a library lemma then calling `solveByElim` on the resulting goals.
+* calling `tactic true`
+* or applying a library lemma then calling `tactic false` on the resulting goals.
+
+Typically here `tactic` is `solveByElim`,
+with the `Bool` flag indicating whether it may retry with `exfalso`.
 
 If it successfully closes the goal, returns `none`.
 Otherwise, it returns `some a`, where `a : Array (List MVarId × MetavarContext)`,

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -152,8 +152,7 @@ private def addImport (name : Name) (constInfo : ConstantInfo) :
   forallTelescope constInfo.type fun _ type => do
     let e ← InitEntry.fromExpr type (name, DeclMod.none)
     let a := #[e]
-    let biff := e.key == .const ``Iff 2
-    if biff then
+    if e.key == .const ``Iff 2 then
       let a := a.push (←e.mkSubEntry 0 (name, DeclMod.mp))
       let a := a.push (←e.mkSubEntry 1 (name, DeclMod.mpr))
       pure a

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -413,7 +413,7 @@ Try to solve the goal either by:
 If it successfully closes the goal, returns `none`.
 Otherwise, it returns `some a`, where `a : Array (List MVarId × MetavarContext)`,
 with an entry for each library lemma which was successfully applied,
-containing the metavariable context after the application, and a list of the subsidiary goals.
+containing a list of the subsidiary goals, and the metavariable context after the application.
 
 (Always succeeds, and the metavariable context stored in the monad is reverted,
 unless the goal was completely solved.)

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -431,6 +431,11 @@ instance : Ord SubgoalRankType :=
   have : Ord (Nat × Int) := lexOrd
   lexOrd
 
+/-- Count how many local hypotheses appear in an expression. -/
+def countLocalHypsUsed [Monad m] [MonadLCtx m] [MonadMCtx m] (e : Expr) : m Nat := do
+  let e' ← instantiateMVars e
+  return (← getLocalHyps).foldr (init := 0) fun h n => if h.occurs e' then n + 1 else n
+
 /-- Returns a tuple:
 * are there no remaining goals?
 * how many local hypotheses were used?

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -13,17 +13,20 @@ import Std.Util.Pickle
 /-!
 # Library search
 
-This file defines tactics `exact?` and `apply?`,
+This file defines tactics `std_exact?` and `std_apply?`,
 (formerly known as `library_search`)
-and a term elaborator `exact?%`
+and a term elaborator `std_exact?%`
 that tries to find a lemma
 solving the current goal
 (subgoals are solved using `solveByElim`).
 
 ```
-example : x < x + 1 := exact?%
-example : Nat := by exact?
+example : x < x + 1 := std_exact?%
+example : Nat := by std_exact?
 ```
+
+These functions will likely lose their `std_` prefix once
+we are ready to replace the corresponding implementations in Mathlib.
 -/
 
 namespace Std.Tactic.LibrarySearch

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -1,0 +1,333 @@
+/-
+Copyright (c) 2021 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner, Scott Morrison
+-/
+import Std.Lean.Expr
+import Std.Util.Pickle
+import Std.Util.Cache
+import Std.Tactic.SolveByElim
+import Std.Data.MLList.Heartbeats
+
+/-!
+# Library search
+
+This file defines tactics `exact?` and `apply?`,
+(formerly known as `library_search`)
+and a term elaborator `exact?%`
+that tries to find a lemma
+solving the current goal
+(subgoals are solved using `solveByElim`).
+
+```
+example : x < x + 1 := exact?%
+example : Nat := by exact?
+```
+-/
+
+namespace Std.Tactic.LibrarySearch
+
+open Lean Meta Std.Tactic.TryThis
+
+initialize registerTraceClass `Tactic.librarySearch
+initialize registerTraceClass `Tactic.librarySearch.lemmas
+
+/-- Configuration for `DiscrTree`. -/
+def discrTreeConfig : WhnfCoreConfig := {}
+
+/--
+A "modifier" for a declaration.
+* `none` indicates the original declaration,
+* `mp` indicates that (possibly after binders) the declaration is an `↔`,
+  and we want to consider the forward direction,
+* `mpr` similarly, but for the backward direction.
+-/
+inductive DeclMod
+  | /-- the original declaration -/ none
+  | /-- the forward direction of an `iff` -/ mp
+  | /-- the backward direction of an `iff` -/ mpr
+deriving DecidableEq, Ord
+
+instance : ToString DeclMod where
+  toString m := match m with | .none => "" | .mp => "mp" | .mpr => "mpr"
+
+/--
+An even wider class of "internal" names than reported by `Name.isInternalDetail`.
+-/
+-- from Lean.Server.Completion
+private def isBlackListed (env : Environment) (declName : Name) : Bool :=
+  declName == ``sorryAx
+  || declName.isInternalDetail
+  || declName matches .str _ "inj"
+  || declName matches .str _ "noConfusionType"
+  || isAuxRecursor env declName
+  || isNoConfusion env declName
+  || isRecCore env declName
+  || isMatcherCore env declName
+
+/-- Prepare the discrimination tree entries for a lemma. -/
+def processLemma (name : Name) (constInfo : ConstantInfo) :
+    MetaM (Array (Array DiscrTree.Key × (Name × DeclMod))) := do
+  if constInfo.isUnsafe then return #[]
+  if isBlackListed (←getEnv) name then return #[]
+  withNewMCtxDepth do withReducible do
+    let (_, _, type) ← forallMetaTelescope constInfo.type
+    let keys ← DiscrTree.mkPath type discrTreeConfig
+    let mut r := #[(keys, (name, DeclMod.none))]
+    match type.getAppFnArgs with
+    | (``Iff, #[lhs, rhs]) => do
+      return r.push (← DiscrTree.mkPath rhs discrTreeConfig, (name, DeclMod.mp))
+        |>.push (← DiscrTree.mkPath lhs discrTreeConfig, (name, DeclMod.mpr))
+    | _ => return r
+
+/-- Insert a lemma into the discrimination tree. -/
+-- Recall that `apply?` caches the discrimination tree on disk.
+-- If you are modifying this file, you will probably want to delete
+-- `build/lib/MathlibExtras/LibrarySearch.extra`
+-- so that the cache is rebuilt.
+def addLemma (name : Name) (constInfo : ConstantInfo)
+    (lemmas : DiscrTree (Name × DeclMod)) : MetaM (DiscrTree (Name × DeclMod)) := do
+  let mut lemmas := lemmas
+  for (key, value) in ← processLemma name constInfo do
+    lemmas := lemmas.insertIfSpecific key value discrTreeConfig
+  return lemmas
+
+/-- Construct the discrimination tree of all lemmas. -/
+def buildDiscrTree : IO (DiscrTreeCache (Name × DeclMod)) :=
+  DiscrTreeCache.mk "apply?: init cache" processLemma
+    -- Sort so lemmas with longest names come first.
+    -- This is counter-intuitive, but the way that `DiscrTree.getMatch` returns results
+    -- means that the results come in "batches", with more specific matches *later*.
+    -- Thus we're going to call reverse on the result of `DiscrTree.getMatch`,
+    -- so if we want to try lemmas with shorter names first,
+    -- we need to put them into the `DiscrTree` backwards.
+    (post? := some fun A =>
+      A.map (fun (n, m) => (n.toString.length, n, m)) |>.qsort (fun p q => p.1 > q.1) |>.map (·.2))
+
+open System (FilePath)
+
+/--
+Once we reach Mathlib, and have `cache` available,
+it will be essential that we load a precomputed cache for `exact?` from a `.olean` file.
+
+This makes no sense here in Std, where there is no caching mechanism.
+-/
+def cachePath : IO FilePath :=
+  try
+    return (← findOLean `MathlibExtras.LibrarySearch).withExtension "extra"
+  catch _ =>
+    return "build" / "lib" / "MathlibExtras" / "LibrarySearch.extra"
+
+/--
+Retrieve the current current of lemmas.
+-/
+initialize librarySearchLemmas : DiscrTreeCache (Name × DeclMod) ← unsafe do
+  let path ← cachePath
+  if (← path.pathExists) then
+    let (d, _r) ← unpickle (DiscrTree (Name × DeclMod)) path
+    -- We can drop the `CompactedRegion` value; we do not plan to free it
+    DiscrTreeCache.mk "apply?: using cache" processLemma (init := pure d)
+  else
+    buildDiscrTree
+
+/-- Shortcut for calling `solveByElim`. -/
+def solveByElim (goals : List MVarId) (required : List Expr) (exfalso := false) (depth) := do
+  -- There is only a marginal decrease in performance for using the `symm` option for `solveByElim`.
+  -- (measured via `lake build && time lake env lean test/librarySearch.lean`).
+  let cfg : SolveByElim.Config :=
+    { maxDepth := depth, exfalso := exfalso, symm := true, commitIndependentGoals := true }
+  let cfg := if !required.isEmpty then cfg.requireUsingAll required else cfg
+  SolveByElim.solveByElim.processSyntax cfg false false [] [] #[] goals
+
+private def emoji (e:Except ε α) := if e.toBool then checkEmoji else crossEmoji
+
+/--
+Try applying the given lemma (with symmetry modifier) to the goal,
+then try to close subsequent goals using `solveByElim`.
+If `solveByElim` succeeds, we return `[]` as the list of new subgoals,
+otherwise the full list of subgoals.
+-/
+def librarySearchLemma (lem : Name) (mod : DeclMod) (required : List Expr) (solveByElimDepth := 6)
+    (goal : MVarId) : MetaM (List MVarId) :=
+  withTraceNode `Tactic.librarySearch (return m!"{emoji ·} trying {lem}") do
+    let lem ← mkConstWithFreshMVarLevels lem
+    let lem ← match mod with
+    | .none => pure lem
+    | .mp => mapForallTelescope (fun e => mkAppM ``Iff.mp #[e]) lem
+    | .mpr => mapForallTelescope (fun e => mkAppM ``Iff.mpr #[e]) lem
+    let newGoals ← goal.apply lem { allowSynthFailures := true }
+    try
+      let subgoals ← solveByElim newGoals required (exfalso := false) (depth := solveByElimDepth)
+      pure subgoals
+    catch _ =>
+      if required.isEmpty then
+        pure newGoals
+      else
+        failure
+
+/--
+Returns a lazy list of the results of applying a library lemma,
+then calling `solveByElim` on the resulting goals.
+-/
+def librarySearchCore (goal : MVarId)
+    (required : List Expr) (solveByElimDepth := 6) : Nondet MetaM (List MVarId) :=
+  .squash fun _ => do
+    let ty ← goal.getType
+    let lemmas := (← librarySearchLemmas.getMatch ty).toList
+    trace[Tactic.librarySearch.lemmas] m!"Candidate library_search lemmas:\n{lemmas}"
+    return (Nondet.ofList lemmas).filterMapM fun (lem, mod) =>
+      observing? <| librarySearchLemma lem mod required solveByElimDepth goal
+
+/--
+Run `librarySearchCore` on both the goal and `symm` applied to the goal.
+-/
+def librarySearchSymm (goal : MVarId)
+    (required : List Expr) (solveByElimDepth := 6) :
+    Nondet MetaM (List MVarId) :=
+  (librarySearchCore goal required solveByElimDepth) <|>
+  .squash fun _ => do
+    if let some symm ← observing? goal.applySymm then
+      return librarySearchCore symm required solveByElimDepth
+    else
+      return .nil
+
+/-- A type synonym for our subgoal ranking algorithm. -/
+def subgoalRankType : Type := Bool × Nat × Int
+  deriving ToString
+
+instance : Ord subgoalRankType :=
+  have : Ord (Nat × Int) := lexOrd
+  lexOrd
+
+/-- Returns a tuple:
+* are there no remaining goals?
+* how many local hypotheses were used?
+* how many goals remain, negated?
+
+Larger values (i.e. no remaining goals, more local hypotheses, fewer remaining goals)
+are better.
+-/
+def subgoalRanking (goal : MVarId) (subgoals : List MVarId) : MetaM subgoalRankType := do
+  return (subgoals.isEmpty, ← countLocalHypsUsed (.mvar goal), - subgoals.length)
+
+/-- Sort the incomplete results from `librarySearchCore` according to
+* the number of local hypotheses used (the more the better) and
+* the number of remaining subgoals (the fewer the better).
+-/
+def sortResults (goal : MVarId) (R : Array (List MVarId × MetavarContext)) :
+    MetaM (Array (List MVarId × MetavarContext)) := do
+  let R' ← R.mapM fun (gs, ctx) => do
+    return (← withMCtx ctx (subgoalRanking goal gs), gs, ctx)
+  let R'' := R'.qsort fun a b => compare a.1 b.1 = Ordering.gt
+  return R''.map (·.2)
+
+/--
+Try to solve the goal either by:
+* calling `solveByElim`
+* or applying a library lemma then calling `solveByElim` on the resulting goals.
+
+If it successfully closes the goal, returns `none`.
+Otherwise, it returns `some a`, where `a : Array (MetavarContext × List MVarId)`,
+with an entry for each library lemma which was successfully applied,
+containing the metavariable context after the application, and a list of the subsidiary goals.
+
+(Always succeeds, and the metavariable context stored in the monad is reverted,
+unless the goal was completely solved.)
+
+(Note that if `solveByElim` solves some but not all subsidiary goals,
+this is not currently tracked.)
+-/
+def librarySearch (goal : MVarId) (required : List Expr)
+    (solveByElimDepth := 6) (leavePercentHeartbeats : Nat := 10) :
+    MetaM (Option (Array (List MVarId × MetavarContext))) := do
+  let librarySearchEmoji := fun
+    | .error _ => bombEmoji
+    | .ok (some _) => crossEmoji
+    | .ok none => checkEmoji
+  withTraceNode `Tactic.librarySearch (return m!"{librarySearchEmoji ·} {← goal.getType}") do
+  profileitM Exception "librarySearch" (← getOptions) do
+  (do
+    _ ← solveByElim [goal] required (exfalso := true) (depth := solveByElimDepth)
+    return none) <|>
+  (do
+    let results ← librarySearchSymm goal required solveByElimDepth
+      |>.mapM (fun x => do pure (x, ← getMCtx))
+      |>.toMLList'
+      -- Don't use too many heartbeats.
+      |>.whileAtLeastHeartbeatsPercent leavePercentHeartbeats
+      -- Stop if we find something that closes the goal
+      |>.takeUpToFirst (·.1.isEmpty)
+      |>.asArray
+    match results.find? (·.1.isEmpty) with
+    | none => return (← sortResults goal results)
+    | some (_, ctx) => do
+      setMCtx ctx
+      return none)
+
+open Lean.Parser.Tactic
+
+-- TODO: implement the additional options for `library_search` from Lean 3,
+-- in particular including additional lemmas
+-- with `exact? [X, Y, Z]` or `exact? with attr`.
+
+-- For now we only implement the basic functionality.
+-- The full syntax is recognized, but will produce a "Tactic has not been implemented" error.
+
+/-- Syntax for `exact?` -/
+syntax (name := exact?') "exact?" (config)? (simpArgs)?
+  (" using " (colGt term),+)? : tactic
+
+/-- Syntax for `apply?` -/
+syntax (name := apply?') "apply?" (config)? (simpArgs)?
+  (" using " (colGt term),+)? : tactic
+
+
+open Elab.Tactic Elab Tactic
+
+/-- Implementation of the `exact?` tactic. -/
+def exact? (tk : Syntax) (required : Option (Array (TSyntax `term))) (requireClose : Bool) :
+    TacticM Unit := do
+  let mvar ← getMainGoal
+  let (_, goal) ← (← getMainGoal).intros
+  goal.withContext do
+    let required := (← (required.getD #[]).mapM getFVarId).toList.map .fvar
+    if let some suggestions ← librarySearch goal required then
+      if requireClose then
+        throwError "`exact?` could not close the goal. Try `apply?` to see partial suggestions."
+      reportOutOfHeartbeats `library_search tk
+      for suggestion in suggestions do
+        withMCtx suggestion.2 do
+          addExactSuggestion tk (← instantiateMVars (mkMVar mvar)).headBeta (addSubgoalsMsg := true)
+      if suggestions.isEmpty then logError "apply? didn't find any relevant lemmas"
+      admitGoal goal
+    else
+      addExactSuggestion tk (← instantiateMVars (mkMVar mvar)).headBeta
+
+elab_rules : tactic | `(tactic| exact? $[using $[$required],*]?) => do
+  exact? (← getRef) required true
+
+elab_rules : tactic | `(tactic| apply? $[using $[$required],*]?) => do
+  exact? (← getRef) required false
+
+/-- Deprecation warning for `library_search`. -/
+elab tk:"library_search" : tactic => do
+  logWarning ("`library_search` has been renamed to `apply?`" ++
+    " (or `exact?` if you only want solutions closing the goal)")
+  exact? tk none false
+
+open Elab Term in
+/-- Term elaborator using the `exact?` tactic. -/
+elab tk:"exact?%" : term <= expectedType => do
+  let goal ← mkFreshExprMVar expectedType
+  let (_, introdGoal) ← goal.mvarId!.intros
+  introdGoal.withContext do
+    if let some suggestions ← librarySearch introdGoal [] then
+      reportOutOfHeartbeats `library_search tk
+      for suggestion in suggestions do
+        withMCtx suggestion.2 do
+          addTermSuggestion tk (← instantiateMVars goal).headBeta
+      if suggestions.isEmpty then logError "exact? didn't find any relevant lemmas"
+      mkSorry expectedType (synthetic := true)
+    else
+      addTermSuggestion tk (← instantiateMVars goal).headBeta
+      instantiateMVars goal

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -149,7 +149,8 @@ numbers (<10k) seemed to degrade initialization performance.
 -/
 private def constantsPerTask : Nat := 6500
 
-private def addImport (name : Name) (constInfo : ConstantInfo) : MetaM (Array (InitEntry (Name × DeclMod))) :=
+private def addImport (name : Name) (constInfo : ConstantInfo) :
+    MetaM (Array (InitEntry (Name × DeclMod))) :=
   forallTelescope constInfo.type fun _ type => do
     let e ← InitEntry.fromExpr type (name, DeclMod.none)
     let a := #[e]
@@ -491,8 +492,8 @@ def exact? (tk : Syntax) (required : Option (Array (TSyntax `term)))
       addExactSuggestion tk (← instantiateMVars (mkMVar mvar)).headBeta
     -- Found suggestions
     | some suggestions =>
-      if requireClose then
-        throwError "`std_exact?` could not close the goal. Try `std_apply?` to see partial suggestions."
+      if requireClose then throwError
+        "`std_exact?` could not close the goal. Try `std_apply?` to see partial suggestions."
       reportOutOfHeartbeats `library_search tk
       for (_, suggestionMCtx) in suggestions do
         withMCtx suggestionMCtx do

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -464,10 +464,10 @@ def librarySearchSymm (searchFn : CandidateFinder) (tgt : Expr) : MetaM (Array E
     pure $ l1
 
 /-- A type synonym for our subgoal ranking algorithm. -/
-def subgoalRankType : Type := Bool × Nat × Int
+def SubgoalRankType := Bool × Nat × Int
   deriving ToString
 
-instance : Ord subgoalRankType :=
+instance : Ord SubgoalRankType :=
   have : Ord (Nat × Int) := lexOrd
   lexOrd
 
@@ -479,7 +479,7 @@ instance : Ord subgoalRankType :=
 Larger values (i.e. no remaining goals, more local hypotheses, fewer remaining goals)
 are better.
 -/
-def subgoalRanking (goal : MVarId) (subgoals : List MVarId) : MetaM subgoalRankType := do
+def subgoalRanking (goal : MVarId) (subgoals : List MVarId) : MetaM SubgoalRankType := do
   return (subgoals.isEmpty, ← countLocalHypsUsed (.mvar goal), - subgoals.length)
 
 /-- Sort the incomplete results from `librarySearchCore` according to

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -388,7 +388,8 @@ def librarySearchLemma (act : List MVarId → MetaM (List MVarId)) (allowFailure
 Interleave x y interleaves the elements of x and y until one is empty and then returns
 final elements in other list.
 -/
-def interleaveWith {α β γ} (f : α → γ) (x : Array α) (g : β → γ) (y : Array β) : Array γ  := Id.run do
+def interleaveWith {α β γ} (f : α → γ) (x : Array α) (g : β → γ) (y : Array β) : Array γ :=
+    Id.run do
   let mut res := Array.mkEmpty (x.size + y.size)
   let n := min x.size y.size
   for h : i in [0:n] do

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -71,7 +71,7 @@ open System (FilePath)
 
 /--
 Once we reach Mathlib, and have `cache` available,
-it will be essential that we load a precomputed cache for `exact?` from a `.olean` file.
+we may still want to load a precomputed cache for `exact?` from a `.olean` file.
 
 This makes no sense here in Std, where there is no caching mechanism.
 -/

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 202 Gabriel Ebner. All rights reserved.
+Copyright (c) 2021-2023 Gabriel Ebner and Lean FRO. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner, Joe Hendrix, Scott Morrison
 -/

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2021 Gabriel Ebner. All rights reserved.
+Copyright (c) 202 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Gabriel Ebner, Scott Morrison
+Authors: Gabriel Ebner, Joe Hendrix, Scott Morrison
 -/
 import Std.Lean.CoreM
 import Std.Lean.Expr

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -111,11 +111,6 @@ Constructs an discriminator tree from the current environment.
 def buildImportCache (config : WhnfCoreConfig) : MetaM (DiscrTree (Name × DeclMod)) := do
   let profilingName := "apply?: init cache"
   -- Sort so lemmas with longest names come first.
-  -- This is counter-intuitive, but the way that `DiscrTree.getMatch` returns results
-  -- means that the results come in "batches", with more specific matches *later*.
-  -- Thus we're going to call reverse on the result of `DiscrTree.getMatch`,
-  -- so if we want to try lemmas with shorter names first,
-  -- we need to put them into the `DiscrTree` backwards.
   let post (A : Array (Name × DeclMod)) :=
         A.map (fun (n, m) => (n.toString.length, n, m)) |>.qsort (fun p q => p.1 > q.1) |>.map (·.2)
   profileitM Exception profilingName (← getOptions) do

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -207,7 +207,7 @@ def push (d : PreDiscrTree α) (k : Key) (e : LazyEntry α) : PreDiscrTree α :=
 /-- Convert a pre-discrimination tree to a lazy discrimination tree. -/
 def toTree (d : PreDiscrTree α) (config : WhnfCoreConfig := {}) : LazyDiscrTree α :=
   let { roots, tries } := d
-  { config, root := roots, array := tries.map (.node {} 0 {}) }
+  { config, roots, tries := tries.map (.node {} 0 {}) }
 
 /-- Merge two discrimination trees. -/
 protected def append (x y : PreDiscrTree α) : PreDiscrTree α :=

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -157,7 +157,7 @@ private def addImport (name : Name) (constInfo : ConstantInfo) :
   forallTelescope constInfo.type fun _ type => do
     let e ← InitEntry.fromExpr type (name, DeclMod.none)
     let a := #[e]
-    let biff := e.key == DiscrTree.Key.const ``Iff 2
+    let biff := e.key == .const ``Iff 2
     if biff then
       let a := a.push (←e.mkSubEntry 0 (name, DeclMod.mp))
       let a := a.push (←e.mkSubEntry 1 (name, DeclMod.mpr))

--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -152,12 +152,10 @@ def localMatches (config : WhnfCoreConfig) (ty : Expr) : MetaM (Array (Name × D
 /--
 Candidate finding function that uses strict discrimination tree for resolution.
 -/
-def discrTreeSearchFn (config : WhnfCoreConfig) (importTree : DiscrTree (Name × DeclMod)) (ty : Expr) :
-    MetaM (List (Name × DeclMod)) := do
+def discrTreeSearchFn (config : WhnfCoreConfig) (importTree : DiscrTree (Name × DeclMod))
+    (ty : Expr) : MetaM (List (Name × DeclMod)) := do
   let locals ← localMatches config ty
   let imports := (← importTree.getMatch ty config).reverse
-  for (nm, d) in imports do
-    IO.println s!"Try {nm} : {d}"
   pure <| (locals ++ imports).toList
 
 /--
@@ -194,8 +192,8 @@ This is a monad for building initial discrimination tree.
 @[reducible]
 private def TreeInitM := StateT (LazyDiscrTree (Name × DeclMod)) MetaM
 
-private def pushEntry (lctx : LocalContext × LocalInstances) (type : Expr) (name : Name) (m : DeclMod) :
-    TreeInitM Unit := do
+private def pushEntry (lctx : LocalContext × LocalInstances) (type : Expr) (name : Name)
+    (m : DeclMod) : TreeInitM Unit := do
   fun t => ((),·) <$> t.addEntry lctx type (name, m)
 
 /-- Push entries for constant to array. -/

--- a/Std/Tactic/Relation/Symm.lean
+++ b/Std/Tactic/Relation/Symm.lean
@@ -75,35 +75,13 @@ def applySymm (e : Expr) : MetaM Expr := do
 
 end Lean.Expr
 
-namespace Std.Tactic
-
-/--
-This looks for a symmetry lemma matching the target type.
-
-If it finds it, it returns a pair (f, argType) where f has type `argType -> tgt`.
--/
-def findSymm (tgt : Expr) : MetaM (Option (Expr × Expr)) := do
-  let lems ← Expr.getSymmLems <| (← instantiateMVars tgt).cleanupAnnotations
-  withNewMCtxDepth do
-    for lemName in lems do
-      let (lem, args, body) ← Expr.unpackSymLem lemName
-      if ← isDefEq tgt body then
-        let argType ← instantiateMVars args.back
-        let instArgs ←  args.pop.mapM instantiateMVars
-        -- Create lambda for apply lemma and return it.
-        return (mkAppN lem instArgs, argType)
-    return none
-
-end Std.Tactic
 
 namespace Lean.MVarId
-
 
 /--
 Apply a symmetry lemma (i.e. marked with `@[symm]`) to a metavariable.
 
 The type of `g` should be of the form `a ~ b`, and is used to index the symm lemmas.
-
 -/
 def applySymm (g : MVarId) : MetaM MVarId := do
   let tgt <- g.getTypeCleanup

--- a/Std/Tactic/Relation/Symm.lean
+++ b/Std/Tactic/Relation/Symm.lean
@@ -50,64 +50,73 @@ open Std.Tactic
 
 namespace Lean.Expr
 
+/-- Return the symmetry lemmas that mattch the target type. -/
+def getSymmLems (tgt : Expr) : MetaM (Array Name) := do
+  let .app (.app rel _) _ := tgt
+    | throwError "symmetry lemmas only apply to binary relations, not{indentExpr tgt}"
+  (symmExt.getState (← getEnv)).getMatch rel symmExt.config
+
+/-- FIXME -/
+def unpackSymLem (lem : Name) : MetaM (Expr × Array Expr × Expr) := do
+  let lem ← mkConstWithFreshMVarLevels lem
+  let (args, _, body) ← withReducible <| forallMetaTelescopeReducing (← inferType lem)
+  return (lem, args, body)
+
 /-- Given a term `e : a ~ b`, construct a term in `b ~ a` using `@[symm]` lemmas. -/
 def applySymm (e : Expr) : MetaM Expr := do
-  go (← instantiateMVars (← inferType e)) fun lem args body => do
-    let .true ← isDefEq args.back e | failure
-    mkExpectedTypeHint (mkAppN lem args) (← instantiateMVars body)
-where
-  /--
-  Internal implementation of `Lean.Expr.applySymm`, `Lean.MVarId.applySymm`,
-  and the user-facing tactic.
-
-  `tgt` should be of the form `a ~ b`, and is used to index the symm lemmas.
-
-  `k lem args body` should calculate a result,
-  given a candidate `symm` lemma `lem`, which will have type `∀ args, body`.
-
-  In `Lean.Expr.applySymm` this result will be a new `Expr`,
-  and in `Lean.MVarId.applySymm` and `Lean.MVarId.applySymmAt` this result will be a new goal.
-  -/
-  -- This function is rather opaque, but the design with a generic continuation `k`
-  -- is necessary in order to factor out all the common requirements below.
-  go (tgt : Expr) {α} (k : Expr → Array Expr → Expr → MetaM α) : MetaM α := do
-    let .app (.app rel _) _ := tgt
-      | throwError "symmetry lemmas only apply to binary relations, not{indentExpr tgt}"
-    for lem in ← (symmExt.getState (← getEnv)).getMatch rel symmExt.config do
-      try
-        let lem ← mkConstWithFreshMVarLevels lem
-        let (args, _, body) ← withReducible <| forallMetaTelescopeReducing (← inferType lem)
-        return (← k lem args body)
-      catch _ => pure ()
-    throwError "no applicable symmetry lemma found for{indentExpr tgt}"
+  let tgt <- instantiateMVars (← inferType e)
+  let lems ← getSymmLems tgt
+  let act lem := do
+        let (lem, args, body) ← unpackSymLem lem
+        let .true ← isDefEq args.back e | failure
+        mkExpectedTypeHint (mkAppN lem args) (← instantiateMVars body)
+  lems.toList.firstM act
+    <|> throwError m!"no applicable symmetry lemma found for {indentExpr tgt}"
 
 end Lean.Expr
 
+namespace Std.Tactic
+
+/--
+This looks for a symmetry lemma matching the target type.
+
+If it finds it, it returns a pair (f, argType) where f has type `argType -> tgt`.
+-/
+def findSymm (tgt : Expr) : MetaM (Option (Expr × Expr)) := do
+  let lems ← Expr.getSymmLems <| (← instantiateMVars tgt).cleanupAnnotations
+  withNewMCtxDepth do
+    for lemName in lems do
+      let (lem, args, body) ← Expr.unpackSymLem lemName
+      if ← isDefEq tgt body then
+        let argType ← instantiateMVars args.back
+        let instArgs ←  args.pop.mapM instantiateMVars
+        -- Create lambda for apply lemma and return it.
+        return (mkAppN lem instArgs, argType)
+    return none
+
+end Std.Tactic
+
 namespace Lean.MVarId
 
-/-- Apply a symmetry lemma (i.e. marked with `@[symm]`) to a metavariable. -/
+
+/--
+Apply a symmetry lemma (i.e. marked with `@[symm]`) to a metavariable.
+
+The type of `g` should be of the form `a ~ b`, and is used to index the symm lemmas.
+
+-/
 def applySymm (g : MVarId) : MetaM MVarId := do
-  go (← g.getTypeCleanup) g fun lem args body g => do
-    let .true ← isDefEq (← g.getType) body | failure
-    g.assign (mkAppN lem args)
-    return args.back.mvarId!
-where
-  /--
-  Internal implementation of `Lean.MVarId.applySymm` and the user-facing tactic.
-
-  `tgt` should be of the form `a ~ b`, and is used to index the symm lemmas.
-
-  `k lem args body goal` should transform `goal` into a new goal,
-  given a candidate `symm` lemma `lem`, which will have type `∀ args, body`.
-  Depending on whether we are working on a hypothesis or a goal,
-  `k` will internally use either `replace` or `assign`.
-  -/
-  go (tgt : Expr) (g : MVarId) (k : Expr → Array Expr → Expr → MVarId → MetaM MVarId) :
-    MetaM MVarId := do
-  Expr.applySymm.go tgt fun lem args body => do
-    let g' ← k lem args body g
-    g'.setTag (← g.getTag)
-    return g'
+  let tgt <- g.getTypeCleanup
+  let lems ← Expr.getSymmLems tgt
+  let act lem : MetaM MVarId := do
+        let (lem, args, body) ← Expr.unpackSymLem lem
+        let .true ← isDefEq (← g.getType) body | failure
+        g.assign (mkAppN lem args)
+        let g' := args.back.mvarId!
+        g'.setTag (← g.getTag)
+        pure g'
+  lems.toList.firstM act
+    <|> throwError m!"no applicable symmetry lemma found for {indentExpr tgt}"
 
 /-- Use a symmetry lemma (i.e. marked with `@[symm]`) to replace a hypothesis in a goal. -/
 def applySymmAt (h : FVarId) (g : MVarId) : MetaM MVarId := do

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -1,29 +1,10 @@
 import Std
---import Mathlib.Tactic.LibrarySearch
---import Mathlib.Util.AssertNoSorry
---import Mathlib.Algebra.Order.Ring.Canonical
---import Mathlib.Data.Quot
---import Mathlib.Data.Nat.Prime
---import Mathlib.Data.Real.Basic
-
 set_option autoImplicit true
 
 -- Enable this option for tracing:
--- set_option trace.Tactic.librarySearch true
+-- set_option trace.Tactic.stdLibrarySearch true
 -- And this option to trace all candidate lemmas before application.
--- set_option trace.Tactic.librarySearch.lemmas true
--- It may also be useful to enable
--- set_option trace.Meta.Tactic.solveByElim true
-
--- Recall that `apply?` caches the discrimination tree on disk.
--- If you are modifying the way that `apply?` indexes lemmas,
--- while testing you will probably want to delete
--- `.lake/build/lib/MathlibExtras/LibrarySearch.extra`
--- so that the cache is rebuilt.
-
--- We need to set this here, as the lakefile does not enable this during testing.
--- https://github.com/leanprover-community/mathlib4/issues/6440
-set_option pp.unicode.fun true
+-- set_option trace.Tactic.stdLibrarySearch.lemmas true
 
 noncomputable section
 

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -1,0 +1,243 @@
+import Std
+--import Mathlib.Tactic.LibrarySearch
+--import Mathlib.Util.AssertNoSorry
+--import Mathlib.Algebra.Order.Ring.Canonical
+--import Mathlib.Data.Quot
+--import Mathlib.Data.Nat.Prime
+--import Mathlib.Data.Real.Basic
+
+set_option autoImplicit true
+
+-- Enable this option for tracing:
+-- set_option trace.Tactic.librarySearch true
+-- And this option to trace all candidate lemmas before application.
+-- set_option trace.Tactic.librarySearch.lemmas true
+-- It may also be useful to enable
+-- set_option trace.Meta.Tactic.solveByElim true
+
+-- Recall that `apply?` caches the discrimination tree on disk.
+-- If you are modifying the way that `apply?` indexes lemmas,
+-- while testing you will probably want to delete
+-- `.lake/build/lib/MathlibExtras/LibrarySearch.extra`
+-- so that the cache is rebuilt.
+
+-- We need to set this here, as the lakefile does not enable this during testing.
+-- https://github.com/leanprover-community/mathlib4/issues/6440
+set_option pp.unicode.fun true
+
+noncomputable section
+
+/-- info: Try this: exact Nat.lt.base x -/
+#guard_msgs in
+example (x : Nat) : x ≠ x.succ := Nat.ne_of_lt (by std_apply?)
+
+/-- info: Try this: exact Nat.zero_lt_succ 1 -/
+#guard_msgs in
+example : 0 ≠ 1 + 1 := Nat.ne_of_lt (by std_apply?)
+
+example : 0 ≠ 1 + 1 := Nat.ne_of_lt (by exact Fin.size_pos')
+
+/-- info: Try this: exact Nat.add_comm x y -/
+#guard_msgs in
+example (x y : Nat) : x + y = y + x := by std_apply?
+
+/-- info: Try this: exact fun a ↦ Nat.add_le_add_right a k -/
+#guard_msgs in
+example (n m k : Nat) : n ≤ m → n + k ≤ m + k := by std_apply?
+
+/-- info: Try this: exact Nat.mul_dvd_mul_left a w -/
+#guard_msgs in
+example (ha : a > 0) (w : b ∣ c) : a * b ∣ a * c := by std_apply?
+
+-- Could be any number of results (`Int.one`, `Int.zero`, etc)
+#guard_msgs (drop info) in
+example : Int := by std_apply?
+
+/-- info: Try this: Nat.lt.base x -/
+#guard_msgs in
+example : x < x + 1 := exact?%
+
+/-- info: Try this: exact p -/
+#guard_msgs in
+example (P : Prop) (p : P) : P := by std_apply?
+/-- info: Try this: exact False.elim (np p) -/
+#guard_msgs in
+example (P : Prop) (p : P) (np : ¬P) : false := by std_apply?
+/-- info: Try this: exact h x rfl -/
+#guard_msgs in
+example (X : Type) (P : Prop) (x : X) (h : ∀ x : X, x = x → P) : P := by std_apply?
+
+-- Could be any number of results (`fun x ↦ x`, `id`, etc)
+#guard_msgs (drop info) in
+example (α : Prop) : α → α := by std_apply?
+
+-- Note: these examples no longer work after we turned off lemmas with discrimination key `#[*]`.
+-- example (p : Prop) : (¬¬p) → p := by std_apply? -- says: `exact not_not.mp`
+-- example (a b : Prop) (h : a ∧ b) : a := by std_apply? -- says: `exact h.left`
+-- example (P Q : Prop) : (¬ Q → ¬ P) → (P → Q) := by std_apply? -- say: `exact Function.mtr`
+
+/-- info: Try this: exact Nat.add_comm a b -/
+#guard_msgs in
+example (a b : Nat) : a + b = b + a :=
+by std_apply?
+
+/-- info: Try this: exact Nat.mul_sub_left_distrib n m k -/
+#guard_msgs in
+example (n m k : Nat) : n * (m - k) = n * m - n * k :=
+by std_apply?
+
+attribute [symm] Eq.symm
+
+/-- info: Try this: exact Eq.symm (Nat.mul_sub_left_distrib n m k) -/
+#guard_msgs in
+example (n m k : Nat) : n * m - n * k = n * (m - k) := by
+  std_apply?
+
+/-- info: Try this: exact eq_comm -/
+#guard_msgs in
+example {α : Type} (x y : α) : x = y ↔ y = x := by std_apply?
+
+/-- info: Try this: exact Nat.add_pos_left ha b -/
+#guard_msgs in
+example (a b : Nat) (ha : 0 < a) (_hb : 0 < b) : 0 < a + b := by std_apply?
+
+/-- info: Try this: exact Nat.add_pos_left ha b -/
+#guard_msgs in
+-- Verify that if maxHeartbeats is 0 we don't stop immediately.
+set_option maxHeartbeats 0 in
+example (a b : Nat) (ha : 0 < a) (_hb : 0 < b) : 0 < a + b := by std_apply?
+
+section synonym
+
+/-- info: Try this: exact Nat.add_pos_left ha b -/
+#guard_msgs in
+example (a b : Nat) (ha : a > 0) (_hb : 0 < b) : 0 < a + b := by std_apply?
+
+/-- info: Try this: exact Nat.le_of_dvd w h -/
+#guard_msgs in
+example (a b : Nat) (h : a ∣ b) (w : b > 0) : a ≤ b :=
+by std_apply?
+
+/-- info: Try this: exact Nat.le_of_dvd w h -/
+#guard_msgs in
+example (a b : Nat) (h : a ∣ b) (w : b > 0) : b ≥ a := by std_apply?
+
+-- TODO: A lemma with head symbol `¬` can be used to prove `¬ p` or `⊥`
+/-- info: Try this: exact Nat.not_lt_zero a -/
+#guard_msgs in
+example (a : Nat) : ¬ (a < 0) := by std_apply?
+/-- info: Try this: exact Nat.not_succ_le_zero a h -/
+#guard_msgs in
+example (a : Nat) (h : a < 0) : False := by std_apply?
+
+-- An inductive type hides the constructor's arguments enough
+-- so that `apply?` doesn't accidentally close the goal.
+inductive P : Nat → Prop
+  | gt_in_head {n : Nat} : n < 0 → P n
+
+-- This lemma with `>` as its head symbol should also be found for goals with head symbol `<`.
+theorem lemma_with_gt_in_head (a : Nat) (h : P a) : 0 > a := by cases h; assumption
+
+-- This lemma with `false` as its head symbols should also be found for goals with head symbol `¬`.
+theorem lemma_with_false_in_head (a b : Nat) (_h1 : a < b) (h2 : P a) : False := by
+  apply Nat.not_lt_zero; cases h2; assumption
+
+/-- info: Try this: exact lemma_with_gt_in_head a h -/
+#guard_msgs in
+example (a : Nat) (h : P a) : 0 > a := by std_apply?
+/-- info: Try this: exact lemma_with_gt_in_head a h -/
+#guard_msgs in
+example (a : Nat) (h : P a) : a < 0 := by std_apply?
+
+/-- info: Try this: exact lemma_with_false_in_head a b h1 h2 -/
+#guard_msgs in
+example (a b : Nat) (h1 : a < b) (h2 : P a) : False := by std_apply?
+
+-- TODO this no longer works:
+-- example (a b : Nat) (h1 : a < b) : ¬ (P a) := by std_apply? -- says `exact lemma_with_false_in_head a b h1`
+
+end synonym
+
+/-- info: Try this: exact fun P ↦ iff_not_self -/
+#guard_msgs in
+example : ∀ P : Prop, ¬(P ↔ ¬P) := by std_apply?
+
+-- We even find `iff` results:
+/-- info: Try this: exact Iff.mpr (Nat.dvd_add_iff_left h₁) h₂ -/
+#guard_msgs in
+example {a b c : Nat} (h₁ : a ∣ c) (h₂ : a ∣ b + c) : a ∣ b := by std_apply?
+
+-- Note: these examples no longer work after we turned off lemmas with discrimination key `#[*]`.
+-- example {α : Sort u} (h : Empty) : α := by std_apply? -- says `exact Empty.elim h`
+-- example (f : A → C) (g : B → C) : (A ⊕ B) → C := by std_apply? -- says `exact Sum.elim f g`
+-- example (n : Nat) (r : ℚ) : ℚ := by std_apply? using n, r -- exact nsmulRec n r
+
+opaque f : Nat → Nat
+axiom F (a b : Nat) : f a ≤ f b ↔ a ≤ b
+
+/-- info: Try this: exact Iff.mpr (F a b) h -/
+#guard_msgs in
+example (a b : Nat) (h : a ≤ b) : f a ≤ f b := by std_apply?
+
+/-- info: Try this: exact List.join L -/
+#guard_msgs in
+example (L : List (List Nat)) : List Nat := by std_apply? using L
+
+-- Could be any number of results
+#guard_msgs (drop info) in
+example (P _Q : List Nat) (h : Nat) : List Nat := by std_apply? using h, P
+
+-- Could be any number of results
+#guard_msgs (drop info) in
+example (l : List α) (f : α → β ⊕ γ) : List β × List γ := by
+  std_apply? using f -- partitionMap f l
+
+-- Could be any number of results (`Nat.mul n m`, `Nat.add n m`, etc)
+#guard_msgs (drop info) in
+example (n m : Nat) : Nat := by std_apply? using n, m
+
+#guard_msgs (drop info) in
+example (P Q : List Nat) (_h : Nat) : List Nat := by std_exact? using P, Q
+
+-- Check that we don't use sorryAx:
+-- (see https://github.com/leanprover-community/mathlib4/issues/226)
+theorem Bool_eq_iff {A B : Bool} : (A = B) = (A ↔ B) :=
+  by (cases A <;> cases B <;> simp)
+
+/-- info: Try this: exact Bool_eq_iff -/
+#guard_msgs in
+theorem Bool_eq_iff2 {A B : Bool} : (A = B) = (A ↔ B) := by
+  std_apply? -- exact Bool_eq_iff
+
+-- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/library_search.20regression/near/354025788
+-- Disabled for Std
+--/-- info: Try this: exact surjective_quot_mk r -/
+--#guard_msgs in
+--example {r : α → α → Prop} : Function.Surjective (Quot.mk r) := by exact?
+
+-- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/library_search.20failing.20to.20apply.20symm
+-- Disabled for Std
+-- /-- info: Try this: exact Iff.symm Nat.prime_iff -/
+--#guard_msgs in
+--example (n : Nat) : Prime n ↔ Nat.Prime n := by
+--  std_exact?
+
+-- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/exact.3F.20recent.20regression.3F/near/387691588
+-- Disabled for Std
+--lemma ex' (x : Nat) (_h₁ : x = 0) (h : 2 * 2 ∣ x) : 2 ∣ x := by
+--  std_exact? says exact dvd_of_mul_left_dvd h
+
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/apply.3F.20failure/near/402534407
+-- Disabled for Std
+--example (P Q : Prop) (h : P → Q) (h' : ¬Q) : ¬P := by
+--  std_exact? says exact mt h h'
+
+-- Removed until we come up with a way of handling nonspecific lemmas
+-- that does not pollute the output or cause too much slow-down.
+-- -- Example from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Exact.3F.20fails.20on.20le_antisymm/near/388993167
+-- set_option linter.unreachableTactic false in
+-- example {x y : ℝ} (hxy : x ≤ y) (hyx : y ≤ x) : x = y := by
+--   -- This example non-deterministically picks between `le_antisymm hxy hyx` and `ge_antisymm hyx hxy`.
+--   first
+--   | exact? says exact le_antisymm hxy hyx
+--   | exact? says exact ge_antisymm hyx hxy

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -36,7 +36,7 @@ example : Int := by std_apply?
 
 /-- info: Try this: Nat.lt.base x -/
 #guard_msgs in
-example : x < x + 1 := exact?%
+example : x < x + 1 := std_exact?%
 
 /-- info: Try this: exact p -/
 #guard_msgs in

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -22,7 +22,7 @@ example : 0 ≠ 1 + 1 := Nat.ne_of_lt (by exact Fin.size_pos')
 #guard_msgs in
 example (x y : Nat) : x + y = y + x := by std_apply?
 
-/-- info: Try this: exact fun a ↦ Nat.add_le_add_right a k -/
+/-- info: Try this: exact fun a => Nat.add_le_add_right a k -/
 #guard_msgs in
 example (n m k : Nat) : n ≤ m → n + k ≤ m + k := by std_apply?
 
@@ -48,7 +48,7 @@ example (P : Prop) (p : P) (np : ¬P) : false := by std_apply?
 #guard_msgs in
 example (X : Type) (P : Prop) (x : X) (h : ∀ x : X, x = x → P) : P := by std_apply?
 
--- Could be any number of results (`fun x ↦ x`, `id`, etc)
+-- Could be any number of results (`fun x => x`, `id`, etc)
 #guard_msgs (drop info) in
 example (α : Prop) : α → α := by std_apply?
 
@@ -139,7 +139,7 @@ example (a b : Nat) (h1 : a < b) (h2 : P a) : False := by std_apply?
 
 end synonym
 
-/-- info: Try this: exact fun P ↦ iff_not_self -/
+/-- info: Try this: exact fun P => iff_not_self -/
 #guard_msgs in
 example : ∀ P : Prop, ¬(P ↔ ¬P) := by std_apply?
 


### PR DESCRIPTION
This is a large PR that builds upon #343 to rename the Mathlib specific cache path and improve performance of library initialization when used without a cache.  It does this primarily by introducing a lazy discriminator tree that defers population of tree branches from initialization to first lookup.

Testing on OSX is currently showing that initializing the tree using Mathlib takes under 2 seconds and a simply query adds an additional 2-3 seconds.  It would be good to get additional information more machines (particularly Windows), but I think the timings are low enough that most users will not need caching.