### PR TITLE
chore: make nightly-testing-YYYY-MM-DD a tag, not a branch

### DIFF
--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -44,7 +44,14 @@ jobs:
         toolchain=$(<lean-toolchain)
         if [[ $toolchain =~ leanprover/lean4:nightly-([a-zA-Z0-9_-]+) ]]; then
           version=${BASH_REMATCH[1]}
-          git push origin refs/heads/nightly-testing:refs/heads/nightly-testing-$version
+          if git ls-remote --tags origin refs/tags/nightly-testing-$version | grep -q 'refs/tags/nightly-testing-$version'; then
+              echo "Tag nightly-testing-$version already exists on the remote."
+          else
+              # If the tag does not exist, create and push the tag to remote
+              echo "Creating tag nightly-testing-$version from the current state of the nightly-testing branch."
+              git tag nightly-testing-$version
+              git push origin nightly-testing-$version
+          fi
         else
           echo "Error: The file lean-toolchain does not contain the expected pattern."
           exit 1

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -39,7 +39,7 @@ jobs:
         ref: nightly-testing # checkout nightly-testing branch
         fetch-depth: 0 # checkout all branches so that we can push from `nightly-testing` to `nightly-testing-YYYY-MM-DD`
         token: ${{ secrets.NIGHTLY_TESTING }}
-    - name: Update the nightly-testing-YYYY-MM-DD branch
+    - name: Update the nightly-testing-YYYY-MM-DD tag
       run: |
         toolchain=$(<lean-toolchain)
         if [[ $toolchain =~ leanprover/lean4:nightly-([a-zA-Z0-9_-]+) ]]; then

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -44,7 +44,7 @@ jobs:
         toolchain=$(<lean-toolchain)
         if [[ $toolchain =~ leanprover/lean4:nightly-([a-zA-Z0-9_-]+) ]]; then
           version=${BASH_REMATCH[1]}
-          if git ls-remote --tags origin refs/tags/nightly-testing-$version | grep -q 'refs/tags/nightly-testing-$version'; then
+          if git ls-remote --tags --exit-code origin "refs/tags/nightly-testing-$version" >/dev/null; then
               echo "Tag nightly-testing-$version already exists on the remote."
           else
               # If the tag does not exist, create and push the tag to remote


### PR DESCRIPTION
This is the Std companion for https://github.com/leanprover-community/mathlib4/pull/9842

I will update https://leanprover-community.github.io/contribute/tags_and_branches.html when merged.