### PR TITLE
feat: `trySetOptions` / `tryEraseAttrs` command elab helpers

### DIFF
--- a/Std/Lean/Elab/Command.lean
+++ b/Std/Lean/Elab/Command.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2023 Mac Malone. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mac Malone
+-/
+import Lean.Elab.Command
+
+/-!
+# Command elaboration helpers
+-/
+
+namespace Lean.Elab.Command
+
+/--
+For each named option which exists, set its value.
+Will still fail if the set value does not match the option's proper type
+(e.g., setting a string value to a boolean option).
+-/
+def trySetOptions (settings : Array (Name × DataValue)) : CommandElabM PUnit := do
+  let opts ← getOptions
+  let ⟨_, opts⟩ ← StateT.run (s := opts) <| settings.forM fun ⟨optName, val⟩ => do
+    if let .ok decl ← getOptionDecl optName |>.toBaseIO then
+      unless decl.defValue.sameCtor val do
+        throwError "type mismatch for '{optName}'"
+      modify (·.insert optName val)
+  modifyScope ({· with opts})
+
+/--
+If `attrName` exists, try to erase it from the specified declaration names,
+skipping any that do not exist (or, due to implementation constraints,
+fail to erase).
+
+Thus, ``tryEraseAttr `my_attr  #[`foo, `bar]`` is essentially equivalent to
+the command `attribute [-my_attr] foo bar`, except it will not error if the
+attribute or declaration names do not exist.
+-/
+def tryEraseAttr (attrName : Name) (declNames : Array Name) : CoreM PUnit := do
+  let attrState := attributeExtension.getState (← getEnv)
+  if let some attr := attrState.map.find? attrName then
+    declNames.forM fun declName =>
+      try
+        attr.erase declName
+      catch _ =>
+        -- This consumes all types of errors, rather than just existence ones,
+        -- but there does not appear to be a better general way to achieve this
+        pure ()
+
+/--
+for each named attribute which exists,
+erase from it the specified declaration names, ignoring failures.
+-/
+def tryEraseAttrs (attrs :  Array (Name × Array Name)) : CommandElabM PUnit := do
+  liftCoreM <| attrs.forM fun ⟨attrName, declNames⟩ => tryEraseAttr attrName declNames

--- a/test/command_elab.lean
+++ b/test/command_elab.lean
@@ -1,0 +1,53 @@
+import Std.Tactic.RunCmd
+import Std.Tactic.GuardMsgs
+import Std.Lean.Elab.Command
+import Lean.Meta.Tactic.Simp
+import Std.Tactic.Ext
+
+open Lean Elab Command
+
+/-- error: type mismatch for 'maxHeartbeats' -/
+#guard_msgs in run_cmd trySetOptions #[⟨`maxHeartbeats, true⟩]
+
+/-
+Verify that `trySetOptions` and `tryEraseAttrs` properly
+set options, erase attributes, and skip nonexistent ones
+-/
+
+run_cmd do
+  trySetOptions #[
+    ⟨`push_neg.use_distrib, true⟩,
+    ⟨`warningAsError, true⟩
+  ]
+  tryEraseAttrs #[
+    ⟨`simp, #[`ne_eq, `foo]⟩,
+    ⟨`ext, #[`Prod.ext, `foo]⟩,
+    ⟨`instance, #[
+      `Int.instDivInt_1,`Int.instDivInt,
+      `EuclideanDomain.instDiv, `Nat.instDivNat
+    ]⟩,
+    ⟨`norm_num, #[`Mathlib.Meta.NormNum.evalNatDvd]⟩
+  ]
+
+/-- info: true -/
+#guard_msgs(info) in run_cmd
+  logInfo <| repr <| (← getOptions).get `warningAsError false
+
+/-- info: false -/
+#guard_msgs(info) in run_cmd-- true
+  logInfo <| repr <| (← getOptions).get `push_neg.use_distrib false
+
+/-- info: #[Lean.Meta.Origin.decl `ne_eq false] -/
+#guard_msgs(info) in run_cmd
+  let thms := Lean.Meta.simpExtension.getState (← getEnv)
+  logInfo <| repr <| thms.erased.fold Array.push Array.empty
+
+/-- info: #[`Prod.ext] -/
+#guard_msgs(info) in run_cmd-- #[`Prod.ext]
+  let thms := Std.Tactic.Ext.extExtension.getState (← getEnv)
+  logInfo <| repr <| thms.erased.fold Array.push Array.empty
+
+/-- info: #[`Int.instDivInt, `Nat.instDivNat] -/
+#guard_msgs(info) in run_cmd
+  let insts ← liftCoreM Lean.Meta.getErasedInstances
+  logInfo <| repr <| insts.fold Array.push Array.empty


### PR DESCRIPTION
Helpers which I wrote for @hrmacbeth to use in her Mechanics of Proof [package](https://github.com/hrmacbeth/math2001/tree/main) to help with initializing options and attributes for a teaching environment. She suggested I PR these helpers to Std as they quite helpful when configuring custom environments and are thus useful to many who teach Lean.