### PR TITLE
chore: potential nontermination at `simp`

### DIFF
--- a/Std/Data/Array/Lemmas.lean
+++ b/Std/Data/Array/Lemmas.lean
@@ -354,14 +354,14 @@ theorem forIn_eq_data_forIn [Monad m]
       Array.forIn.loop as f i h b = forIn (as.data.drop j) b f
     | 0, _, _, _, rfl => by rw [List.drop_length]; rfl
     | i+1, _, _, j, ij => by
-      simp [forIn.loop]
+      simp only [forIn.loop, Nat.add]
       have j_eq : j = size as - 1 - i := by simp [← ij, ← Nat.add_assoc]
       have : as.size - 1 - i < as.size := j_eq ▸ ij ▸ Nat.lt_succ_of_le (Nat.le_add_right ..)
       have : as[size as - 1 - i] :: as.data.drop (j + 1) = as.data.drop j := by
         rw [j_eq]; exact List.get_cons_drop _ ⟨_, this⟩
-      simp [← this]; congr; funext x; congr; funext b
+      simp only [← this, List.forIn_cons]; congr; funext x; congr; funext b
       rw [loop (i := i)]; rw [← ij, Nat.succ_add]; rfl
-  conv => lhs; simp [forIn, Array.forIn]
+  conv => lhs; simp only [forIn, Array.forIn]
   rw [loop (Nat.zero_add _)]; rfl
 
 /-! ### zipWith / zip -/

--- a/Std/Data/Array/Lemmas.lean
+++ b/Std/Data/Array/Lemmas.lean
@@ -361,7 +361,8 @@ theorem forIn_eq_data_forIn [Monad m]
         rw [j_eq]; exact List.get_cons_drop _ ⟨_, this⟩
       simp [← this]; congr; funext x; congr; funext b
       rw [loop (i := i)]; rw [← ij, Nat.succ_add]; rfl
-  simp [forIn, Array.forIn]; rw [loop (Nat.zero_add _)]; rfl
+  conv => lhs; simp [forIn, Array.forIn]
+  rw [loop (Nat.zero_add _)]; rfl
 
 /-! ### zipWith / zip -/
 

--- a/Std/Data/RBMap/Lemmas.lean
+++ b/Std/Data/RBMap/Lemmas.lean
@@ -389,7 +389,7 @@ theorem forIn_visit_eq_bindList [Monad m] [LawfulMonad m] {t : RBNode α} :
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m] {t : RBNode α} :
     forIn (m := m) t init f = forIn t.toList init f := by
-  conv => lhs; simp [forIn, RBNode.forIn]
+  conv => lhs; simp only [forIn, RBNode.forIn]
   rw [List.forIn_eq_bindList, forIn_visit_eq_bindList]
 
 end fold
@@ -415,7 +415,7 @@ theorem foldl_eq_foldl_toList {t : RBNode.Stream α} : t.foldl f init = t.toList
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m] {t : RBNode α} :
     forIn (m := m) t init f = forIn t.toList init f := by
-  conv => lhs; simp [forIn, RBNode.forIn]
+  conv => lhs; simp only [forIn, RBNode.forIn]
   rw [List.forIn_eq_bindList, forIn_visit_eq_bindList]
 
 end Stream

--- a/Std/Data/RBMap/Lemmas.lean
+++ b/Std/Data/RBMap/Lemmas.lean
@@ -389,7 +389,8 @@ theorem forIn_visit_eq_bindList [Monad m] [LawfulMonad m] {t : RBNode α} :
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m] {t : RBNode α} :
     forIn (m := m) t init f = forIn t.toList init f := by
-  simp [forIn, RBNode.forIn]; rw [List.forIn_eq_bindList, forIn_visit_eq_bindList]
+  conv => lhs; simp [forIn, RBNode.forIn]
+  rw [List.forIn_eq_bindList, forIn_visit_eq_bindList]
 
 end fold
 
@@ -414,7 +415,8 @@ theorem foldl_eq_foldl_toList {t : RBNode.Stream α} : t.foldl f init = t.toList
 
 theorem forIn_eq_forIn_toList [Monad m] [LawfulMonad m] {t : RBNode α} :
     forIn (m := m) t init f = forIn t.toList init f := by
-  simp [forIn, RBNode.forIn]; rw [List.forIn_eq_bindList, forIn_visit_eq_bindList]
+  conv => lhs; simp [forIn, RBNode.forIn]
+  rw [List.forIn_eq_bindList, forIn_visit_eq_bindList]
 
 end Stream
 


### PR DESCRIPTION
Using `simp [forIn]` may cause nontermination with different `simp` reduction strategies. We have the following theorem
```
@[simp] theorem forIn_eq_forIn [Monad m] : @List.forIn α β m _ = forIn := rfl
```
Then, executing `simp [forIn]` in a term containing `forIn` iterating over a `List` may cause nontermination since the theorem above will fold it again.

Remark: the reduction strategy implemented
https://github.com/leanprover/lean4/pull/3118 triggers the nontermination.