### PR TITLE
feat: more UIntX lemmas

### DIFF
--- a/Std/Data/UInt.lean
+++ b/Std/Data/UInt.lean
@@ -1,4 +1,12 @@
 import Std.Data.Nat.Init.Lemmas
+import Std.Tactic.Ext.Attr
+
+/-! ### UInt8 -/
+
+@[ext] theorem UInt8.ext : {x y : UInt8} → x.toNat = y.toNat → x = y
+  | ⟨⟨_,_⟩⟩, ⟨⟨_,_⟩⟩, rfl => rfl
+
+@[simp] theorem UInt8.val_val_eq_toNat (x : UInt8) : x.val.val = x.toNat := rfl
 
 theorem UInt8.toNat_lt (x : UInt8) : x.toNat < 2 ^ 8 := x.val.isLt
 
@@ -11,7 +19,14 @@ theorem UInt8.toNat_lt (x : UInt8) : x.toNat < 2 ^ 8 := x.val.isLt
 @[simp] theorem UInt8.toUInt64_toNat (x : UInt8) : x.toUInt64.toNat = x.toNat :=
   Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le x.toNat_lt (by decide))
 
+/-! ### UInt16 -/
+
+@[ext] theorem UInt16.ext : {x y : UInt16} → x.toNat = y.toNat → x = y
+  | ⟨⟨_,_⟩⟩, ⟨⟨_,_⟩⟩, rfl => rfl
+
 theorem UInt16.toNat_lt (x : UInt16) : x.toNat < 2 ^ 16 := x.val.isLt
+
+@[simp] theorem UInt16.val_val_eq_toNat (x : UInt16) : x.val.val = x.toNat := rfl
 
 @[simp] theorem UInt16.toUInt8_toNat (x : UInt16) : x.toUInt8.toNat = x.toNat % 2 ^ 8 := rfl
 
@@ -20,6 +35,13 @@ theorem UInt16.toNat_lt (x : UInt16) : x.toNat < 2 ^ 16 := x.val.isLt
 
 @[simp] theorem UInt16.toUInt64_toNat (x : UInt16) : x.toUInt64.toNat = x.toNat :=
   Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le x.toNat_lt (by decide))
+
+/-! ### UInt32 -/
+
+@[ext] theorem UInt32.ext : {x y : UInt32} → x.toNat = y.toNat → x = y
+  | ⟨⟨_,_⟩⟩, ⟨⟨_,_⟩⟩, rfl => rfl
+
+@[simp] theorem UInt32.val_val_eq_toNat (x : UInt32) : x.val.val = x.toNat := rfl
 
 theorem UInt32.toNat_lt (x : UInt32) : x.toNat < 2 ^ 32 := x.val.isLt
 
@@ -30,6 +52,13 @@ theorem UInt32.toNat_lt (x : UInt32) : x.toNat < 2 ^ 32 := x.val.isLt
 @[simp] theorem UInt32.toUInt64_toNat (x : UInt32) : x.toUInt64.toNat = x.toNat :=
   Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le x.toNat_lt (by decide))
 
+/-! ### UInt64 -/
+
+@[ext] theorem UInt64.ext : {x y : UInt64} → x.toNat = y.toNat → x = y
+  | ⟨⟨_,_⟩⟩, ⟨⟨_,_⟩⟩, rfl => rfl
+
+@[simp] theorem UInt64.val_val_eq_toNat (x : UInt64) : x.val.val = x.toNat := rfl
+
 theorem UInt64.toNat_lt (x : UInt64) : x.toNat < 2 ^ 64 := x.val.isLt
 
 @[simp] theorem UInt64.toUInt8_toNat (x : UInt64) : x.toUInt8.toNat = x.toNat % 2 ^ 8 := rfl
@@ -37,6 +66,13 @@ theorem UInt64.toNat_lt (x : UInt64) : x.toNat < 2 ^ 64 := x.val.isLt
 @[simp] theorem UInt64.toUInt16_toNat (x : UInt64) : x.toUInt16.toNat = x.toNat % 2 ^ 16 := rfl
 
 @[simp] theorem UInt64.toUInt32_toNat (x : UInt64) : x.toUInt32.toNat = x.toNat % 2 ^ 32 := rfl
+
+/-! ### USize -/
+
+@[ext] theorem USize.ext : {x y : USize} → x.toNat = y.toNat → x = y
+  | ⟨⟨_,_⟩⟩, ⟨⟨_,_⟩⟩, rfl => rfl
+
+@[simp] theorem USize.val_val_eq_toNat (x : USize) : x.val.val = x.toNat := rfl
 
 theorem USize.size_eq : USize.size = 2 ^ System.Platform.numBits := by
   have : 1 ≤ 2 ^ System.Platform.numBits := Nat.succ_le_of_lt (Nat.pow_two_pos _)


### PR DESCRIPTION
The proposed `[ext]` lemmas use `.toNat` instead of `.val`. I find these more useful but I don't know if there are side effects to skipping an intermediate step like that.