### PR TITLE
feat: add `Std.Data.List.SplitOnList`

### DIFF
--- a/Std/Data/List.lean
+++ b/Std/Data/List.lean
@@ -6,3 +6,4 @@ import Std.Data.List.Init.Lemmas
 import Std.Data.List.Lemmas
 import Std.Data.List.Pairwise
 import Std.Data.List.Perm
+import Std.Data.List.SplitOnList

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -139,6 +139,8 @@ theorem drop_eq_get_cons : ∀ {n} {l : List α} (h), drop n l = get l ⟨n, h�
 @[simp] theorem isEmpty_nil : ([] : List α).isEmpty = true := rfl
 @[simp] theorem isEmpty_cons : (x :: xs : List α).isEmpty = false := rfl
 
+theorem isEmpty_iff_eq_nil {l : List α} : l.isEmpty ↔ l = [] := by cases l <;> simp [isEmpty]
+
 /-! ### append -/
 
 theorem append_eq_append : List.append l₁ l₂ = l₁ ++ l₂ := rfl

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -2116,9 +2116,8 @@ theorem length_le_of_isPrefixOf [BEq α] {l₁ l₂ : List α} (h : l₁.isPrefi
   | [],    _     => simp
   | _::_,  []    => simp [isPrefixOf] at h
   | a::as, b::bs =>
-    simp [isPrefixOf] at h
-    simp [Nat.succ_le_succ_iff]
-    exact length_le_of_isPrefixOf h.2
+    simp only [isPrefixOf, Bool.and_eq_true] at h
+    simpa [Nat.succ_le_succ_iff] using length_le_of_isPrefixOf h.2
 
 theorem length_le_of_isSuffixOf [BEq α] {l₁ l₂ : List α} (h : l₁.isSuffixOf l₂) :
     l₁.length ≤ l₂.length := by

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -2108,6 +2108,22 @@ theorem disjoint_take_drop : ∀ {l : List α}, l.Nodup → m ≤ n → Disjoint
       refine ⟨fun h => h₀ _ (mem_of_mem_drop h) rfl, ?_⟩
       exact disjoint_take_drop h₁ (Nat.le_of_succ_le_succ h)
 
+/-! ### isPrefixOf and isSuffixOf -/
+
+theorem length_le_of_isPrefixOf [BEq α] {l₁ l₂ : List α} (h : l₁.isPrefixOf l₂) :
+    l₁.length ≤ l₂.length := by
+  match l₁, l₂ with
+  | [],    _     => simp
+  | _::_,  []    => simp [isPrefixOf] at h
+  | a::as, b::bs =>
+    simp [isPrefixOf] at h
+    simp [Nat.succ_le_succ_iff]
+    exact length_le_of_isPrefixOf h.2
+
+theorem length_le_of_isSuffixOf [BEq α] {l₁ l₂ : List α} (h : l₁.isSuffixOf l₂) :
+    l₁.length ≤ l₂.length := by
+  simpa [length_reverse] using length_le_of_isPrefixOf h
+
 /-! ### takeWhile and dropWhile -/
 
 @[simp] theorem takeWhile_append_dropWhile (p : α → Bool) :

--- a/Std/Data/List/SplitOnList.lean
+++ b/Std/Data/List/SplitOnList.lean
@@ -63,7 +63,7 @@ def splitOnList [BEq α] (l sep : List α) : List (List α) :=
             · apply length_pos.mpr; simp [← isEmpty_iff_eq_nil, h]
             · apply length_le_of_isPrefixOf (P_of_splitOnceRightP sep.isPrefixOf l l₁ l₂ e)
           _ ≤ length l₁ + length l₂ := Nat.le_add_left ..
-      splitOnList (l₂.drop sep.length) sep
+      l₁ :: splitOnList (l₂.drop sep.length) sep
 termination_by _ => l.length
 
 end List

--- a/Std/Data/List/SplitOnList.lean
+++ b/Std/Data/List/SplitOnList.lean
@@ -75,6 +75,6 @@ def splitOnList [BEq α] (l sep : List α) : List (List α) :=
              (length_le_of_isPrefixOf (P_of_splitOnceRightP sep.isPrefixOf l l₁ l₂ e))
           _ ≤ length l₁ + length l₂ := Nat.le_add_left ..
       l₁ :: splitOnList (l₂.drop sep.length) sep
-termination_by _ => l.length
+termination_by l.length
 
 end List

--- a/Std/Data/List/SplitOnList.lean
+++ b/Std/Data/List/SplitOnList.lean
@@ -5,6 +5,18 @@ Authors: Bulhwi Cha, Mario Carneiro
 -/
 import Std.Data.List.Lemmas
 
+/-!
+# `List.splitOnList`
+
+This file introduces the `List.splitOnList` function, which is a specification for `String.splitOn`.
+We need it to prove `String.splitOn_of_valid` in `Std.Data.String.Lemmas`.
+```
+[1, 1, 2, 3, 2, 4, 4].splitOnList []     = [[1, 1, 2, 3, 2, 4, 4]]
+[1, 1, 2, 3, 2, 4, 4].splitOnList [5, 6] = [[1, 1, 2, 3, 2, 4, 4]]
+[1, 1, 2, 3, 2, 4, 4].splitOnList [2, 3] = [[1, 1], [2, 4, 4]]
+```
+-/
+
 namespace List
 
 /-- Returns `(l₁, l₂)` for the first split `l = l₁ ++ l₂` such that `P l₂` returns true. -/

--- a/Std/Data/List/SplitOnList.lean
+++ b/Std/Data/List/SplitOnList.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2024 Bulhwi Cha, Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bulhwi Cha, Mario Carneiro
+-/
+import Std.Data.List.Lemmas
+
+namespace List
+
+/-- Returns `(l₁, l₂)` for the first split `l = l₁ ++ l₂` such that `P l₂` returns true. -/
+def splitOnceP (P : List α → Bool) (l : List α) : Option (List α × List α) :=
+  if P l then
+    some ([], l)
+  else
+    match l with
+    | [] => none
+    | a :: l => (splitOnceP P l).map fun (l, r) => (a :: l, r)
+
+theorem eq_append_of_splitOnceP (P : List α → Bool) (l : List α) :
+    ∀ l₁ l₂, splitOnceP P l = some (l₁, l₂) → l = l₁ ++ l₂ := by
+  induction l with
+  | nil => simp [splitOnceP]
+  | cons a l ih =>
+    simp [splitOnceP]
+    if h : P (a :: l) then
+      simp [h]
+    else
+      simp [h]
+      match e : splitOnceP P l with
+      | none => simp
+      | some (lf, rt) => simp; apply ih; assumption
+
+theorem P_of_splitOnceP (P : List α → Bool) (l : List α) :
+    ∀ l₁ l₂, splitOnceP P l = some (l₁, l₂) → P l₂ := by
+  induction l with
+  | nil => simp [splitOnceP]
+  | cons a l ih =>
+    simp [splitOnceP]
+    if h : P (a :: l) then
+      simp [h]
+    else
+      simp [h]
+      match e : splitOnceP P l with
+      | none => simp
+      | some (lf, rt) => simp; apply ih; assumption
+
+/--
+Split a list at every occurrence of a separator list. The separators are not in the result.
+```
+[1, 1, 2, 3, 2, 4, 4].splitOnList [2, 3] = [[1, 1], [2, 4, 4]]
+```
+-/
+def splitOnList [BEq α] (l sep : List α) : List (List α) :=
+  if h : sep.isEmpty then
+    [l]
+  else
+    match e : splitOnceP sep.isPrefixOf l with
+    | none => [l]
+    | some (l₁, l₂) =>
+      have : length l₂ - sep.length < length l := by
+        rw [eq_append_of_splitOnceP (sep.isPrefixOf) l l₁ l₂ e, length_append]
+        calc
+          length l₂ - length sep < length l₂ := by
+            apply Nat.sub_lt_self
+            · apply length_pos.mpr; simp [← isEmpty_iff_eq_nil, h]
+            · apply length_le_of_isPrefixOf (P_of_splitOnceP sep.isPrefixOf l l₁ l₂ e)
+          _ ≤ length l₁ + length l₂ := Nat.le_add_left ..
+      splitOnList (l₂.drop sep.length) sep
+termination_by _ => l.length
+
+end List

--- a/Std/Data/List/SplitOnList.lean
+++ b/Std/Data/List/SplitOnList.lean
@@ -58,10 +58,9 @@ def splitOnList [BEq α] (l sep : List α) : List (List α) :=
       have : length l₂ - sep.length < length l := by
         rw [eq_append_of_splitOnceRightP (sep.isPrefixOf) l l₁ l₂ e, length_append]
         calc
-          length l₂ - length sep < length l₂ := by
-            apply Nat.sub_lt_self
-            · apply length_pos.mpr; simp [← isEmpty_iff_eq_nil, h]
-            · apply length_le_of_isPrefixOf (P_of_splitOnceRightP sep.isPrefixOf l l₁ l₂ e)
+          length l₂ - length sep < length l₂ :=
+            Nat.sub_lt_self (by simp [length_pos, ← isEmpty_iff_eq_nil, h])
+             (length_le_of_isPrefixOf (P_of_splitOnceRightP sep.isPrefixOf l l₁ l₂ e))
           _ ≤ length l₁ + length l₂ := Nat.le_add_left ..
       l₁ :: splitOnList (l₂.drop sep.length) sep
 termination_by _ => l.length

--- a/Std/Data/List/SplitOnList.lean
+++ b/Std/Data/List/SplitOnList.lean
@@ -21,11 +21,10 @@ theorem eq_append_of_splitOnceP (P : List α → Bool) (l : List α) :
   induction l with
   | nil => simp [splitOnceP]
   | cons a l ih =>
-    simp [splitOnceP]
     if h : P (a :: l) then
-      simp [h]
+      simp [splitOnceP, h]
     else
-      simp [h]
+      simp only [splitOnceP, h, ite_false]
       match e : splitOnceP P l with
       | none => simp
       | some (lf, rt) => simp; apply ih; assumption
@@ -35,11 +34,10 @@ theorem P_of_splitOnceP (P : List α → Bool) (l : List α) :
   induction l with
   | nil => simp [splitOnceP]
   | cons a l ih =>
-    simp [splitOnceP]
     if h : P (a :: l) then
-      simp [h]
+      simp [splitOnceP, h]
     else
-      simp [h]
+      simp only [splitOnceP, h, ite_false]
       match e : splitOnceP P l with
       | none => simp
       | some (lf, rt) => simp; apply ih; assumption

--- a/Std/Data/List/SplitOnList.lean
+++ b/Std/Data/List/SplitOnList.lean
@@ -8,37 +8,37 @@ import Std.Data.List.Lemmas
 namespace List
 
 /-- Returns `(l₁, l₂)` for the first split `l = l₁ ++ l₂` such that `P l₂` returns true. -/
-def splitOnceP (P : List α → Bool) (l : List α) : Option (List α × List α) :=
+def splitOnceRightP (P : List α → Bool) (l : List α) : Option (List α × List α) :=
   if P l then
     some ([], l)
   else
     match l with
     | [] => none
-    | a :: l => (splitOnceP P l).map fun (l, r) => (a :: l, r)
+    | a :: l => (splitOnceRightP P l).map fun (l, r) => (a :: l, r)
 
-theorem eq_append_of_splitOnceP (P : List α → Bool) (l : List α) :
-    ∀ l₁ l₂, splitOnceP P l = some (l₁, l₂) → l = l₁ ++ l₂ := by
+theorem eq_append_of_splitOnceRightP (P : List α → Bool) (l : List α) :
+    ∀ l₁ l₂, splitOnceRightP P l = some (l₁, l₂) → l = l₁ ++ l₂ := by
   induction l with
-  | nil => simp [splitOnceP]
+  | nil => simp [splitOnceRightP]
   | cons a l ih =>
     if h : P (a :: l) then
-      simp [splitOnceP, h]
+      simp [splitOnceRightP, h]
     else
-      simp only [splitOnceP, h, ite_false]
-      match e : splitOnceP P l with
+      simp only [splitOnceRightP, h, ite_false]
+      match e : splitOnceRightP P l with
       | none => simp
       | some (lf, rt) => simp; apply ih; assumption
 
-theorem P_of_splitOnceP (P : List α → Bool) (l : List α) :
-    ∀ l₁ l₂, splitOnceP P l = some (l₁, l₂) → P l₂ := by
+theorem P_of_splitOnceRightP (P : List α → Bool) (l : List α) :
+    ∀ l₁ l₂, splitOnceRightP P l = some (l₁, l₂) → P l₂ := by
   induction l with
-  | nil => simp [splitOnceP]
+  | nil => simp [splitOnceRightP]
   | cons a l ih =>
     if h : P (a :: l) then
-      simp [splitOnceP, h]
+      simp [splitOnceRightP, h]
     else
-      simp only [splitOnceP, h, ite_false]
-      match e : splitOnceP P l with
+      simp only [splitOnceRightP, h, ite_false]
+      match e : splitOnceRightP P l with
       | none => simp
       | some (lf, rt) => simp; apply ih; assumption
 
@@ -52,16 +52,16 @@ def splitOnList [BEq α] (l sep : List α) : List (List α) :=
   if h : sep.isEmpty then
     [l]
   else
-    match e : splitOnceP sep.isPrefixOf l with
+    match e : splitOnceRightP sep.isPrefixOf l with
     | none => [l]
     | some (l₁, l₂) =>
       have : length l₂ - sep.length < length l := by
-        rw [eq_append_of_splitOnceP (sep.isPrefixOf) l l₁ l₂ e, length_append]
+        rw [eq_append_of_splitOnceRightP (sep.isPrefixOf) l l₁ l₂ e, length_append]
         calc
           length l₂ - length sep < length l₂ := by
             apply Nat.sub_lt_self
             · apply length_pos.mpr; simp [← isEmpty_iff_eq_nil, h]
-            · apply length_le_of_isPrefixOf (P_of_splitOnceP sep.isPrefixOf l l₁ l₂ e)
+            · apply length_le_of_isPrefixOf (P_of_splitOnceRightP sep.isPrefixOf l l₁ l₂ e)
           _ ≤ length l₁ + length l₂ := Nat.le_add_left ..
       splitOnList (l₂.drop sep.length) sep
 termination_by _ => l.length


### PR DESCRIPTION
* Move a theorem from `Mathlib.Data.List.Basic` to Std.
* Add theorems about `List.isPrefixOf` and `List.isSuffixOf`.
* Add `Std.Data.List.SplitOnList`.

`List.splitOnList` is a specification for `String.splitOn`. We need it to prove `String.splitOn_of_valid`, which is on the to-do list in `Std.Data.String.Lemmas`.

Co-authored-by: Mario Carneiro <di.gama@gmail.com>
Co-authored-by: Scott Morrison <scott.morrison@gmail.com>

---

See https://github.com/leanprover/std4/pull/495.