### PR TITLE
feat: lemmas about Int.gcd

### DIFF
--- a/Std/Data/Int.lean
+++ b/Std/Data/Int.lean
@@ -1,3 +1,4 @@
 import Std.Data.Int.Basic
 import Std.Data.Int.DivMod
+import Std.Data.Int.Gcd
 import Std.Data.Int.Lemmas

--- a/Std/Data/Int/DivMod.lean
+++ b/Std/Data/Int/DivMod.lean
@@ -625,6 +625,8 @@ protected theorem dvd_zero (n : Int) : n ∣ 0 := ⟨0, (Int.mul_zero _).symm⟩
 
 protected theorem dvd_refl (n : Int) : n ∣ n := ⟨1, (Int.mul_one _).symm⟩
 
+protected theorem one_dvd (n : Int) : 1 ∣ n := ⟨n, (Int.one_mul n).symm⟩
+
 protected theorem dvd_trans : ∀ {a b c : Int}, a ∣ b → b ∣ c → a ∣ c
   | _, _, _, ⟨d, rfl⟩, ⟨e, rfl⟩ => ⟨d * e, by rw [Int.mul_assoc]⟩
 
@@ -688,6 +690,14 @@ theorem dvd_natAbs {a b : Int} : a ∣ b.natAbs ↔ a ∣ b :=
   match natAbs_eq b with
   | .inl e => by rw [← e]
   | .inr e => by rw [← Int.dvd_neg, ← e]
+
+theorem natAbs_dvd_self {a : Int} : (a.natAbs : Int) ∣ a := by
+  rw [Int.natAbs_dvd]
+  exact Int.dvd_refl a
+
+theorem dvd_natAbs_self {a : Int} : a ∣ (a.natAbs : Int) := by
+  rw [Int.dvd_natAbs]
+  exact Int.dvd_refl a
 
 theorem ofNat_dvd_left {n : Nat} {z : Int} : (↑n : Int) ∣ z ↔ n ∣ z.natAbs := by
   rw [← natAbs_dvd_natAbs, natAbs_ofNat]

--- a/Std/Data/Int/Gcd.lean
+++ b/Std/Data/Int/Gcd.lean
@@ -23,11 +23,11 @@ theorem gcd_dvd_right {a b : Int} : (gcd a b : Int) ∣ b := by
   rw [← Int.ofNat_dvd] at this
   exact Int.dvd_trans this natAbs_dvd_self
 
-@[simp] theorem gcd_one_left {a : Int} : gcd 1 a = 1 := by simp [gcd]
-@[simp] theorem gcd_one_right {a : Int} : gcd a 1 = 1 := by simp [gcd]
+@[simp] theorem one_gcd {a : Int} : gcd 1 a = 1 := by simp [gcd]
+@[simp] theorem gcd_one {a : Int} : gcd a 1 = 1 := by simp [gcd]
 
-@[simp] theorem gcd_neg_left {a b : Int} : gcd a (-b) = gcd a b := by simp [gcd]
-@[simp] theorem gcd_neg_right {a b : Int} : gcd a (-b) = gcd a b := by simp [gcd]
+@[simp] theorem neg_gcd {a b : Int} : gcd a (-b) = gcd a b := by simp [gcd]
+@[simp] theorem gcd_neg {a b : Int} : gcd a (-b) = gcd a b := by simp [gcd]
 
 /-- Computes the least common multiple of two integers, as a `Nat`. -/
 def lcm (m n : Int) : Nat := m.natAbs.lcm n.natAbs

