### PR TITLE
feat: add a `TacticM Unit` frontend for omega that can be used as an aesop rule

### DIFF
--- a/Std/Tactic/Omega/Frontend.lean
+++ b/Std/Tactic/Omega/Frontend.lean
@@ -423,6 +423,20 @@ def omega (facts : List Expr) (g : MVarId) (cfg : OmegaConfig := {}) : MetaM Uni
 
 open Lean Elab Tactic Parser.Tactic
 
+/-- The `omega` tactic, for resolving integer and natural linear arithmetic problems. -/
+def omegaTactic (cfg : OmegaConfig) : TacticM Unit := do
+  liftMetaFinishingTactic fun g => do
+    let g ← falseOrByContra g
+    g.withContext do
+      let hyps := (← getLocalHyps).toList
+      trace[omega] "analyzing {hyps.length} hypotheses:\n{← hyps.mapM inferType}"
+      omega hyps g cfg
+
+/-- The `omega` tactic, for resolving integer and natural linear arithmetic problems. This
+`TacticM Unit` frontend with default configuration can be used as an Aesop rule, for example via
+the tactic call `aesop (add 50% tactic Std.Tactic.Omega.omegaDefault)`. -/
+def omegaDefault : TacticM Unit := omegaTactic {}
+
 /--
 The `omega` tactic, for resolving integer and natural linear arithmetic problems.
 
@@ -457,9 +471,4 @@ syntax (name := omegaSyntax) "omega" (config)? : tactic
 elab_rules : tactic |
     `(tactic| omega $[$cfg]?) => do
   let cfg ← elabOmegaConfig (mkOptionalNode cfg)
-  liftMetaFinishingTactic fun g => do
-    let g ← falseOrByContra g
-    g.withContext do
-      let hyps := (← getLocalHyps).toList
-      trace[omega] "analyzing {hyps.length} hypotheses:\n{← hyps.mapM inferType}"
-      omega hyps g cfg
+  omegaTactic cfg


### PR DESCRIPTION
This adds two `TacticM Unit` frontends for omega: `omegaTactic` which takes an `OmegaConfig` parameter, and `omegaDefault` which uses the default configuration. The latter can be used as an aesop rule (which must be a declaration of type `TacticM Unit`).

I've experimented a bit with this as a `get_elem_tactic` replacement, where I add `omega` as a safe rule together with some `forward` rules to bring useful facts into context before the omega call, and it works remarkably well!