### PR TITLE
chore: fix missing import in Std.Tactic.LibrarySearch

### DIFF
--- a/Std/Tactic/LibrarySearch.lean
+++ b/Std/Tactic/LibrarySearch.lean
@@ -7,6 +7,7 @@ import Std.Lean.CoreM
 import Std.Lean.Expr
 import Std.Lean.Meta.DiscrTree
 import Std.Lean.Meta.LazyDiscrTree
+import Std.Data.Option.Basic
 import Std.Tactic.SolveByElim
 import Std.Util.Pickle
 


### PR DESCRIPTION
This is fixing an error in `main`, so I intend to merge immediately after CI passes.