### PR TITLE
feat: Control warningAsError (default off but stays on in CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: build std
         id: build
-        run: lake build
+        run: lake build -Kwerror
 
       - name: test std
         if: steps.build.outcome == 'success'

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,13 +2,26 @@ import Lake
 
 open Lake DSL
 
+/-- Turn a config option into a Boolean -/
+def enabled (val : Option String) (default : Bool := false) : Bool :=
+  match val with
+  | .some "off" => false
+  | .some "false" => false
+  | .some "on" => true
+  | .some "true" => true
+  | .some _ => not default -- This allows -K=opt to flip the default.
+  | _ => default
+
+-- Selectively choose an option if feature is enabled.
+macro "optArg?" x:ident ws d:ident v:term : term =>
+  `(if enabled (get_config? $x) $d then $v else default)
+
 package std where
-  moreLeanArgs := #["-DwarningAsError=true"]
-  leanOptions := Id.run do
-    let mut opts := #[⟨`linter.missingDocs, true⟩]
-    if get_config? disable_new_compiler |>.isSome then
-      opts := opts.push ⟨`compiler.enableNew, false⟩
-    opts
+  moreLeanArgs :=
+    optArg? werror false #["-DwarningAsError=true"]
+  leanOptions :=
+    #[⟨`linter.missingDocs, true⟩] ++
+    optArg? disable_new_compiler true #[⟨`compiler.enableNew, false⟩]
 
 @[default_target]
 lean_lib Std
@@ -18,5 +31,5 @@ lean_exe runLinter where
   srcDir := "scripts"
   supportInterpreter := true
 
-meta if get_config? doc = some "on" then
+meta if enabled (get_config? doc) then
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,14 +2,14 @@ import Lake
 
 open Lake DSL
 
-macro "optArg?" x:ident v:term : term =>
+macro "opt_arg?" x:ident v:term : term =>
   `(if get_config? $x |>.isSome then $v else default)
 
 package std where
-  moreLeanArgs := optArg? werror #["-DwarningAsError=true"]
+  moreLeanArgs := opt_arg? werror #["-DwarningAsError=true"]
   leanOptions :=
     #[⟨`linter.missingDocs, true⟩] ++
-    optArg? disable_new_compiler #[⟨`compiler.enableNew, false⟩]
+    opt_arg? disable_new_compiler #[⟨`compiler.enableNew, false⟩]
 
 @[default_target]
 lean_lib Std

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,8 +2,7 @@ import Lake
 
 open Lake DSL
 
-macro "opt_arg?" x:ident v:term : term =>
-  `(if get_config? $x |>.isSome then $v else default)
+macro "opt_arg?" x:ident v:term : term => `(if get_config? $x |>.isSome then $v else default)
 
 package std where
   moreLeanArgs := opt_arg? werror #["-DwarningAsError=true"]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,26 +2,14 @@ import Lake
 
 open Lake DSL
 
-/-- Turn a config option into a Boolean -/
-def enabled (val : Option String) (default : Bool := false) : Bool :=
-  match val with
-  | .some "off" => false
-  | .some "false" => false
-  | .some "on" => true
-  | .some "true" => true
-  | .some _ => not default -- This allows -K=opt to flip the default.
-  | _ => default
-
--- Selectively choose an option if feature is enabled.
-macro "optArg?" x:ident ws d:ident v:term : term =>
-  `(if enabled (get_config? $x) $d then $v else default)
+macro "optArg?" x:ident v:term : term =>
+  `(if get_config? $x |>.isSome then $v else default)
 
 package std where
-  moreLeanArgs :=
-    optArg? werror false #["-DwarningAsError=true"]
+  moreLeanArgs := optArg? werror #["-DwarningAsError=true"]
   leanOptions :=
     #[⟨`linter.missingDocs, true⟩] ++
-    optArg? disable_new_compiler true #[⟨`compiler.enableNew, false⟩]
+    optArg? disable_new_compiler #[⟨`compiler.enableNew, false⟩]
 
 @[default_target]
 lean_lib Std
@@ -31,5 +19,5 @@ lean_exe runLinter where
   srcDir := "scripts"
   supportInterpreter := true
 
-meta if enabled (get_config? doc) then
+meta if get_config? doc |>.isSome then
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"


### PR DESCRIPTION
This also has the new compiler to default off and uses a more declarative approach to keyword flags as I'd like `lakefile.lean` to be as declarative as possible (maybe we can upstream those parts).