### PR TITLE
feat: adaptations for leanprover/lean4#3159

### DIFF
--- a/Std/CodeAction/Basic.lean
+++ b/Std/CodeAction/Basic.lean
@@ -147,7 +147,7 @@ partial def findInfoTree? (kind : SyntaxNodeKind) (tgtRange : String.Range)
   (f : ContextInfo → Info → Bool) (canonicalOnly := false) :
     Option (ContextInfo × InfoTree) :=
   match t with
-  | .context ctx t => findInfoTree? kind tgtRange ctx t f canonicalOnly
+  | .context ctx t => findInfoTree? kind tgtRange (ctx.mergeIntoOuter? ctx?) t f canonicalOnly
   | node@(.node i ts) => do
     if let some ctx := ctx? then
       if let some range := i.stx.getRange? canonicalOnly then

--- a/Std/Lean/InfoTree.lean
+++ b/Std/Lean/InfoTree.lean
@@ -14,7 +14,7 @@ partial def InfoTree.foldInfo' (init : α) (f : ContextInfo → InfoTree → α 
 where
   /-- `foldInfo'.go` is like `foldInfo'` but with an additional outer context parameter `ctx?`. -/
   go ctx? a
-  | context ctx t => go ctx a t
+  | context ctx t => go (ctx.mergeIntoOuter? ctx?) a t
   | t@(node i ts) =>
     let a := match ctx? with
       | none => a

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-01-16
+leanprover/lean4:nightly-2024-01-23


### PR DESCRIPTION
Adaptations for leanprover/lean4#3159, written by @mhuisi. These changes have already landed in `nightly-testing`: this is a PR to `bump/v4.6.0`.