### PR TITLE
feat: (Lawful)BEq for AssocList

### DIFF
--- a/Std/Data/AssocList.lean
+++ b/Std/Data/AssocList.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import Std.Data.List.Basic
-import Std.Util.ProofWanted
 
 namespace Std
 
@@ -271,5 +270,7 @@ instance [BEq α] [LawfulBEq α] [BEq β] [LawfulBEq β] : LawfulBEq (AssocList 
         simp_all only [beq_cons₂, Bool.and_eq_true, beq_iff_eq, cons.injEq, true_and, and_imp]
         exact fun _ _ => ih
 
-proof_wanted beq_iff_toList_beq [BEq α] [BEq β] {L M : AssocList α β} :
-    L == M ↔ L.toList == M.toList
+protected theorem beq_eq [BEq α] [BEq β] {l m : AssocList α β} :
+    (l == m) = (l.toList == m.toList) := by
+  simp [(· == ·)]
+  induction l generalizing m <;> cases m <;> simp [*, (· == ·), AssocList.beq, List.beq]

--- a/Std/Data/AssocList.lean
+++ b/Std/Data/AssocList.lean
@@ -237,7 +237,7 @@ instance : Stream (AssocList α β) (α × β) := ⟨pop?⟩
 @[simp] theorem toList_toAssocList (l : AssocList α β) : l.toList.toAssocList = l := by
   induction l <;> simp [*]
 
-private def beq [BEq α] [BEq β] : AssocList α β → AssocList α β → Bool
+protected def beq [BEq α] [BEq β] : AssocList α β → AssocList α β → Bool
   | .nil, .nil => true
   | .cons _ _ _, .nil => false
   | .nil, .cons _ _ _ => false
@@ -258,8 +258,8 @@ instance [BEq α] [BEq β] : BEq (AssocList α β) where beq := beq
     ((.cons a b t : AssocList α β) == .cons a' b' t') = (a == a' && b == b' && t == t') := rfl
 
 instance [BEq α] [LawfulBEq α] [BEq β] [LawfulBEq β] : LawfulBEq (AssocList α β) where
-  rfl := @fun L => by induction L <;> simp_all
-  eq_of_beq := @fun L M => by
+  rfl {L} := by induction L <;> simp_all
+  eq_of_beq {L M} := by
     induction L generalizing M with
     | nil => cases M <;> simp_all
     | cons a b L ih =>

--- a/Std/Data/AssocList.lean
+++ b/Std/Data/AssocList.lean
@@ -241,13 +241,13 @@ protected def beq [BEq α] [BEq β] : AssocList α β → AssocList α β → Bo
   | .nil, .nil => true
   | .cons _ _ _, .nil => false
   | .nil, .cons _ _ _ => false
-  | .cons a b t, .cons a' b' t' => a == a' && b == b' && beq t t'
+  | .cons a b t, .cons a' b' t' => a == a' && b == b' && AssocList.beq t t'
 
 /--
 Boolean equality for `AssocList`.
 (This relation cares about the ordering of the key-value pairs.)
 -/
-instance [BEq α] [BEq β] : BEq (AssocList α β) where beq := beq
+instance [BEq α] [BEq β] : BEq (AssocList α β) where beq := AssocList.beq
 
 @[simp] theorem beq_nil₂ [BEq α] [BEq β] : ((.nil : AssocList α β) == .nil) = true := rfl
 @[simp] theorem beq_nil_cons [BEq α] [BEq β] : ((.nil : AssocList α β) == .cons a b t) = false :=
@@ -267,4 +267,4 @@ instance [BEq α] [LawfulBEq α] [BEq β] [LawfulBEq β] : LawfulBEq (AssocList 
       | nil => simp_all
       | cons a' b' M =>
         simp_all only [beq_cons₂, Bool.and_eq_true, beq_iff_eq, cons.injEq, true_and, and_imp]
-        exact fun _ _ => ih _
+        exact fun _ _ => ih

--- a/Std/Data/AssocList.lean
+++ b/Std/Data/AssocList.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import Std.Data.List.Basic
+import Std.Util.ProofWanted
 
 namespace Std
 
@@ -237,6 +238,7 @@ instance : Stream (AssocList α β) (α × β) := ⟨pop?⟩
 @[simp] theorem toList_toAssocList (l : AssocList α β) : l.toList.toAssocList = l := by
   induction l <;> simp [*]
 
+/-- Implementation of `==` on `AssocList`. -/
 protected def beq [BEq α] [BEq β] : AssocList α β → AssocList α β → Bool
   | .nil, .nil => true
   | .cons _ _ _, .nil => false
@@ -268,3 +270,6 @@ instance [BEq α] [LawfulBEq α] [BEq β] [LawfulBEq β] : LawfulBEq (AssocList 
       | cons a' b' M =>
         simp_all only [beq_cons₂, Bool.and_eq_true, beq_iff_eq, cons.injEq, true_and, and_imp]
         exact fun _ _ => ih
+
+proof_wanted beq_iff_toList_beq [BEq α] [BEq β] {L M : AssocList α β} :
+    L == M ↔ L.toList == M.toList


### PR DESCRIPTION
I worry slightly that someone will say they want the relation that *doesn't* care about the ordering of key-value pairs, but that is rather harder to calculate, not `Lawful`, and ... I want this one!