### PR TITLE
chore: remove unnecessary `have`

### DIFF
--- a/Std/Tactic/Omega/OmegaM.lean
+++ b/Std/Tactic/Omega/OmegaM.lean
@@ -148,7 +148,6 @@ Return its index, and, if it is new, a collection of interesting facts about the
 def lookup (e : Expr) : OmegaM (Nat × Option (HashSet Expr)) := do
   let c ← getThe State
   for h : i in [:c.atoms.size] do
-    have : i < c.atoms.size := h.2
     if ← isDefEq e c.atoms[i] then
       return (i, none)
   trace[omega] "New atom: {e}"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-01-03
+leanprover/lean4:nightly-2024-01-09


### PR DESCRIPTION
After leanprover/lean4#3132 the linter will complain about this.