### PR TITLE
chore: move MVarId.note

### DIFF
--- a/Std/Lean/Meta/Basic.lean
+++ b/Std/Lean/Meta/Basic.lean
@@ -328,6 +328,11 @@ where
       else
         return e.hasFVar
 
+/-- Add the hypothesis `h : t`, given `v : t`, and return the new `FVarId`. -/
+def note (g : MVarId) (h : Name) (v : Expr) (t? : Option Expr := .none) :
+    MetaM (FVarId × MVarId) := do
+  (← g.assert h (← match t? with | some t => pure t | none => inferType v) v).intro1P
+
 /-- Get the type the given metavariable after instantiating metavariables and cleaning up
 annotations. -/
 def getTypeCleanup (mvarId : MVarId) : MetaM Expr :=

--- a/Std/Tactic/SolveByElim.lean
+++ b/Std/Tactic/SolveByElim.lean
@@ -32,11 +32,6 @@ open Std.Tactic
 
 namespace Lean.MVarId
 
-/-- Add the hypothesis `h : t`, given `v : t`, and return the new `FVarId`. -/
-def note (g : MVarId) (h : Name) (v : Expr) (t : Option Expr := .none) :
-    MetaM (FVarId × MVarId) := do
-  (← g.assert h (← t.getDM (inferType v)) v).intro1P
-
 /-- For every hypothesis `h : a ~ b` where a `@[symm]` lemma is available,
 add a hypothesis `h_symm : b ~ a`. -/
 def symmSaturate (g : MVarId) : MetaM MVarId := g.withContext do


### PR DESCRIPTION
Several Mathlib tactics use this, so it is not ideal to have this in `SolveByElim`.