### PR TITLE
feat: omega handles iff and implications

### DIFF
--- a/Std/Logic.lean
+++ b/Std/Logic.lean
@@ -612,7 +612,8 @@ theorem Decidable.not_iff [Decidable b] : ¬(a ↔ b) ↔ (¬a ↔ b) := by
 theorem Decidable.iff_not_comm [Decidable a] [Decidable b] : (a ↔ ¬b) ↔ (b ↔ ¬a) := by
   rw [@iff_def a, @iff_def b]; exact and_congr imp_not_comm not_imp_comm
 
-theorem Decidable.iff_iff_and_or_not_and_not [Decidable b] : (a ↔ b) ↔ (a ∧ b) ∨ (¬a ∧ ¬b) :=
+theorem Decidable.iff_iff_and_or_not_and_not {a b : Prop} [Decidable b] :
+    (a ↔ b) ↔ (a ∧ b) ∨ (¬a ∧ ¬b) :=
   ⟨fun e => if h : b then .inl ⟨e.2 h, h⟩ else .inr ⟨mt e.1 h, h⟩,
    Or.rec (And.rec iff_of_true) (And.rec iff_of_false)⟩
 

--- a/Std/Tactic/Omega/Frontend.lean
+++ b/Std/Tactic/Omega/Frontend.lean
@@ -243,8 +243,6 @@ def addIntInequality (p : MetaProblem) (h y : Expr) : OmegaM MetaProblem := do
     problem := ← (p.problem.addInequality lc.const lc.coeffs
       (some do mkAppM ``le_of_le_of_eq #[h, (← prf)])) |>.solveEqualities }
 
-
-
 /-- Given a fact `h` with type `¬ P`, return a more useful fact obtained by pushing the negation. -/
 def pushNot (h P : Expr) : MetaM (Option Expr) := do
   match P with

--- a/Std/Tactic/Omega/Frontend.lean
+++ b/Std/Tactic/Omega/Frontend.lean
@@ -36,8 +36,6 @@ and progressively process the facts.
 As we process the facts, we may generate additional facts
 (e.g. about coercions and integer divisions).
 To avoid duplicates, we maintain a `HashSet` of previously processed facts.
-
-TODO: we may want to solve equalities as we find them.
 -/
 structure MetaProblem where
   /-- An integer linear arithmetic problem. -/
@@ -245,29 +243,41 @@ def addIntInequality (p : MetaProblem) (h y : Expr) : OmegaM MetaProblem := do
     problem := ← (p.problem.addInequality lc.const lc.coeffs
       (some do mkAppM ``le_of_le_of_eq #[h, (← prf)])) |>.solveEqualities }
 
+
+
 /-- Given a fact `h` with type `¬ P`, return a more useful fact obtained by pushing the negation. -/
 def pushNot (h P : Expr) : Option Expr := do
-  match P.getAppFnArgs with
-  | (``LT.lt, #[.const ``Int [], _, x, y]) => some (mkApp3 (.const ``Int.le_of_not_lt []) x y h)
-  | (``LE.le, #[.const ``Int [], _, x, y]) => some (mkApp3 (.const ``Int.lt_of_not_le []) x y h)
-  | (``LT.lt, #[.const ``Nat [], _, x, y]) => some (mkApp3 (.const ``Nat.le_of_not_lt []) x y h)
-  | (``LE.le, #[.const ``Nat [], _, x, y]) => some (mkApp3 (.const ``Nat.lt_of_not_le []) x y h)
-  | (``GT.gt, #[.const ``Int [], _, x, y]) => some (mkApp3 (.const ``Int.le_of_not_lt []) y x h)
-  | (``GE.ge, #[.const ``Int [], _, x, y]) => some (mkApp3 (.const ``Int.lt_of_not_le []) y x h)
-  | (``GT.gt, #[.const ``Nat [], _, x, y]) => some (mkApp3 (.const ``Nat.le_of_not_lt []) y x h)
-  | (``GE.ge, #[.const ``Nat [], _, x, y]) => some (mkApp3 (.const ``Nat.lt_of_not_le []) y x h)
-  | (``Eq, #[.const ``Nat [], x, y]) => some (mkApp3 (.const ``Nat.lt_or_gt_of_ne []) x y h)
-  | (``Eq, #[.const ``Int [], x, y]) => some (mkApp3 (.const ``Int.lt_or_gt_of_ne []) x y h)
-  | (``Dvd.dvd, #[.const ``Nat [], _, k, x]) =>
-    some (mkApp3 (.const ``Nat.emod_pos_of_not_dvd []) k x h)
-  | (``Dvd.dvd, #[.const ``Int [], _, k, x]) =>
-    -- This introduces a disjunction that could be avoided by checking `k ≠ 0`.
-    some (mkApp3 (.const ``Int.emod_pos_of_not_dvd []) k x h)
-  | (``Or, #[P₁, P₂]) => some (mkApp3 (.const ``and_not_not_of_not_or []) P₁ P₂ h)
-  | (``And, #[P₁, P₂]) =>
-    some (mkApp5 (.const ``Decidable.or_not_not_of_not_and []) P₁ P₂
-      (.app (.const ``Classical.propDecidable []) P₁)
-      (.app (.const ``Classical.propDecidable []) P₂) h)
+  match P with
+  | .forallE _ t b _ =>
+    some (mkApp4 (.const ``Decidable.and_not_of_not_imp []) t b
+      (.app (.const ``Classical.propDecidable []) t) h)
+  | .app _ _ =>
+    match P.getAppFnArgs with
+    | (``LT.lt, #[.const ``Int [], _, x, y]) => some (mkApp3 (.const ``Int.le_of_not_lt []) x y h)
+    | (``LE.le, #[.const ``Int [], _, x, y]) => some (mkApp3 (.const ``Int.lt_of_not_le []) x y h)
+    | (``LT.lt, #[.const ``Nat [], _, x, y]) => some (mkApp3 (.const ``Nat.le_of_not_lt []) x y h)
+    | (``LE.le, #[.const ``Nat [], _, x, y]) => some (mkApp3 (.const ``Nat.lt_of_not_le []) x y h)
+    | (``GT.gt, #[.const ``Int [], _, x, y]) => some (mkApp3 (.const ``Int.le_of_not_lt []) y x h)
+    | (``GE.ge, #[.const ``Int [], _, x, y]) => some (mkApp3 (.const ``Int.lt_of_not_le []) y x h)
+    | (``GT.gt, #[.const ``Nat [], _, x, y]) => some (mkApp3 (.const ``Nat.le_of_not_lt []) y x h)
+    | (``GE.ge, #[.const ``Nat [], _, x, y]) => some (mkApp3 (.const ``Nat.lt_of_not_le []) y x h)
+    | (``Eq, #[.const ``Nat [], x, y]) => some (mkApp3 (.const ``Nat.lt_or_gt_of_ne []) x y h)
+    | (``Eq, #[.const ``Int [], x, y]) => some (mkApp3 (.const ``Int.lt_or_gt_of_ne []) x y h)
+    | (``Dvd.dvd, #[.const ``Nat [], _, k, x]) =>
+      some (mkApp3 (.const ``Nat.emod_pos_of_not_dvd []) k x h)
+    | (``Dvd.dvd, #[.const ``Int [], _, k, x]) =>
+      -- This introduces a disjunction that could be avoided by checking `k ≠ 0`.
+      some (mkApp3 (.const ``Int.emod_pos_of_not_dvd []) k x h)
+    | (``Or, #[P₁, P₂]) => some (mkApp3 (.const ``and_not_not_of_not_or []) P₁ P₂ h)
+    | (``And, #[P₁, P₂]) =>
+      some (mkApp5 (.const ``Decidable.or_not_not_of_not_and []) P₁ P₂
+        (.app (.const ``Classical.propDecidable []) P₁)
+        (.app (.const ``Classical.propDecidable []) P₂) h)
+    | (``Iff, #[P₁, P₂]) =>
+      some (mkApp5 (.const ``Decidable.and_not_or_not_and_of_not_iff []) P₁ P₂
+        (.app (.const ``Classical.propDecidable []) P₁)
+        (.app (.const ``Classical.propDecidable []) P₂) h)
+    | _ => none
   | _ => none
 
 /--
@@ -318,6 +328,9 @@ partial def addFact (p : MetaProblem) (h : Expr) : OmegaM (MetaProblem × Nat) :
       p.addFact (mkApp3 (.const ``Exists.choose_spec [← getLevel α]) α P h)
     | (``Subtype, #[α, P]) =>
       p.addFact (mkApp3 (.const ``Subtype.property [← getLevel α]) α P h)
+    | (``Iff, #[P₁, P₂]) =>
+      p.addFact (mkApp4 (.const ``Decidable.and_or_not_and_not_of_iff [])
+        P₁ P₂ (.app (.const ``Classical.propDecidable []) P₂) h)
     | (``Or, #[_, _]) =>
       if (← cfg).splitDisjunctions then
         return ({ p with disjunctions := p.disjunctions.insert h }, 1)

--- a/Std/Tactic/Omega/Logic.lean
+++ b/Std/Tactic/Omega/Logic.lean
@@ -20,3 +20,13 @@ namespace Std.Tactic.Omega
 
 alias ⟨and_not_not_of_not_or, _⟩ := not_or
 alias ⟨Decidable.or_not_not_of_not_and, _⟩ := Decidable.not_and_iff_or_not
+
+alias ⟨Decidable.and_or_not_and_not_of_iff, _⟩ := Decidable.iff_iff_and_or_not_and_not
+
+theorem Decidable.not_iff_iff_and_not_or_not_and [Decidable a] [Decidable b] :
+    (¬ (a ↔ b)) ↔ (a ∧ ¬ b) ∨ ((¬ a) ∧ b) := by
+  by_cases b <;> simp_all [Decidable.not_not]
+
+alias ⟨Decidable.and_not_or_not_and_of_not_iff, _⟩ := Decidable.not_iff_iff_and_not_or_not_and
+
+alias ⟨Decidable.and_not_of_not_imp, _⟩ := Decidable.not_imp

--- a/test/false_or_by_contra.lean
+++ b/test/false_or_by_contra.lean
@@ -18,7 +18,7 @@ example (h : False) : ¬ P := by
   guard_target = False
   simp_all
 
-example (h : False) : P := by
+example {P  : Prop} (h : False) : P := by
   false_or_by_contra <;> rename_i h
   guard_hyp h : ¬ P
   guard_target = False

--- a/test/false_or_by_contra.lean
+++ b/test/false_or_by_contra.lean
@@ -1,25 +1,33 @@
 import Std.Tactic.FalseOrByContra
 import Std.Tactic.GuardExpr
 
-example (h : False) : False := by
+example (w : False) : False := by
   false_or_by_contra
   guard_target = False
-  exact h
+  exact w
 
-example (h : False) : x ≠ y := by
+example (_ : False) : x ≠ y := by
   false_or_by_contra <;> rename_i h
   guard_hyp h : x = y
   guard_target = False
   simp_all
 
-example (h : False) : ¬ P := by
+example (_ : False) : ¬ P := by
   false_or_by_contra <;> rename_i h
   guard_hyp h : P
   guard_target = False
   simp_all
 
-example {P  : Prop} (h : False) : P := by
+example {P : Prop} (_ : False) : P := by
   false_or_by_contra <;> rename_i h
   guard_hyp h : ¬ P
+  guard_target = False
+  simp_all
+
+-- It doesn't make sense to use contradiction if the goal is a Type (rather than a Prop).
+example {P : Type} (_ : False) : P := by
+  false_or_by_contra
+  fail_if_success
+    have : ¬ P := by assumption
   guard_target = False
   simp_all

--- a/test/omega/test.lean
+++ b/test/omega/test.lean
@@ -287,3 +287,12 @@ example (p n p' n' : Nat) (h : p + n' = p' + n) : n + p' = n' + p := by
   omega
 
 example (a b c : Int) (h1 : 32 / a < b) (h2 : b < c) : 32 / a < c := by omega
+
+-- Verify that we can handle `iff` statements in hypotheses:
+example (a b : Int) (h : a < 0 ↔ b < 0) (w : b > 3) : a ≥ 0 := by omega
+
+-- Verify that we can prove `iff` goals:
+example (a b : Int) (h : a > 7) (w : b > 2) : a > 0 ↔ b > 0 := by omega
+
+-- Verify that we can prove implications:
+example (a : Int) : a > 0 → a > -1 := by omega

--- a/test/omega/test.lean
+++ b/test/omega/test.lean
@@ -296,3 +296,6 @@ example (a b : Int) (h : a > 7) (w : b > 2) : a > 0 ↔ b > 0 := by omega
 
 -- Verify that we can prove implications:
 example (a : Int) : a > 0 → a > -1 := by omega
+
+-- Verify that we don't treat function goals as implications.
+example (a : Nat) (h : a < 0) : Nat → Nat := by omega


### PR DESCRIPTION
While looking at theorems that "ought" to be proved by `omega`, I found a number of `iff` goals where one would need `constructor <;> (intros; omega)` to close the goal. This PR slightly powers up `omega` so it can do this by itself.