### PR TITLE
feat: let_projs tactic, recursively adding projections of hypotheses

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -101,6 +101,7 @@ import Std.Tactic.HaveI
 import Std.Tactic.Instances
 import Std.Tactic.LabelAttr
 import Std.Tactic.LeftRight
+import Std.Tactic.LetProjs
 import Std.Tactic.LibrarySearch
 import Std.Tactic.Lint
 import Std.Tactic.Lint.Basic

--- a/Std/Lean/Meta/Basic.lean
+++ b/Std/Lean/Meta/Basic.lean
@@ -335,7 +335,12 @@ def note (g : MVarId) (h : Name) (v : Expr) (t? : Option Expr := .none) :
     MetaM (FVarId × MVarId) := do
   (← g.assert h (← match t? with | some t => pure t | none => inferType v) v).intro1P
 
-/-- Get the type the given metavariable after instantiating metavariables and cleaning up
+/-- Adds a let binding `h : t := v`, given `v : t`, and return the new `FVarId`. -/
+def «let» (g : MVarId) (h : Name) (v : Expr) (t? : Option Expr := .none) :
+    MetaM (FVarId × MVarId) := do
+  (← g.define h (← match t? with | some t => pure t | none => inferType v) v).intro1P
+
+/-- Get the type of the given metavariable after instantiating metavariables and cleaning up
 annotations. -/
 def getTypeCleanup (mvarId : MVarId) : MetaM Expr :=
   return (← instantiateMVars (← mvarId.getType)).cleanupAnnotations

--- a/Std/Tactic/LetProjs.lean
+++ b/Std/Tactic/LetProjs.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2023 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison
+-/
+import Std.Lean.Meta.Basic
+import Std.Lean.Expr
+import Lean.Elab.Tactic.ElabTerm
+
+/-!
+# `let_projs`
+
+`let_projs` adds let bindings for all projections of local hypotheses, recursively.
+
+It should not be used interactively,
+but may be useful as a preprocessing step for tactics such as `solve_by_elim`.
+-/
+
+open Lean Meta
+
+/--
+Analogue of `Lean.getStructureFields`,
+but return an empty array rather than panicking if `structName` does not refer to a structure.
+-/
+def Lean.getStructureFields! (env : Environment) (structName : Name) : Array Name :=
+  if let some info := getStructureInfo? env structName then
+    info.fieldNames
+  else
+    #[]
+
+/--
+Builds all the projections of an expression,
+returning an array of pairs consisting of the projection name
+and the projection applied to the original expression.
+-/
+def allProjs (e : Expr) : MetaM (Array (Name × Expr)) := do
+  let (c, _) := (← inferType e).getAppFnArgs
+  let env ← getEnv
+  unless isStructure env c do
+    return #[]
+  (getStructureFields! env c).filterMapM fun f =>
+    (getProjFnForField? env c f).mapM fun p => return (f, ← mkAppM p #[e])
+
+/--
+Add to the local context all projections of an expression,
+naming them all with a prefix `h` followed by the projection name.
+-/
+def letAllProjs (e : Expr) (h : Name) (g : MVarId) : MetaM (MVarId × Array FVarId) := g.withContext do
+  let mut r := #[]
+  let mut g := g
+  for ⟨n, p⟩ in ← allProjs e do
+    let n' := match h with | .str a b => .str a (b ++ "_" ++ n.toString) | _ => h
+    let ⟨h', g'⟩ ← g.«let» n' p
+    g := g'
+    r := r.push h'
+  return (g, r)
+
+/--
+Add to the local context all projections of a local variable,
+and then all projections of these results, and so on.
+
+(If `e` is not of the form `.fvar h`, does nothing.)
+-/
+partial def letAllProjsRec (e : Expr) (g : MVarId) : MetaM MVarId := g.withContext do
+  if let .fvar h := e then
+    let (g', new) ← letAllProjs e (← h.getDecl).userName g
+    new.foldlM (init := g') fun g h => letAllProjsRec (.fvar h) g
+  else
+    pure g
+
+open Elab Tactic
+
+/--
+`let_projs` adds let bindings for all projections of the specified hypotheses.
+-/
+def let_projs (hs : Array FVarId) : TacticM Unit := do
+  for e in hs.map .fvar do
+    liftMetaTactic (fun g => return [← letAllProjsRec e g])
+
+/--
+`let_projs` adds let bindings for all projections of local hypotheses, recursively.
+
+For example in
+```
+example (x : Nat × Nat × Nat) : True := by
+  let_projs
+  trivial
+```
+we have
+```
+x_fst: ℕ := x.1
+x_snd: ℕ × ℕ := x.2
+x_snd_fst: ℕ := x_snd.1
+x_snd_snd: ℕ := x_snd.2
+```
+
+`let_projs h₁ h₂` only adds let bindings for projections of the specified hypotheses.
+-/
+syntax (name := let_projs_syntax) "let_projs" (ppSpace colGt ident)* : tactic
+
+@[inherit_doc let_projs_syntax]
+elab_rules : tactic | `(tactic| let_projs $hs:ident*) => do
+  let hs ← getFVarIds hs
+  let hs := if hs.isEmpty then (← getLocalHyps).map Expr.fvarId! else hs
+  let_projs hs

--- a/Std/Tactic/LetProjs.lean
+++ b/Std/Tactic/LetProjs.lean
@@ -38,10 +38,8 @@ and the projection applied to the original expression.
 def allProjs (e : Expr) : MetaM (Array (Name × Expr)) := do
   let (c, _) := (← inferType e).getAppFnArgs
   let env ← getEnv
-  unless isStructure env c do
-    return #[]
-  (getStructureFields! env c).filterMapM fun f =>
-    (getProjFnForField? env c f).mapM fun p => return (f, ← mkAppM p #[e])
+  unless isStructure env c do return #[]
+  (getStructureFields! env c).filterMapM fun f => return (f, ← mkProjection e f)
 
 /--
 Add to the local context all projections of an expression,

--- a/test/let_projs.lean
+++ b/test/let_projs.lean
@@ -20,3 +20,11 @@ example (s : S) (x : Nat × Nat) : Nat := by
 example (s : S) (x : Nat × Nat) : Nat := by
   let_projs
   exact s_z_den + x_snd
+
+class Foo
+class Bar extends Foo
+
+example [Bar] : True := by
+  let_projs
+  have : Foo := ‹_›
+  trivial

--- a/test/let_projs.lean
+++ b/test/let_projs.lean
@@ -1,0 +1,22 @@
+import Std.Tactic.LetProjs
+import Std.Data.Rat.Basic
+
+structure R where
+  x : Nat
+  y : Int
+
+structure S extends R where
+  z : Rat
+
+example (x : Nat × Nat × Nat) : True := by
+  let_projs
+  trivial
+
+example (s : S) (x : Nat × Nat) : Nat := by
+  let_projs x
+  clear s -- check that we didn't create let bindings mentioning `s`
+  exact x_fst
+
+example (s : S) (x : Nat × Nat) : Nat := by
+  let_projs
+  exact s_z_den + x_snd


### PR DESCRIPTION
`let_projs` adds let bindings for all projections of local hypotheses, recursively.

It's probably rarely useful interactively, but may be useful as a preprocessing step for tactics such as `solve_by_elim`.