### PR TITLE
feat: "Try this:" custom code action title

### DIFF
--- a/Std/Tactic/TryThis.lean
+++ b/Std/Tactic/TryThis.lean
@@ -96,9 +96,12 @@ apply the replacement.
     let .ok suggestions := suggestions.getArr? | panic! "bad type"
     let mut result := result
     for h : i in [:suggestions.size] do
-      let .ok newText := (suggestions[i]'h.2).getObjValAs? String "suggestion" | panic! "bad type"
+      let suggestion := suggestions[i]'h.2
+      let .ok newText := suggestion.getObjValAs? String "suggestion" | panic! "bad type"
+      let codeActionTitle := (suggestion.getObjValAs? String "codeActionTitle").toOption.getD <|
+        "Try this: " ++ newText
       result := result.push {
-        eager.title := "Try this: " ++ newText
+        eager.title := codeActionTitle
         eager.kind? := "quickfix"
         -- Only make the first option preferred
         eager.isPreferred? := if i = 0 then true else none
@@ -275,6 +278,14 @@ structure Suggestion where
   /-- How to represent the suggestion as `MessageData`. This is used only in the info diagnostic.
   If `none`, we use `suggestion`. Use `toMessageData` to render a `Suggestion` in this manner. -/
   messageData? : Option MessageData := none
+  /-- How to construct the text that appears in the lightbulb menu from the suggestion text. If
+  `none`, we use `fun ppSuggestionText => "Try this: " ++ ppSuggestionText`. Only the pretty-printed
+  `suggestion : SuggestionText` is used here.
+
+  Note that (if not `none`) a prop `codeActionTitle : String` will be included in the Json, not
+  `toCodeActionTitle?` itself, as the application of `toCodeAction` to the pretty-printed
+  `suggestion : SuggestionText` must be performed before encoding. -/
+  toCodeActionTitle? : Option (String → String) := none
   deriving Inhabited
 
 /-- Converts a `Suggestion` to `Json` in `CoreM`. We need `CoreM` in order to pretty-print syntax.
@@ -288,6 +299,8 @@ def Suggestion.toJsonM (s : Suggestion) (w : Option Nat := none) (indent column 
   if let some preInfo := s.preInfo? then json := ("preInfo", preInfo) :: json
   if let some postInfo := s.postInfo? then json := ("postInfo", postInfo) :: json
   if let some style := s.style? then json := ("style", toJson style) :: json
+  if let some tocodeActionTitle := s.toCodeActionTitle? then
+    json := ("codeActionTitle", tocodeActionTitle text) :: json
   return Json.mkObj json
 
 /- If `messageData?` is specified, we use that; otherwise (by default), we use `toMessageData` of
@@ -349,6 +362,9 @@ The parameters are:
   * `messageData?`: an optional message to display in place of `suggestion` in the info diagnostic
     (only). The widget message uses only `suggestion`. If `messageData?` is `none`, we simply use
     `suggestion` instead.
+  * `toCodeActionTitle?`: an optional function `String → String` describing how to transform the
+    pretty-printed suggestion text into the code action text which appears in the lightbulb menu.
+    If `none`, we simply prepend `"Try This: "` to the suggestion text.
 * `origSpan?`: a syntax object whose span is the actual text to be replaced by `suggestion`.
   If not provided it defaults to `ref`.
 * `header`: a string that begins the display. By default, it is `"Try this: "`.
@@ -378,6 +394,9 @@ The parameters are:
   * `messageData?`: an optional message to display in place of `suggestion` in the info diagnostic
     (only). The widget message uses only `suggestion`. If `messageData?` is `none`, we simply use
     `suggestion` instead.
+  * `toCodeActionTitle?`: an optional function `String → String` describing how to transform the
+    pretty-printed suggestion text into the code action text which appears in the lightbulb menu.
+    If `none`, we simply prepend `"Try This: "` to the suggestion text.
 * `origSpan?`: a syntax object whose span is the actual text to be replaced by `suggestion`.
   If not provided it defaults to `ref`.
 * `header`: a string that precedes the list. By default, it is `"Try these:"`.

--- a/test/tryThis.lean
+++ b/test/tryThis.lean
@@ -225,3 +225,9 @@ info: Grab bag:
 /-- error: no suggestions available -/
 #guard_msgs in
 #demo #[]
+
+/- The messages and suggestion should still read `Try this: rfl`, but the text in the lightbulb
+menu should read "Consider rfl, please" -/
+/-- info: Try this: rfl -/
+#guard_msgs in
+#demo1 { s with toCodeActionTitle? := fun text => "Consider " ++ text ++ ", please" }

--- a/test/tryThis.lean
+++ b/test/tryThis.lean
@@ -231,3 +231,27 @@ menu should read "Consider rfl, please" -/
 /-- info: Try this: rfl -/
 #guard_msgs in
 #demo1 { s with toCodeActionTitle? := fun text => "Consider " ++ text ++ ", please" }
+
+/-- Add suggestions with a default code action title prefix. -/
+elab "add_suggestions" s:term "with_code_action_prefix" h:str : tactic => unsafe do
+  let s ← evalTerm (Array Suggestion) (.app (.const ``Array [.zero]) (.const ``Suggestion [])) s
+  addSuggestions (← getRef) s (codeActionPrefix? := h.getString)
+
+/-- Demo adding suggestions with a header. -/
+macro "#demo" s:term "with_code_action_prefix" h:str : command => `(example : True := by
+  add_suggestions $s with_code_action_prefix $h; trivial)
+
+/- The messages and suggestions should still read `Try these: ...`, but the text in the lightbulb
+menu should read "Maybe use: rfl"; "Maybe use: rfl"; "Also consider rfl, please!" -/
+/--
+info: Try these:
+• rfl
+• rfl
+• rfl
+-/
+#guard_msgs in
+#demo #[
+  s,
+  s,
+  { s with toCodeActionTitle? := fun text => "Also consider " ++ text ++ ", please!" }
+] with_code_action_prefix "Maybe use: "


### PR DESCRIPTION
Currently, the code action title in the lightbulb menu is hardcoded to `Try this: <prettyPrintedSuggestionText>`. This needs to be customized in various cases, such as teaching in non-English languages. This PR:

* Adds a field `toCodeActionTitle? : Option (String -> String)` to `Suggestion`, which, if provided, can be applied to the pretty-printed suggestion text and transform it as desired (note that this application occurs prior to encoding, so we only pass the resulting code action title `String`, if any, to the Json version of the `Suggestion` structure; note also that we don't want to pretty-print twice, so we take in the pretty-printed `String` as an argument instead of the `SuggestionText` itself)
* Adds an argument `codeActionPrefix? : Option String := none` to `addSuggestions` to conveniently provide a default code action title prefix to use for all elements in an `Array Suggestion` which do not have a nontrivial `toCodeAction?` value.

See [zulip](https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/Trythis.20code.20action.20title) for the feature request and discussion on the choice of default behavior.