### PR TITLE
chore: upstream Lean.MVarId.applyConst

### DIFF
--- a/Std/Lean/Meta/Basic.lean
+++ b/Std/Lean/Meta/Basic.lean
@@ -328,6 +328,10 @@ annotations. -/
 def getTypeCleanup (mvarId : MVarId) : MetaM Expr :=
   return (← instantiateMVars (← mvarId.getType)).cleanupAnnotations
 
+/-- Short-hand for applying a constant to the goal. -/
+def applyConst (mvar : MVarId) (c : Name) (cfg : ApplyConfig := {}) : MetaM (List MVarId) := do
+  mvar.apply (← mkConstWithFreshMVarLevels c) cfg
+
 end MVarId
 
 


### PR DESCRIPTION
I could inline this at the point of use in `omega`, but as it is widely used in Mathlib it seems a reasonable moment to push it to Std.