### PR TITLE
feat: lemmas for BitVec

### DIFF
--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -334,7 +334,13 @@ As a numeric operation, this is equivalent to `a / 2^s`, rounding down.
 
 SMT-Lib name: `bvlshr` except this operator uses a `Nat` shift value.
 -/
-def ushiftRight (a : BitVec n) (s : Nat) : BitVec n := .ofNat n (a.toNat >>> s)
+def ushiftRight (a : BitVec n) (s : Nat) : BitVec n :=
+  ⟨a.toNat >>> s, by
+  let ⟨a, lt⟩ := a
+  simp only [BitVec.toNat, Nat.shiftRight_eq_div_pow, Nat.div_lt_iff_lt_mul (Nat.pow_two_pos s)]
+  rw [←Nat.mul_one a]
+  exact Nat.mul_lt_mul_of_lt_of_le' lt (Nat.pow_two_pos s) (Nat.le_refl 1)⟩
+
 instance : HShiftRight (BitVec w) Nat (BitVec w) := ⟨.ushiftRight⟩
 
 /--

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -6,32 +6,6 @@ import Std.Data.Nat.Lemmas
 import Std.Tactic.Ext
 import Std.Tactic.Simpa
 import Std.Tactic.Omega
-import Std.Tactic.PrintPrefix
-
-namespace Fin
-
-@[simp] theorem ofNat'_add (x : Nat) (lt : 0 < n) (y : Fin n) :
-    Fin.ofNat' x lt + y = Fin.ofNat' (x + y.val) lt := by
-  apply Fin.eq_of_val_eq
-  simp [Fin.ofNat', HAdd.hAdd, Add.add, Fin.add]
-
-@[simp] theorem add_ofNat' (x : Fin n) (y : Nat) (lt : 0 < n) :
-    x + Fin.ofNat' y lt = Fin.ofNat' (x.val + y) lt := by
-  apply Fin.eq_of_val_eq
-  simp [Fin.ofNat', HAdd.hAdd, Add.add, Fin.add]
-
-@[simp] theorem ofNat'_sub (x : Nat) (lt : 0 < n) (y : Fin n) :
-    Fin.ofNat' x lt - y = Fin.ofNat' (x + (n - y.val)) lt := by
-  apply Fin.eq_of_val_eq
-  simp [Fin.ofNat', HSub.hSub, Sub.sub, Fin.sub]
-
-@[simp] theorem sub_ofNat' (x : Fin n) (y : Nat) (lt : 0 < n) :
-    x - Fin.ofNat' y lt = Fin.ofNat' (x.val + (n - y % n)) lt := by
-  apply Fin.eq_of_val_eq
-  simp [Fin.ofNat', HSub.hSub, Sub.sub, Fin.sub]
-
-end Fin
-
 
 namespace Std.BitVec
 

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -13,7 +13,7 @@ namespace Std.BitVec
 theorem eq_of_toNat_eq {n} : ∀ {i j : BitVec n}, i.toNat = j.toNat → i = j
   | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
 
-@[simp] theorem zero_is_unique (x : BitVec 0) : x = 0#0 := by
+theorem zero_is_unique (x : BitVec 0) : x = 0#0 := by
   let ⟨i, lt⟩ := x
   have p : i < 1 := lt
   have q : i = 0 := by omega
@@ -81,7 +81,7 @@ theorem eq_of_getMsb_eq {x y : BitVec w}
 @[simp] theorem toNat_ofNat (x w : Nat) : (BitVec.ofNat w x).toNat = x % 2^w := by
   simp [BitVec.toNat, BitVec.ofNat, Fin.ofNat']
 
-@[simp] theorem toNat_zero (n : Nat) : (0#n).toNat = 0 := by trivial
+@[deprecated toNat_ofNat] theorem toNat_zero (n : Nat) : (0#n).toNat = 0 := by trivial
 
 @[simp] theorem toNat_mod_cancel (x : BitVec n) : x.toNat % (2^n) = x.toNat :=
   Nat.mod_eq_of_lt x.isLt
@@ -164,7 +164,7 @@ protected theorem extractLsb_ofNat (x n : Nat) (hi lo : Nat) :
   intro ⟨i, _lt⟩
   simp [BitVec.ofNat]
 
-@[simp] theorem extractLsb'_toNat (hi lo : Nat) (x : BitVec n) :
+@[simp] theorem extractLsb'_toNat (s m : Nat) (x : BitVec n) :
   (extractLsb' s m x).toNat = (x.toNat >>> s) % 2^m := rfl
 
 @[simp] theorem extractLsb_toNat (hi lo : Nat) (x : BitVec n) :
@@ -286,9 +286,9 @@ theorem add_toNat {n} (x y : BitVec n) : (x + y).toNat = (x.toNat + y.toNat) % 2
 
 @[simp] theorem ofFin_add (x : Fin (2^n)) (y : BitVec n) : .ofFin x + y = .ofNat n (x.val + y.toNat) := by rfl
 @[simp] theorem add_ofFin (x : BitVec n) (y : Fin (2^n)) : x + .ofFin y = .ofNat n (x.toNat + y.val) := by rfl
-@[simp] theorem ofNat_add {n} (x : Nat) (y : BitVec n) : .ofNat n x + y = .ofNat n (x + y.toNat) := by
+theorem ofNat_add {n} (x : Nat) (y : BitVec n) : .ofNat n x + y = .ofNat n (x + y.toNat) := by
   apply eq_of_toNat_eq ; simp [BitVec.ofNat]
-@[simp] theorem add_ofNat {n} (x : BitVec n) (y : Nat) : x + .ofNat n y = .ofNat n (x.toNat + y) := by
+theorem add_ofNat {n} (x : BitVec n) (y : Nat) : x + .ofNat n y = .ofNat n (x.toNat + y) := by
   apply eq_of_toNat_eq ; simp [BitVec.ofNat]
 
 protected theorem add_assoc (x y z : BitVec n) : x + y + z = x + (y + z) := by
@@ -312,9 +312,10 @@ protected theorem add_comm (x y : BitVec n) : x + y = y + x := by
 
 @[simp] theorem ofFin_sub (x : Fin (2^n)) (y : BitVec n) : .ofFin x - y = .ofNat n (x.val + (2^n - y.toNat)) := rfl
 @[simp] theorem sub_ofFin (x : BitVec n) (y : Fin (2^n)) : x - .ofFin y = .ofNat n (x.toNat + (2^n - y.val)) := by rfl
-@[simp] theorem ofNat_sub {n} (x : Nat) (y : BitVec n) : .ofNat n x - y = .ofNat n (x + (2^n - y.toNat)) := by
+
+theorem ofNat_sub {n} (x : Nat) (y : BitVec n) : .ofNat n x - y = .ofNat n (x + (2^n - y.toNat)) := by
   apply eq_of_toNat_eq ; simp [BitVec.ofNat]
-@[simp] theorem sub_ofNat {n} (x : BitVec n) (y : Nat) : x - .ofNat n y = .ofNat n (x.toNat + (2^n - y % 2^n)) := by
+theorem sub_ofNat {n} (x : BitVec n) (y : Nat) : x - .ofNat n y = .ofNat n (x.toNat + (2^n - y % 2^n)) := by
   apply eq_of_toNat_eq ; simp [BitVec.ofNat]
 
 @[simp] protected theorem sub_zero (x : BitVec n) : x - (0#n) = x := by apply eq_of_toNat_eq ; simp
@@ -356,10 +357,6 @@ theorem sub_toAdd {n} (x y : BitVec n) : x - y = x + - y := by
   x < BitVec.ofNat n y ↔ x.toNat < y % 2^n := Iff.rfl
 @[simp] theorem ofNat_lt (x : Nat) (y : BitVec n) :
   BitVec.ofNat n x < y ↔ x % 2^n < y.toNat := Iff.rfl
-
-@[simp] protected theorem zero_le (x : BitVec n) : 0#n <= x := by
-  let ⟨x, lt⟩ := x
-  simp
 
 protected theorem lt_of_le_ne (x y : BitVec n) (h1 : x <= y) (h2 : ¬ x = y) : x < y := by
   revert h1 h2

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -56,6 +56,9 @@ theorem eq_mk_iff_val_eq {a : Fin n} {k : Nat} {hk : k < n} :
 
 theorem mk_val (i : Fin n) : (⟨i, i.isLt⟩ : Fin n) = i := Fin.eta ..
 
+@[simp] theorem val_ofNat' (a : Nat) (is_pos : n > 0) :
+  (Fin.ofNat' a is_pos).val = a % n := rfl
+
 @[simp] theorem ofNat'_zero_val : (Fin.ofNat' 0 h).val = 0 := Nat.zero_mod _
 
 @[simp] theorem mod_val (a b : Fin n) : (a % b).val = a.val % b.val :=
@@ -80,6 +83,8 @@ theorem dite_val {n : Nat} {c : Prop} [Decidable c] {x y : Fin n} :
 theorem le_def {a b : Fin n} : a ≤ b ↔ a.1 ≤ b.1 := .rfl
 
 theorem lt_def {a b : Fin n} : a < b ↔ a.1 < b.1 := .rfl
+
+theorem lt_iff_val_lt_val {a b : Fin n} : a < b ↔ a.val < b.val := Iff.rfl
 
 @[simp] protected theorem not_le {a b : Fin n} : ¬ a ≤ b ↔ b < a := Nat.not_le
 

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -728,6 +728,30 @@ theorem addCases_right {m n : Nat} {motive : Fin (m + n) → Sort _} {left right
 
 @[simp] theorem coe_clamp (n m : Nat) : (clamp n m : Nat) = min n m := rfl
 
+/-! ### add -/
+
+@[simp] theorem ofNat'_add (x : Nat) (lt : 0 < n) (y : Fin n) :
+    Fin.ofNat' x lt + y = Fin.ofNat' (x + y.val) lt := by
+  apply Fin.eq_of_val_eq
+  simp [Fin.ofNat', HAdd.hAdd, Add.add, Fin.add]
+
+@[simp] theorem add_ofNat' (x : Fin n) (y : Nat) (lt : 0 < n) :
+    x + Fin.ofNat' y lt = Fin.ofNat' (x.val + y) lt := by
+  apply Fin.eq_of_val_eq
+  simp [Fin.ofNat', HAdd.hAdd, Add.add, Fin.add]
+
+/-! ### sub -/
+
+@[simp] theorem ofNat'_sub (x : Nat) (lt : 0 < n) (y : Fin n) :
+    Fin.ofNat' x lt - y = Fin.ofNat' (x + (n - y.val)) lt := by
+  apply Fin.eq_of_val_eq
+  simp [Fin.ofNat', HSub.hSub, Sub.sub, Fin.sub]
+
+@[simp] theorem sub_ofNat' (x : Fin n) (y : Nat) (lt : 0 < n) :
+    x - Fin.ofNat' y lt = Fin.ofNat' (x.val + (n - y % n)) lt := by
+  apply Fin.eq_of_val_eq
+  simp [Fin.ofNat', HSub.hSub, Sub.sub, Fin.sub]
+
 /-! ### mul -/
 
 theorem val_mul {n : Nat} : ∀ a b : Fin n, (a * b).val = a.val * b.val % n

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -59,7 +59,7 @@ theorem mk_val (i : Fin n) : (⟨i, i.isLt⟩ : Fin n) = i := Fin.eta ..
 @[simp] theorem val_ofNat' (a : Nat) (is_pos : n > 0) :
   (Fin.ofNat' a is_pos).val = a % n := rfl
 
-@[simp] theorem ofNat'_zero_val : (Fin.ofNat' 0 h).val = 0 := Nat.zero_mod _
+@[deprecated ofNat'_zero_val] theorem ofNat'_zero_val : (Fin.ofNat' 0 h).val = 0 := Nat.zero_mod _
 
 @[simp] theorem mod_val (a b : Fin n) : (a % b).val = a.val % b.val :=
   rfl

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -365,7 +365,7 @@ theorem bitwise_lt_two_pow (left : x < 2^n) (right : y < 2^n) : (Nat.bitwise f x
 
 /-! ### and -/
 
-theorem testBit_and (x y i : Nat) : (x &&& y).testBit i = (x.testBit i && y.testBit i) := by
+@[simp] theorem testBit_and (x y i : Nat) : (x &&& y).testBit i = (x.testBit i && y.testBit i) := by
   simp [HAnd.hAnd, AndOp.and, land, testBit_bitwise ]
 
 theorem and_lt_two_pow (x : Nat) {y n : Nat} (right : y < 2^n) : (x &&& y) < 2^n := by
@@ -407,7 +407,7 @@ theorem or_lt_two_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ||| y
 
 /-! ### xor -/
 
-theorem testBit_xor (x y i : Nat) : (x ^^^ y).testBit i = Bool.xor (x.testBit i) (y.testBit i) := by
+@[simp] theorem testBit_xor (x y i : Nat) : (x ^^^ y).testBit i = Bool.xor (x.testBit i) (y.testBit i) := by
   simp [HXor.hXor, Xor.xor, xor, testBit_bitwise ]
 
 theorem xor_lt_two_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ^^^ y < 2^n :=

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -231,7 +231,7 @@ theorem testBit_two_pow_add_gt {i j : Nat} (j_lt_i : j < i) (x : Nat) :
   | d+1 =>
     simp [pow_succ, Nat.mul_comm _ 2,  Nat.mul_add_mod]
 
-theorem testBit_mod_two_pow (x j i : Nat) :
+@[simp] theorem testBit_mod_two_pow (x j i : Nat) :
     testBit (x % 2^j) i = (decide (i < j) && testBit x i) := by
   induction x using Nat.strongInductionOn generalizing j i with
   | ind x hyp =>
@@ -399,7 +399,7 @@ theorem and_pow_two_identity {x : Nat} (lt : x < 2^n) : x &&& 2^n-1 = x := by
   unfold bitwise
   simp [@eq_comm _ 0]
 
-theorem testBit_or (x y i : Nat) : (x ||| y).testBit i = (x.testBit i || y.testBit i) := by
+@[simp] theorem testBit_or (x y i : Nat) : (x ||| y).testBit i = (x.testBit i || y.testBit i) := by
   simp [HOr.hOr, OrOp.or, lor, testBit_bitwise ]
 
 theorem or_lt_two_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ||| y < 2^n :=
@@ -471,9 +471,9 @@ theorem mul_add_lt_is_or {b : Nat} (b_lt : b < 2^i) (a : Nat) : 2^i * a + b = 2^
 
 /-! ### shiftLeft and shiftRight -/
 
-theorem testBit_shiftLeft (x : Nat) : testBit (x <<< i) j =
+@[simp] theorem testBit_shiftLeft (x : Nat) : testBit (x <<< i) j =
     (decide (j ≥ i) && testBit x (j-i)) := by
   simp [shiftLeft_eq, Nat.mul_comm _ (2^_), testBit_mul_pow_two]
 
-theorem testBit_shiftRight (x : Nat) : testBit (x >>> i) j = testBit x (i+j) := by
+@[simp] theorem testBit_shiftRight (x : Nat) : testBit (x >>> i) j = testBit x (i+j) := by
   simp [testBit, ←shiftRight_add]

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -407,7 +407,8 @@ theorem or_lt_two_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ||| y
 
 /-! ### xor -/
 
-@[simp] theorem testBit_xor (x y i : Nat) : (x ^^^ y).testBit i = Bool.xor (x.testBit i) (y.testBit i) := by
+@[simp] theorem testBit_xor (x y i : Nat) :
+    (x ^^^ y).testBit i = Bool.xor (x.testBit i) (y.testBit i) := by
   simp [HXor.hXor, Xor.xor, xor, testBit_bitwise ]
 
 theorem xor_lt_two_pow {x y n : Nat} (left : x < 2^n) (right : y < 2^n) : x ^^^ y < 2^n :=


### PR DESCRIPTION
A user was having trouble with:

```
import Std

open Std BitVec

example (v : Std.BitVec n)  : 0#0 ++ v = BitVec.cast (by omega) v := sorry
```

With these changes:
* add `@[ext]` to `BitVec.eq_of_getLsb_eq`
* add `@[simp]` to a few existing lemmas
* prove additional theorems about `getLsb` applied to other operations

the proof becomes 
```
example (v : Std.BitVec n)  : 0#0 ++ v = BitVec.cast (by omega) v := by ext; simp
```