### PR TITLE
feat: add `String.splitOn_of_valid`

### DIFF
--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -161,6 +161,18 @@ theorem append_eq_append_iff {a b c d : List α} :
   | nil => simp; exact (or_iff_left_of_imp fun ⟨_, ⟨e, rfl⟩, h⟩ => e ▸ h.symm).symm
   | cons a as ih => cases c <;> simp [eq_comm, and_assoc, ih, and_or_left]
 
+theorem append_left_eq_self (l m : List α) : l ++ m = m ↔ l = [] := by
+  constructor <;> intro h
+  · conv at h => rhs; rw [← nil_append m]
+    rwa [append_cancel_right_eq] at h
+  · rw [h, nil_append]
+
+theorem append_right_eq_self (l m : List α) : l ++ m = l ↔ m = [] := by
+  constructor <;> intro h
+  · conv at h => rhs; rw [← append_nil l]
+    rwa [append_cancel_left_eq] at h
+  · rw [h, append_nil]
+
 @[simp] theorem mem_append {a : α} {s t : List α} : a ∈ s ++ t ↔ a ∈ s ∨ a ∈ t := by
   induction s <;> simp_all [or_assoc]
 

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -732,6 +732,29 @@ are often used for theorems about `Array.pop`.  -/
   | _::_::_, ⟨0, _⟩ => rfl
   | _::_::_, ⟨i+1, _⟩ => get_dropLast _ ⟨i, _⟩
 
+/-! ### rdropSublist -/
+
+@[simp] theorem rdropSublist_self [BEq α] [LawfulBEq α] (l : List α) :
+    l.rdropSublist l = [] := by
+  cases l <;> simp [rdropSublist]
+
+@[simp] theorem rdropSublist_append [BEq α] [LawfulBEq α] (l m : List α) :
+    (l++m).rdropSublist m = l := by
+  match l, m with
+  | [], _ => simp [rdropSublist_self]
+  | a::as, [] => simp [rdropSublist]
+  | a::as, b::bs =>
+    simp [rdropSublist]
+    split
+    · next h =>
+      simp at h
+      rw [append_cons, append_left_eq_self] at h
+      simp at h
+    · split <;> rename_i h <;> simp at h ⊢
+      · simp [append_left_eq_self] at h
+        exact h.symm
+      · apply rdropSublist_append
+
 /-! ### nth element -/
 
 @[simp] theorem get_cons_succ {as : List α} {h : i + 1 < (a :: as).length} :

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -370,6 +370,16 @@ protected theorem add_le_add_iff_left {n : Nat} : n + m ≤ n + k ↔ m ≤ k :=
 protected theorem add_le_add_iff_right {n : Nat} : m + n ≤ k + n ↔ m ≤ k :=
   ⟨Nat.le_of_add_le_add_right, fun h => Nat.add_le_add_right h _⟩
 
+protected theorem add_left_le_self {n m : Nat} : n + m ≤ m ↔ n = 0 := by
+  conv => lhs; rhs; rw [← Nat.zero_add m]
+  rw [Nat.add_le_add_iff_right]
+  apply Nat.le_zero
+
+protected theorem add_right_le_self {n m : Nat} : n + m ≤ n ↔ m = 0 := by
+  conv => lhs; rhs; rw [← Nat.add_zero n]
+  rw [Nat.add_le_add_iff_left]
+  apply Nat.le_zero
+
 protected theorem lt_of_add_lt_add_right : ∀ {n : Nat}, k + n < m + n → k < m
   | 0, h => h
   | _+1, h => Nat.lt_of_add_lt_add_right (Nat.lt_of_succ_lt_succ h)


### PR DESCRIPTION
* Add lemmas for `Nat.le` and `List.append`.
* Add functions on `List`:
  * `List.rdropSublist` drops a sublist from the tail end of a list.
  * `List.splitOnSublist` splits a list at every occurrence of a separator sublist. The separators are not in the result.
* Add `simp` lemmas for `List.rdropSublist`.
* State and prove two theorems about `String`: `splitOnAux_of_valid` and `splitOn_of_valid`.

---

Before this pull request gets merged, I need to replace `String.splitOnAux` and `String.splitOn` in Lean core with the modified versions I made:

```lean
def splitOnAux' (s sep : String) (b : Pos) (i : Pos) (j : Pos) (r : List String) : List String :=
  if sep == "" then
    let r := (s.extract b s.endPos)::r
    r.reverse
  else if h : s.atEnd i then
    let r := (s.extract b i)::r
    r.reverse
  else
    have := Nat.sub_lt_sub_left (Nat.gt_of_not_le (mt decide_eq_true h)) (lt_next s _)
    if sep.atEnd j then
      if s.get i == sep.get 0
        splitOnAux' s sep i (s.next i) (sep.next 0) (s.extract b (i - j)::r)
      else
        splitOnAux' s sep i (s.next i) 0 (s.extract b (i - j)::r)
    else if s.get i == sep.get j then
      splitOnAux' s sep b (s.next i) (sep.next j) r
    else
      splitOnAux' s sep b (s.next i) 0 r
termination_by _ => s.endPos.1 - i.1

def splitOn' (s : String) (sep : String := " ") : List String :=
  splitOnAux' s sep 0 0 0 []
```

The function `splitOnAux'` differs from its original version in two ways. First, it checks whether the separator (`sep`) is empty. Second, it checks whether `sep.atEnd j` *before* it checks whether `s.get i == sep.get j`. For these reasons, the outputs of the original `splitOnAux` and its modified version are different for some inputs, as shown in the `#eval` commands below:

```lean
import Std.Data.String.Lemmas

namespace Test

open String
set_option linter.missingDocs false

private def l := "A12a".1
private def m := "B12b".1
private def r := "C12c".1

private def sep₁ := "1".1
private def sep₂ := "2".1
private def acc := ["X", "x"]

#eval splitOnAux  ⟨l++m++sep₁++r⟩ ⟨sep₁++sep₂⟩ ⟨utf8Len l⟩ ⟨utf8Len (l++m++sep₁)⟩
  ⟨utf8Len (sep₁++sep₂)⟩ acc -- output: ["x", "X", "B12b1C", "c"]
#eval splitOnAux' ⟨l++m++sep₁++r⟩ ⟨sep₁++sep₂⟩ ⟨utf8Len l⟩ ⟨utf8Len (l++m++sep₁)⟩
  ⟨utf8Len (sep₁++sep₂)⟩ acc -- ["x", "X", "B12", "C", "c"]

#eval splitOnAux  ⟨l++m++"A".1++r⟩ ⟨"A".1++sep₂⟩ ⟨utf8Len l⟩ ⟨utf8Len (l++m++"A".1)⟩
  ⟨utf8Len ("A".1++sep₂)⟩ acc -- ["x", "X", "B12bAC12c"]
#eval splitOnAux' ⟨l++m++"A".1++r⟩ ⟨"A".1++sep₂⟩ ⟨utf8Len l⟩ ⟨utf8Len (l++m++"A".1)⟩
  ⟨utf8Len ("A".1++sep₂)⟩ acc -- ["x", "X", "B12", "C12c"]

end Test
```

I'll open an issue on [Lean 4 GitHub issues][0] after I get feedback about `splitOnAux'` and `splitOn'`.

[0]: https://github.com/leanprover/lean4/issues
