### PR TITLE
chore: remove spurious bool lemmas; add dual lemmas for List.any/all

### DIFF
--- a/Std/Data/Array/Lemmas.lean
+++ b/Std/Data/Array/Lemmas.lean
@@ -698,8 +698,8 @@ theorem all_iff_forall (p : α → Bool) (as : Array α) (start stop) :
   have := SatisfiesM_anyM_iff_exists (m := Id) (fun a => ! p a) as start stop (! p as[·]) (by simp)
   rw [SatisfiesM_Id_eq] at this
   dsimp [all, allM, Id.run]
-  rw [Bool.not_eq_true', Bool.eq_false_iff, Ne]
-  simp [this]
+  rw [Bool.not_eq_true', (Bool.not_eq_true _).symm, this]
+  simp
 
 theorem all_eq_true (p : α → Bool) (as : Array α) : all as p ↔ ∀ i : Fin as.size, p as[i] := by
   simp [all_iff_forall, Fin.isLt]

--- a/Std/Data/Bool.lean
+++ b/Std/Data/Bool.lean
@@ -42,9 +42,13 @@ theorem false_ne_true : false ≠ true := Bool.noConfusion
 
 theorem eq_false_or_eq_true : (b : Bool) → b = true ∨ b = false := by decide
 
-theorem eq_false_iff : {b : Bool} → b = false ↔ b ≠ true := by decide
+-- N.B. The replacement lemma is symmetric to the original so it is
+-- not a direct replacement.
+@[deprecated Bool.not_eq_true]
+theorem eq_false_iff {b : Bool} : b = false ↔ b ≠ true := Iff.of_eq (Bool.not_eq_true b).symm
 
-theorem ne_false_iff : {b : Bool} → b ≠ false ↔ b = true := by decide
+@[deprecated Bool.not_eq_false]
+theorem ne_false_iff {b : Bool} : b ≠ false ↔ b = true := Iff.of_eq (Bool.not_eq_false b)
 
 /-! ### and -/
 
@@ -72,8 +76,13 @@ theorem and_xor_distrib_right : ∀ (x y z : Bool), (xor x y && z) = xor (x && z
 /-- De Morgan's law for boolean and -/
 theorem not_and : ∀ (x y : Bool), (!(x && y)) = (!x || !y) := by decide
 
+@[deprecated and_eq_true]
 theorem and_eq_true_iff : ∀ (x y : Bool), (x && y) = true ↔ x = true ∧ y = true := by decide
 
+@[simp] theorem and_eq_false (a b : Bool) : ((a && b) = false) = (a = false ∨ b = false) := by
+  cases a <;> cases b <;> decide
+
+@[deprecated and_eq_false]
 theorem and_eq_false_iff : ∀ (x y : Bool), (x && y) = false ↔ x = false ∨ y = false := by decide
 
 /-! ### or -/
@@ -97,8 +106,13 @@ theorem or_and_distrib_right : ∀ (x y z : Bool), ((x && y) || z) = ((x || z) &
 /-- De Morgan's law for boolean or -/
 theorem not_or : ∀ (x y : Bool), (!(x || y)) = (!x && !y) := by decide
 
+@[simp] theorem or_eq_false (a b : Bool) : ((a || b) = false) = (a = false ∧ b = false) := by
+  cases a <;> cases b <;> decide
+
+@[deprecated or_eq_true]
 theorem or_eq_true_iff : ∀ (x y : Bool), (x || y) = true ↔ x = true ∨ y = true := by decide
 
+@[deprecated or_eq_false]
 theorem or_eq_false_iff : ∀ (x y : Bool), (x || y) = false ↔ x = false ∧ y = false := by decide
 
 /-! ### xor -/

--- a/Std/Data/Bool.lean
+++ b/Std/Data/Bool.lean
@@ -79,8 +79,7 @@ theorem not_and : ∀ (x y : Bool), (!(x && y)) = (!x || !y) := by decide
 @[deprecated and_eq_true]
 theorem and_eq_true_iff : ∀ (x y : Bool), (x && y) = true ↔ x = true ∧ y = true := by decide
 
-@[simp] theorem and_eq_false (a b : Bool) : ((a && b) = false) = (a = false ∨ b = false) := by
-  cases a <;> cases b <;> decide
+@[simp] theorem and_eq_false : ∀ (x y : Bool) : ((x && y) = false) = (x = false ∨ y = false) := by decide
 
 @[deprecated and_eq_false]
 theorem and_eq_false_iff : ∀ (x y : Bool), (x && y) = false ↔ x = false ∨ y = false := by decide

--- a/Std/Data/Bool.lean
+++ b/Std/Data/Bool.lean
@@ -105,8 +105,7 @@ theorem or_and_distrib_right : ∀ (x y z : Bool), ((x && y) || z) = ((x || z) &
 /-- De Morgan's law for boolean or -/
 theorem not_or : ∀ (x y : Bool), (!(x || y)) = (!x && !y) := by decide
 
-@[simp] theorem or_eq_false (a b : Bool) : ((a || b) = false) = (a = false ∧ b = false) := by
-  cases a <;> cases b <;> decide
+@[simp] theorem or_eq_false : ∀ (x y : Bool). ((x || y) = false) = (x = false ∧ y = false) := by decide
 
 @[deprecated or_eq_true]
 theorem or_eq_true_iff : ∀ (x y : Bool), (x || y) = true ↔ x = true ∨ y = true := by decide

--- a/Std/Data/HashMap/WF.lean
+++ b/Std/Data/HashMap/WF.lean
@@ -231,7 +231,7 @@ theorem insert_WF [BEq α] [Hashable α] {m : Imp α β} {k v}
       | .inl rfl => rfl
       | .inr h => exact H _ h
   · next h₁ =>
-    rw [Bool.eq_false_iff] at h₁; simp at h₁
+    rw [(Bool.not_eq_true _).symm] at h₁; simp at h₁
     suffices _ by split <;> [exact this; refine expand_WF this]
     refine h.update (.cons ?_) (fun H a h => ?_)
     · exact fun a h h' => h₁ a h (PartialEquivBEq.symm h')

--- a/Std/Data/List/Init/Lemmas.lean
+++ b/Std/Data/List/Init/Lemmas.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Mario Carneiro
 -/
 import Std.Classes.SetNotation
+import Std.Data.Bool
 import Std.Logic
 
 namespace List
@@ -380,9 +381,19 @@ theorem lookup_cons [BEq α] {k : α} :
 
 /-! ### all / any -/
 
-@[simp] theorem all_eq_true {l : List α} : l.all p ↔ ∀ x ∈ l, p x := by induction l <;> simp [*]
+@[simp] theorem all_eq_true (l : List α) (p : α → Bool) : l.all p ↔ ∀ x ∈ l, p x := by
+  induction l <;> simp [*]
 
-@[simp] theorem any_eq_true {l : List α} : l.any p ↔ ∃ x ∈ l, p x := by induction l <;> simp [*]
+@[simp] theorem all_eq_false (l : List α) (p : α → Bool) :
+    l.all p = false ↔ ∃ x ∈ l, p x = false := by
+  induction l <;> simp [*]
+
+@[simp] theorem any_eq_true (l : List α) (p : α → Bool) : l.any p ↔ ∃ x ∈ l, p x := by
+  induction l <;> simp [*]
+
+@[simp] theorem any_eq_false (l : List α) (p : α → Bool) :
+    l.any p = false ↔ ∀ x ∈ l, p x = false := by
+  induction l <;> simp [*]
 
 /-! ### enumFrom -/
 

--- a/Std/Data/Nat/Bitwise.lean
+++ b/Std/Data/Nat/Bitwise.lean
@@ -108,11 +108,10 @@ theorem ne_implies_bit_diff {x y : Nat} (p : x ≠ y) : ∃ i, testBit x i ≠ t
   | ind y hyp =>
     cases Nat.eq_zero_or_pos y with
     | inl yz =>
-      simp only [yz, Nat.zero_testBit, Bool.eq_false_iff]
       simp only [yz] at p
       have ⟨i,ip⟩  := ne_zero_implies_bit_true p
       apply Exists.intro i
-      simp [ip]
+      simp [yz, Nat.zero_testBit, ip]
     | inr ypos =>
       if lsb_diff : x % 2 = y % 2 then
         rw [←Nat.div_add_mod x 2, ←Nat.div_add_mod y 2] at p


### PR DESCRIPTION
This adds a few lemmas to better simplify `t = false` expressions and removes a couple lemmas almost immediately following core lemmas.