--- a/Std/Data/Int/Gcd.lean
+++ b/Std/Data/Int/Gcd.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2023 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Std.Data.Int.DivMod
+import Std.Data.Nat.Gcd
+import Std.Tactic.Simpa
+
+/-!
+# Results about `Int.gcd`.
+-/
+
+namespace Int
+
+theorem gcd_dvd_left {a b : Int} : (gcd a b : Int) ∣ a := by
+  have := Nat.gcd_dvd_left a.natAbs b.natAbs
+  rw [← Int.ofNat_dvd] at this
+  exact Int.dvd_trans this natAbs_dvd_self
+
+theorem gcd_dvd_right {a b : Int} : (gcd a b : Int) ∣ b := by
+  have := Nat.gcd_dvd_right a.natAbs b.natAbs
+  rw [← Int.ofNat_dvd] at this
+  exact Int.dvd_trans this natAbs_dvd_self
+
+@[simp] theorem gcd_one_left {a : Int} : gcd 1 a = 1 := by simp [gcd]
+@[simp] theorem gcd_one_right {a : Int} : gcd a 1 = 1 := by simp [gcd]
+
+@[simp] theorem gcd_neg_left {a b : Int} : gcd a (-b) = gcd a b := by simp [gcd]
+@[simp] theorem gcd_neg_right {a b : Int} : gcd a (-b) = gcd a b := by simp [gcd]
+
+/-- Computes the least common multiple of two integers, as a `Nat`. -/
+def lcm (m n : Int) : Nat := m.natAbs.lcm n.natAbs
+
+theorem lcm_ne_zero (hm : m ≠ 0) (hn : n ≠ 0) : lcm m n ≠ 0 := by
+  simp only [lcm]
+  apply Nat.lcm_ne_zero <;> simpa
+
+theorem dvd_lcm_left {a b : Int} : a ∣ lcm a b :=
+  Int.dvd_trans dvd_natAbs_self (Int.ofNat_dvd.mpr (Nat.dvd_lcm_left a.natAbs b.natAbs))
+
+theorem dvd_lcm_right {a b : Int} : b ∣ lcm a b :=
+  Int.dvd_trans dvd_natAbs_self (Int.ofNat_dvd.mpr (Nat.dvd_lcm_right a.natAbs b.natAbs))
+
+@[simp] theorem lcm_self {a : Int} : lcm a a = a.natAbs := Nat.lcm_self _

--- a/Std/Data/Int/Gcd.lean
+++ b/Std/Data/Int/Gcd.lean
@@ -26,7 +26,7 @@ theorem gcd_dvd_right {a b : Int} : (gcd a b : Int) ∣ b := by
 @[simp] theorem one_gcd {a : Int} : gcd 1 a = 1 := by simp [gcd]
 @[simp] theorem gcd_one {a : Int} : gcd a 1 = 1 := by simp [gcd]
 
-@[simp] theorem neg_gcd {a b : Int} : gcd a (-b) = gcd a b := by simp [gcd]
+@[simp] theorem neg_gcd {a b : Int} : gcd (-a) b = gcd a b := by simp [gcd]
 @[simp] theorem gcd_neg {a b : Int} : gcd a (-b) = gcd a b := by simp [gcd]
 
 /-- Computes the least common multiple of two integers, as a `Nat`. -/

--- a/Std/Data/Nat/Basic.lean
+++ b/Std/Data/Nat/Basic.lean
@@ -107,6 +107,9 @@ there is some `c` such that `b = a * c`.
 -/
 instance : Dvd Nat := ⟨fun a b => ∃ c, b = a * c⟩
 
+/-- The least common multiple of `m` and `n`, defined using `gcd`. -/
+def lcm (m n : Nat) : Nat := m * n / gcd m n
+
 /-- Sum of a list of natural numbers. -/
 protected def sum (l : List Nat) : Nat := l.foldr (·+·) 0
 

--- a/Std/Data/Nat/Gcd.lean
+++ b/Std/Data/Nat/Gcd.lean
@@ -26,9 +26,6 @@ theorem gcd_rec (m n : Nat) : gcd m n = gcd (n % m) m :=
     | _+1, IH => fun _ => H1 _ _ (succ_pos _) (IH _ (mod_lt _ (succ_pos _)) _) )
     n
 
-/-- The least common multiple of `m` and `n`, defined using `gcd`. -/
-def lcm (m n : Nat) : Nat := m * n / gcd m n
-
 /-- `m` and `n` are coprime, or relatively prime, if their `gcd` is 1. -/
 @[reducible] def Coprime (m n : Nat) : Prop := gcd m n = 1
 


### PR DESCRIPTION
We move the definition of `Nat.lcm` from `Std.Data.Nat.Gcd` to `Std.Data.Nat.Basic`, and prove a few lemmas about `Int.gcd`, which are just thin wrappers around the corresponding lemams for `Nat.gcd`, dealing with `natAbs` as necessary.

- [ ] depends on #537