### PR TITLE
chore: ToExpr Int

### DIFF
--- a/Std/Data/Int/Basic.lean
+++ b/Std/Data/Int/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Std.Classes.Dvd
+import Lean.ToExpr
 
 open Nat
 
@@ -164,3 +165,10 @@ protected def shiftRight : Int → Nat → Int
   | Int.negSucc n, s => Int.negSucc (n >>> s)
 
 instance : HShiftRight Int Nat Int := ⟨.shiftRight⟩
+
+open Lean in
+instance : ToExpr Int where
+  toTypeExpr := .const ``Int []
+  toExpr i := match i with
+    | .ofNat n => mkApp (.const ``Int.ofNat []) (toExpr n)
+    | .negSucc n => mkApp (.const ``Int.negSucc []) (toExpr n)


### PR DESCRIPTION
I'm not sure in which file this belongs.

(I'm also still a bit sad that we [decided](https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/ToExpr.20derive.20handler/near/386476438) not to upstream the `ToExpr` derive handler from Mathlib...!)

