### PR TITLE
fix: make exfalso actually do what it claims to

### DIFF
--- a/Std/Tactic/Basic.lean
+++ b/Std/Tactic/Basic.lean
@@ -19,7 +19,7 @@ namespace Std.Tactic
 open Lean Parser.Tactic Elab Command Elab.Tactic Meta
 
 /-- `exfalso` converts a goal `⊢ tgt` into `⊢ False` by applying `False.elim`. -/
-macro "exfalso" : tactic => `(tactic| apply False.elim)
+macro "exfalso" : tactic => `(tactic| refine False.elim ?_)
 
 /--
 `_` in tactic position acts like the `done` tactic: it fails and gives the list

--- a/test/exfalso.lean
+++ b/test/exfalso.lean
@@ -1,0 +1,13 @@
+import Std.Tactic.Basic
+
+private axiom test_sorry : ∀ {α}, α
+
+example {A} (h : False) : A := by
+  exfalso
+  exact h
+
+example {A} : False → A := by
+  exfalso
+  show False -- exfalso is not supposed to close the goal yet
+  exact test_sorry
+  


### PR DESCRIPTION
Before this change,
```lean
example {A} : False → A := by exfalso
```
would work, but the docstring ("converts a goal `⊢ tgt` into `⊢ False`") says it should not.