### PR TITLE
chore: deprecate Int.ofNat_natAbs_eq_of_nonneg

### DIFF
--- a/Std/Data/Int/Lemmas.lean
+++ b/Std/Data/Int/Lemmas.lean
@@ -1340,8 +1340,6 @@ theorem eq_one_of_mul_eq_self_right {a b : Int} (Hpos : b ≠ 0) (H : b * a = b)
 /-! ### nat abs -/
 
 @[deprecated] alias ofNat_natAbs_eq_of_nonneg := natAbs_of_nonneg
-  | (_:Nat), _ => rfl
-  | -[n+1],  h => absurd (negSucc_lt_zero n) (Int.not_lt.2 h)
 
 theorem eq_natAbs_iff_mul_eq_zero : natAbs a = n ↔ (a - n) * (a + n) = 0 := by
   rw [natAbs_eq_iff, Int.mul_eq_zero, ← Int.sub_neg, Int.sub_eq_zero, Int.sub_eq_zero]

--- a/Std/Data/Int/Lemmas.lean
+++ b/Std/Data/Int/Lemmas.lean
@@ -1339,6 +1339,7 @@ theorem eq_one_of_mul_eq_self_right {a b : Int} (Hpos : b ≠ 0) (H : b * a = b)
 
 /-! ### nat abs -/
 
+@[deprecated natAbs_of_nonneg]
 theorem ofNat_natAbs_eq_of_nonneg : ∀ a : Int, 0 ≤ a → Int.natAbs a = a
   | (_:Nat), _ => rfl
   | -[n+1],  h => absurd (negSucc_lt_zero n) (Int.not_lt.2 h)

--- a/Std/Data/Int/Lemmas.lean
+++ b/Std/Data/Int/Lemmas.lean
@@ -1339,8 +1339,7 @@ theorem eq_one_of_mul_eq_self_right {a b : Int} (Hpos : b ≠ 0) (H : b * a = b)
 
 /-! ### nat abs -/
 
-@[deprecated natAbs_of_nonneg]
-theorem ofNat_natAbs_eq_of_nonneg : ∀ a : Int, 0 ≤ a → Int.natAbs a = a
+@[deprecated] alias ofNat_natAbs_eq_of_nonneg := natAbs_of_nonneg
   | (_:Nat), _ => rfl
   | -[n+1],  h => absurd (negSucc_lt_zero n) (Int.not_lt.2 h)
 


### PR DESCRIPTION
Fixes #419.