### PR TITLE
feat: `false_or_by_contra` uses `Decidable.byContra` if possible

### DIFF
--- a/Std/Tactic/FalseOrByContra.lean
+++ b/Std/Tactic/FalseOrByContra.lean
@@ -52,7 +52,7 @@ def falseOrByContra (g : MVarId) (useClassical : Option Bool := none) : MetaM MV
     else
       pure none
     if let some gs := gs then
-      let [g] := gs | panic! "expected one sugoal"
+      let [g] := gs | panic! "expected one subgoal"
       pure (← g.intro1).2
     else
       let [g] ← g.applyConst ``False.elim | panic! "expected one sugoal"

--- a/Std/Tactic/FalseOrByContra.lean
+++ b/Std/Tactic/FalseOrByContra.lean
@@ -33,15 +33,26 @@ syntax (name := false_or_by_contra) "false_or_by_contra" : tactic
 open Meta Elab Tactic
 
 @[inherit_doc false_or_by_contra]
-def falseOrByContra (g : MVarId) : MetaM MVarId := do
+def falseOrByContra (g : MVarId) (useClassical : Option Bool := none) : MetaM MVarId := do
   let ty ← whnfR (← g.getType)
   match ty with
   | .const ``False _ => pure g
   | .app (.const ``Not _) _
   | .app (.const ``Ne _) _ => pure (← g.intro1).2
   | _ =>
-    if ← isProp ty then
-      let [g] ← g.applyConst ``Classical.byContradiction | panic! "expected one sugoal"
+    let gs ← if ← isProp ty then
+      match useClassical with
+      | some true => some <$> g.applyConst ``Classical.byContradiction
+      | some false =>
+        try some <$> g.applyConst ``Decidable.byContradiction
+        catch _ => pure none
+      | none =>
+        try some <$> g.applyConst ``Decidable.byContradiction
+        catch _ => some <$> g.applyConst ``Classical.byContradiction
+    else
+      pure none
+    if let some gs := gs then
+      let [g] := gs | panic! "expected one sugoal"
       pure (← g.intro1).2
     else
       let [g] ← g.applyConst ``False.elim | panic! "expected one sugoal"

--- a/Std/Tactic/Omega/Frontend.lean
+++ b/Std/Tactic/Omega/Frontend.lean
@@ -482,6 +482,7 @@ elab_rules : tactic |
   let cfg ← elabOmegaConfig (mkOptionalNode cfg)
   liftMetaFinishingTactic fun g => do
     let g ← falseOrByContra g
+      (useClassical := false) -- because all the hypotheses we can make use of are decidable
     g.withContext do
       let hyps := (← getLocalHyps).toList
       trace[omega] "analyzing {hyps.length} hypotheses:\n{← hyps.mapM inferType}"


### PR DESCRIPTION
This fixes one of several unnecessary uses of classical axioms in `omega`.