### PR TITLE
feat: better support for 'std_apply? using'

### DIFF
--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -222,3 +222,12 @@ theorem Bool_eq_iff2 {A B : Bool} : (A = B) = (A ↔ B) := by
 --   first
 --   | exact? says exact le_antisymm hxy hyx
 --   | exact? says exact ge_antisymm hyx hxy
+
+/--
+info: Try this: refine Int.mul_ne_zero ?a0 h
+---
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example {x : Int} (h : x ≠ 0) : 2 * x ≠ 0 := by
+  std_apply? using h


### PR DESCRIPTION
Michael Stoll asked on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/exact.3F.20.2F.20apply.3F.20.2F.20rw.3F.20.2F.20.2E.2E.2E.20.20feature.20requests/near/416994860) why
```
example {x : Int} (h : x ≠ 0) : 2 * x ≠ 0 := by std_apply? using h
```
returned nothing, even though
```
example {x : Int} (h : x ≠ 0) : 2 * x ≠ 0 := by std_apply? using h says refine Int.mul_ne_zero ?a0 h
```
This PR fixes this. (And took me way too long to come up with...)