### PR TITLE
chore: fix name of List.singleton_subperm_iff

### DIFF
--- a/Std/Data/List/Perm.lean
+++ b/Std/Data/List/Perm.lean
@@ -252,7 +252,7 @@ theorem Subperm.filter (p : α → Bool) ⦃l l' : List α⦄ (h : l <+~ l') :
   let ⟨xs, hp, h⟩ := h
   exact ⟨_, hp.filter p, h.filter p⟩
 
-@[simp] theorem subperm_singleton_iff {α} {l : List α} {a : α} : [a] <+~ l ↔ a ∈ l := by
+@[simp] theorem singleton_subperm_iff {α} {l : List α} {a : α} : [a] <+~ l ↔ a ∈ l := by
   refine ⟨fun ⟨s, hla, h⟩ => ?_, fun h => ⟨[a], .rfl, singleton_sublist.mpr h⟩⟩
   rwa [perm_singleton.mp hla, singleton_sublist] at h
 


### PR DESCRIPTION
This name was changed during #89, but I think incorrectly, so I'm changing it back here.

Note that Mathlib has another lemma:
```
lemma subperm_singleton_iff : l <+~ [a] ↔ l = [] ∨ l = [a]
```
(correctly named, I think), which has had to be renamed (adding a prime) temporarily to allow for name change that happened in #89.
