### PR TITLE
chore: bump to v4.5.0

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.5.0-rc1
+leanprover/lean4:v4.5.0


### PR DESCRIPTION
This is a noop as `v4.5.0` is identical to `v4.5.0-rc1`.