### PR TITLE
feat: solve_by_elim uses intros and constructor by default

### DIFF
--- a/Std/Tactic/SolveByElim.lean
+++ b/Std/Tactic/SolveByElim.lean
@@ -112,6 +112,10 @@ structure Config extends ApplyRulesConfig where
   /-- Enable backtracking search. -/
   backtracking : Bool := true
   maxDepth := 6
+  /-- Trying calling `intro` if no lemmas apply. -/
+  intro : Bool := true
+  /-- Try calling `constructor` if no lemmas apply. -/
+  constructor : Bool := true
 
 instance : Coe Config BacktrackConfig := ⟨(·.toApplyRulesConfig.toBacktrackConfig)⟩
 
@@ -178,6 +182,10 @@ def withDischarge (cfg : Config := {}) (discharge : MVarId → MetaM (Option (Li
 def introsAfter (cfg : Config := {}) : Config :=
   cfg.withDischarge fun g => do pure [(← g.intro1P).2]
 
+/-- Call `constructor` when no lemmas apply. -/
+def constructorAfter (cfg : Config := {}) : Config :=
+  cfg.withDischarge fun g => g.constructor {newGoals := .all}
+
 /-- Create or modify a `Config` which
 calls `synthInstance` on any goal for which no lemma applies. -/
 def synthInstanceAfter (cfg : Config := {}) : Config :=
@@ -212,6 +220,14 @@ def requireUsingAll (cfg : Config := {}) (use : List Expr) : Config :=
   cfg.testSolutions fun sols => do
     pure <| use.all fun e => sols.any fun s => e.occurs s
 
+/--
+Process the `intro` and `constructor` options by implementing the `discharger` tactic.
+-/
+def processOptions (cfg : Config) : Config :=
+  let cfg := if cfg.intro then introsAfter { cfg with intro := false } else cfg
+  let cfg := if cfg.constructor then constructorAfter { cfg with constructor := false } else cfg
+  cfg
+
 end Config
 
 /--
@@ -225,18 +241,12 @@ def elabContextLemmas (g : MVarId) (lemmas : List (TermElabM Expr)) (ctx : TermE
 /-- Returns the list of tactics corresponding to applying the available lemmas to the goal. -/
 def applyLemmas (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))
     (g : MVarId) : Nondet MetaM (List MVarId) := Nondet.squash fun _ => do
-  -- We handle `cfg.symm` by saturating hypotheses of all goals using `symm`.
-  -- This has better performance that the mathlib3 approach.
-  let g ← if cfg.symm then g.symmSaturate else pure g
   let es ← elabContextLemmas g lemmas ctx
   return applyTactics cfg.toApplyConfig cfg.transparency es g
 
 /-- Applies the first possible lemma to the goal. -/
 def applyFirstLemma (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))
     (g : MVarId) : MetaM (List MVarId) := do
--- We handle `cfg.symm` by saturating hypotheses of all goals using `symm`.
--- This has better performance that the mathlib3 approach.
-let g ← if cfg.symm then g.symmSaturate else pure g
 let es ← elabContextLemmas g lemmas ctx
 applyFirst cfg.toApplyConfig cfg.transparency es g
 
@@ -258,8 +268,15 @@ Custom wrappers (e.g. `apply_assumption` and `apply_rules`) may modify this beha
 -/
 def solveByElim (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))
     (goals : List MVarId) : MetaM (List MVarId) := do
+  let cfg := cfg.processOptions
+  -- We handle `cfg.symm` by saturating hypotheses of all goals using `symm`.
+  -- This has better performance that the mathlib3 approach.
+  let symmGoals ← if cfg.symm then
+    goals.mapM fun g => g.symmSaturate
+  else
+    pure goals
   try
-    run goals
+    run cfg symmGoals
   catch e => do
     -- Implementation note: as with `cfg.symm`, this is different from the mathlib3 approach,
     -- for (not as severe) performance reasons.
@@ -267,11 +284,11 @@ def solveByElim (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM
     | [g], true =>
       withTraceNode `Meta.Tactic.solveByElim
           (fun _ => return m!"⏮️ starting over using `exfalso`") do
-        run [← g.exfalso]
+        run cfg [← g.exfalso]
     | _, _ => throw e
 where
   /-- Run either backtracking search, or repeated application, on the list of goals. -/
-  run : List MVarId → MetaM (List MVarId) :=
+  run (cfg : Config) : List MVarId → MetaM (List MVarId) :=
     if cfg.backtracking then
       backtrack cfg `Meta.Tactic.solveByElim (applyLemmas cfg lemmas ctx)
     else

--- a/test/solve_by_elim.lean
+++ b/test/solve_by_elim.lean
@@ -41,6 +41,7 @@ example {α β γ : Type} (_f : α → β) (g : β → γ) (b : β) : γ := by s
 example {α : Nat → Type} (f : (n : Nat) → α n → α (n+1)) (a : α 0) : α 4 := by
   solve_by_elim only [f, a]
 
+set_option linter.unusedVariables false in
 example (h₁ h₂ : False) : True := by
   -- 'It doesn't make sense to remove local hypotheses when using `only` without `*`.'
   fail_if_success solve_by_elim only [-h₁]
@@ -54,7 +55,7 @@ example (P₁ P₂ : α → Prop) (f : ∀ (a : α), P₁ a → P₂ a → β)
   solve_by_elim
 
 example {X : Type} (x : X) : x = x := by
-  fail_if_success solve_by_elim only -- needs the `rfl` lemma
+  fail_if_success solve_by_elim (config := {constructor := false}) only -- needs the `rfl` lemma
   solve_by_elim
 
 -- Needs to apply `rfl` twice, with different implicit arguments each time.
@@ -62,7 +63,7 @@ example {X : Type} (x : X) : x = x := by
 example {X : Type} (x y : X) (p : Prop) (h : x = x → y = y → p) : p := by solve_by_elim
 
 example : True := by
-  fail_if_success solve_by_elim only -- needs the `trivial` lemma
+  fail_if_success solve_by_elim (config := {constructor := false}) only -- needs the `trivial` lemma
   solve_by_elim
 
 -- Requires backtracking.
@@ -130,8 +131,8 @@ example : 6 = 6 ∧ [7] = [7] := by
 
 -- Test that `Config.intros` causes `solve_by_elim` to call `intro` on intermediate goals.
 example (P : Prop) : P → P := by
-  fail_if_success solve_by_elim
-  solve_by_elim (config := .intros)
+  fail_if_success solve_by_elim (config := {intros := false})
+  solve_by_elim
 
 -- This worked in mathlib3 without the `@`, but now goes into a loop.
 -- If someone wants to diagnose this, please do!
@@ -183,3 +184,8 @@ example : 5 ≤ 7 := by
   exact mySorry
 
 end issue1581
+
+example (x : (α × (β × γ))) : (α × β) × γ := by
+  rcases x with ⟨a, b, c⟩
+  fail_if_success solve_by_elim (config := {constructor := false})
+  solve_by_elim


### PR DESCRIPTION
Defines a discharger for `solve_by_elim` which uses `constructor`, and enables it, and the `intro` discharger, by default.

Combined with #549 this will allow `solve_by_elim` to solve
```
example (x : (α × (β × γ))) : (α × β) × γ := by solve_by_elim
```