### PR TITLE
feat: omega handles min, max, if

### DIFF
--- a/Std/Tactic/Omega/Config.lean
+++ b/Std/Tactic/Omega/Config.lean
@@ -32,6 +32,11 @@ structure OmegaConfig where
   `0 ≤ a ∧ Int.natAbs a = a ∨ a < 0 ∧ Int.natAbs a = - a` for later splitting.
   -/
   splitNatAbs : Bool := true
+  /--
+  Whenever `min a b` or `max a b` is found, rewrite in terms of the definition
+  `if a ≤ b ...`, for later case splitting.
+  -/
+  splitMinMax : Bool := true
 
 /--
 Allow elaboration of `OmegaConfig` arguments to tactics.

--- a/Std/Tactic/Omega/Frontend.lean
+++ b/Std/Tactic/Omega/Frontend.lean
@@ -188,8 +188,16 @@ partial def asLinearComboImpl (e : Expr) : OmegaM (LinearCombo × OmegaM Expr ×
       else
         mkAtomLinearCombo e
     | _ => mkAtomLinearCombo e
-  | (``Min.min, #[_, _, a, b]) => rewrite e (mkApp2 (.const ``Int.min_def []) a b)
-  | (``Max.max, #[_, _, a, b]) => rewrite e (mkApp2 (.const ``Int.max_def []) a b)
+  | (``Min.min, #[_, _, a, b]) =>
+    if (← cfg).splitMinMax then
+      rewrite e (mkApp2 (.const ``Int.min_def []) a b)
+    else
+      mkAtomLinearCombo e
+  | (``Max.max, #[_, _, a, b]) =>
+    if (← cfg).splitMinMax then
+      rewrite e (mkApp2 (.const ``Int.max_def []) a b)
+    else
+      mkAtomLinearCombo e
   | (``Nat.cast, #[_, _, n]) => match n.getAppFnArgs with
     | (``Nat.succ, #[n]) => rewrite e (.app (.const ``Int.ofNat_succ []) n)
     | (``HAdd.hAdd, #[_, _, _, _, a, b]) => rewrite e (mkApp2 (.const ``Int.ofNat_add []) a b)
@@ -209,7 +217,11 @@ partial def asLinearComboImpl (e : Expr) : OmegaM (LinearCombo × OmegaM Expr ×
       | _ => mkAtomLinearCombo e
     | (``Min.min, #[_, _, a, b]) => rewrite e (mkApp2 (.const ``Int.ofNat_min []) a b)
     | (``Max.max, #[_, _, a, b]) => rewrite e (mkApp2 (.const ``Int.ofNat_max []) a b)
-    | (``Int.natAbs, #[n]) => rewrite e (mkApp (.const ``Int.ofNat_natAbs []) n)
+    | (``Int.natAbs, #[n]) =>
+      if (← cfg).splitNatAbs then
+        rewrite e (mkApp (.const ``Int.ofNat_natAbs []) n)
+      else
+        mkAtomLinearCombo e
     | _ => mkAtomLinearCombo e
   | (``Prod.fst, #[α, β, p]) => match p with
     | .app (.app (.app (.app (.const ``Prod.mk [u, v]) _) _) x) y =>
@@ -526,13 +538,15 @@ a natural subtraction appearing in a hypothesis, and try again.
 
 The options
 ```
-omega (config := { splitDisjunctions := true, splitNatSub := true, splitNatAbs := true})
+omega (config :=
+  { splitDisjunctions := true, splitNatSub := true, splitNatAbs := true, splitMinMax := true })
 ```
 can be used to:
 * `splitDisjunctions`: split any disjunctions found in the context,
   if the problem is not otherwise solvable.
 * `splitNatSub`: for each appearance of `((a - b : Nat) : Int)`, split on `a ≤ b` if necessary.
 * `splitNatAbs`: for each appearance of `Int.natAbs a`, split on `0 ≤ a` if necessary.
+* `splitMinMax`: for each occurrence of `min a b`, split on `min a b = a ∨ min a b = b`
 Currently, all of these are on by default.
 -/
 syntax (name := omegaSyntax) "omega" (config)? : tactic

--- a/Std/Tactic/Omega/Frontend.lean
+++ b/Std/Tactic/Omega/Frontend.lean
@@ -181,6 +181,8 @@ partial def asLinearComboImpl (e : Expr) : OmegaM (LinearCombo × OmegaM Expr ×
       else
         mkAtomLinearCombo e
     | _ => mkAtomLinearCombo e
+  | (``Min.min, #[_, _, a, b]) => rewrite e (mkApp2 (.const ``Int.min_def []) a b)
+  | (``Max.max, #[_, _, a, b]) => rewrite e (mkApp2 (.const ``Int.max_def []) a b)
   | (``Nat.cast, #[_, _, n]) => match n.getAppFnArgs with
     | (``Nat.succ, #[n]) => rewrite e (.app (.const ``Int.ofNat_succ []) n)
     | (``HAdd.hAdd, #[_, _, _, _, a, b]) => rewrite e (mkApp2 (.const ``Int.ofNat_add []) a b)
@@ -198,6 +200,9 @@ partial def asLinearComboImpl (e : Expr) : OmegaM (LinearCombo × OmegaM Expr ×
       | .app (.app (.app (.app (.const ``Prod.mk [u, 0]) _) _) x) y =>
         rewrite e (mkApp3 (.const ``Int.ofNat_snd_mk [u]) α x y)
       | _ => mkAtomLinearCombo e
+    | (``Min.min, #[_, _, a, b]) => rewrite e (mkApp2 (.const ``Int.ofNat_min []) a b)
+    | (``Max.max, #[_, _, a, b]) => rewrite e (mkApp2 (.const ``Int.ofNat_max []) a b)
+    | (``Int.natAbs, #[n]) => rewrite e (mkApp (.const ``Int.ofNat_natAbs []) n)
     | _ => mkAtomLinearCombo e
   | (``Prod.fst, #[α, β, p]) => match p with
     | .app (.app (.app (.app (.const ``Prod.mk [u, v]) _) _) x) y =>

--- a/Std/Tactic/Omega/Int.lean
+++ b/Std/Tactic/Omega/Int.lean
@@ -66,6 +66,21 @@ theorem ofNat_congr {a b : Nat} (h : a = b) : (a : Int) = (b : Int) := congrArg 
 theorem ofNat_sub_sub {a b c : Nat} : ((a - b - c : Nat) : Int) = ((a - (b + c) : Nat) : Int) :=
   congrArg _ (Nat.sub_sub _ _ _)
 
+theorem ofNat_min (a b : Nat) : ((min a b : Nat) : Int) = min (a : Int) (b : Int) := by
+  simp only [Nat.min_def, Int.min_def, Int.ofNat_le]
+  split <;> rfl
+
+theorem ofNat_max (a b : Nat) : ((max a b : Nat) : Int) = max (a : Int) (b : Int) := by
+  simp only [Nat.max_def, Int.max_def, Int.ofNat_le]
+  split <;> rfl
+
+theorem ofNat_natAbs (a : Int) : (a.natAbs : Int) = if 0 ≤ a then a else -a := by
+  rw [Int.natAbs]
+  split <;> rename_i n
+  · simp only [Int.ofNat_eq_coe]
+    rw [if_pos (Int.ofNat_nonneg n)]
+  · simp; rfl
+
 theorem natAbs_dichotomy {a : Int} : 0 ≤ a ∧ a.natAbs = a ∨ a < 0 ∧ a.natAbs = -a := by
   by_cases h : 0 ≤ a
   · left

--- a/Std/Tactic/Omega/Int.lean
+++ b/Std/Tactic/Omega/Int.lean
@@ -90,6 +90,9 @@ theorem natAbs_dichotomy {a : Int} : 0 ≤ a ∧ a.natAbs = a ∨ a < 0 ∧ a.na
     rw [Int.ofNat_natAbs_of_nonpos (Int.le_of_lt h)]
     simp_all
 
+theorem neg_le_natAbs {a : Int} : -a ≤ a.natAbs := by
+  simpa using Int.le_natAbs (a := -a)
+
 theorem add_le_iff_le_sub (a b c : Int) : a + b ≤ c ↔ a ≤ c - b := by
   conv =>
     lhs

--- a/Std/Tactic/Omega/OmegaM.lean
+++ b/Std/Tactic/Omega/OmegaM.lean
@@ -123,14 +123,14 @@ def analyzeAtom (e : Expr) : OmegaM (HashSet Expr) := do
   | (``Nat.cast, #[_, _, e']) =>
     -- Casts of natural numbers are non-negative.
     let mut r := {Expr.app (.const ``Int.ofNat_nonneg []) e'}
-    match (← cfg).splitNatSub, (← cfg).splitNatAbs, e'.getAppFnArgs with
-      | true, _, (``HSub.hSub, #[_, _, _, _, a, b]) =>
+    match (← cfg).splitNatSub, e'.getAppFnArgs with
+      | true, (``HSub.hSub, #[_, _, _, _, a, b]) =>
         -- `((a - b : Nat) : Int)` gives a dichotomy
         r := r.insert (mkApp2 (.const ``Int.ofNat_sub_dichotomy []) a b)
-      | _, true, (``Int.natAbs, #[x]) =>
-        -- `(a.natAbs : Int)` gives a dichotomy
-        r := r.insert (mkApp (.const ``Int.natAbs_dichotomy []) x)
-      | _, _,_ => pure ()
+      | _, (``Int.natAbs, #[x]) =>
+        r := r.insert (mkApp (.const ``Int.le_natAbs []) x)
+        r := r.insert (mkApp (.const ``Int.neg_le_natAbs []) x)
+      | _, _ => pure ()
     return r
   | (``HDiv.hDiv, #[_, _, _, _, x, k]) => match natCast? k with
     | none
@@ -143,6 +143,10 @@ def analyzeAtom (e : Expr) : OmegaM (HashSet Expr) := do
       pure <|
       {mkApp3 (.const ``Int.mul_ediv_self_le []) x k (← mkDecideProof ne_zero),
         mkApp3 (.const ``Int.lt_mul_ediv_self_add []) x k (← mkDecideProof pos)}
+  | (``Min.min, #[_, _, x, y]) =>
+    pure <| {mkApp2 (.const ``Int.min_le_left []) x y, mkApp2 (.const ``Int.min_le_right []) x y}
+  | (``Max.max, #[_, _, x, y]) =>
+    pure <| {mkApp2 (.const ``Int.le_max_left []) x y, mkApp2 (.const ``Int.le_max_right []) x y}
   | (``ite, #[α, i, dec, t, e]) =>
       if α == (.const ``Int []) then
         pure <| {mkApp5 (.const ``ite_disjunction [0]) α i dec t e}

--- a/Std/Tactic/Omega/OmegaM.lean
+++ b/Std/Tactic/Omega/OmegaM.lean
@@ -27,7 +27,8 @@ The main functions are:
     `k * a ≤ x < k * a + k`
   * for each new atom of the form `((a - b : Nat) : Int)`, the fact:
     `b ≤ a ∧ ((a - b : Nat) : Int) = a - b ∨ a < b ∧ ((a - b : Nat) : Int) = 0`
-
+  * for each new atom of the form `if P then a else b`, the disjunction:
+    `(P ∧ (if P then a else b) = a) ∨ (¬ P ∧ (if P then a else b) = b)`
 The `OmegaM` monad also keeps an internal cache of visited expressions
 (not necessarily atoms, but arbitrary subexpressions of one side of a linear relation)
 to reduce duplication.
@@ -104,6 +105,10 @@ def intCast? (n : Expr) : Option Int :=
   | (``Nat.cast, #[_, _, n]) => n.nat?
   | _ => n.int?
 
+theorem ite_disjunction {α : Type u} {P : Prop} [Decidable P] {a b : α} :
+    (P ∧ (if P then a else b) = a) ∨ (¬ P ∧ (if P then a else b) = b) := by
+  by_cases P <;> simp_all
+
 /--
 Analyzes a newly recorded atom,
 returning a collection of interesting facts about it that should be added to the context.
@@ -133,6 +138,11 @@ def analyzeAtom (e : Expr) : OmegaM (HashSet Expr) := do
       pure <|
       {mkApp3 (.const ``Int.mul_ediv_self_le []) x k (← mkDecideProof ne_zero),
         mkApp3 (.const ``Int.lt_mul_ediv_self_add []) x k (← mkDecideProof pos)}
+  | (``ite, #[α, i, dec, t, e]) =>
+      if α == (.const ``Int []) then
+        pure <| {mkApp5 (.const ``ite_disjunction [0]) α i dec t e}
+      else
+        pure {}
   | _ => pure ∅
 
 /--

--- a/test/omega/test.lean
+++ b/test/omega/test.lean
@@ -343,3 +343,11 @@ example (a : Nat) (h : a < 0) : Nat → Nat := by omega
 example {a₁ a₂ p₁ p₂ : Nat}
   (h₁ : a₁ = a₂ → ¬p₁ = p₂) :
   (a₁ < a₂ ∨ a₁ = a₂ ∧ p₁ < p₂) ∨ a₂ < a₁ ∨ a₂ = a₁ ∧ p₂ < p₁ := by omega
+
+example {a : Int} (_ : a < if a ≤ b then a else b) : False := by omega
+example {a : Int} (_ : a < min a b) : False := by omega
+example {a : Int} (_ : max a b < b) : False := by omega
+example {a : Nat} (_ : a < min a b) : False := by omega
+example {a : Nat} (_ : max a b < b) : False := by omega
+example {a : Int} : (a.natAbs : Int) ≥ -a := by omega
+example {a b : Int} : (if a < b then a else b - 1) ≤ b := by omega

--- a/test/omega/test.lean
+++ b/test/omega/test.lean
@@ -198,8 +198,12 @@ example (a b c d e : Int)
   fail_if_success omega (config := { splitDisjunctions := false })
   omega
 
-example {x y : Int} (_ : (x - y).natAbs < 3) (_ : x < 5) (_ : y > 15) : False := by
+example {x : Int} (h : x = 7) : x.natAbs = 7 := by
   fail_if_success omega (config := { splitNatAbs := false })
+  fail_if_success omega (config := { splitDisjunctions := false })
+  omega
+
+example {x y : Int} (_ : (x - y).natAbs < 3) (_ : x < 5) (_ : y > 15) : False := by
   omega
 
 example {a b : Int} (h : a < b) (w : b < a) : False := by omega
@@ -315,8 +319,8 @@ def List.permutationsAux.rec' {C : List α → List α → Sort v} (H0 : ∀ is,
   | [], is => H0 is
   | t :: ts, is =>
       H1 t ts is (permutationsAux.rec' H0 H1 ts (t :: is)) (permutationsAux.rec' H0 H1 is [])
-  termination_by _ ts is => (length ts + length is, length ts)
-  decreasing_by simp_wf; omega
+  termination_by ts is => (length ts + length is, length ts)
+  decreasing_by all_goals simp_wf; omega
 
 example {x y w z : Nat} (h : Prod.Lex (· < ·) (· < ·) (x + 1, y + 1) (w, z)) :
     Prod.Lex (· < ·) (· < ·) (x, y) (w, z) := by omega
@@ -348,10 +352,18 @@ example {a₁ a₂ p₁ p₂ : Nat}
 example {i : Nat} (h1 : i < 330) (_h2 : 7 ∣ (660 + i) * (1319 - i)) : 1319 - i < 1979 := by
   omega
 
+example {a : Int} (_ : a < min a b) : False := by omega (config := { splitMinMax := false })
+example {a : Int} (_ : max a b < b) : False := by omega (config := { splitMinMax := false })
+example {a : Nat} (_ : a < min a b) : False := by omega (config := { splitMinMax := false })
+example {a : Nat} (_ : max a b < b) : False := by omega (config := { splitMinMax := false })
+
+example {a b : Nat} (_ : a = 7) (_ : b = 3) : min a b = 3 := by
+  fail_if_success omega (config := { splitMinMax := false })
+  omega
+
+example {a b : Nat} (_ : a + b = 9) : (min a b) % 2 + (max a b) % 2 = 1 := by
+  fail_if_success omega (config := { splitMinMax := false })
+  omega
+
 example {a : Int} (_ : a < if a ≤ b then a else b) : False := by omega
-example {a : Int} (_ : a < min a b) : False := by omega
-example {a : Int} (_ : max a b < b) : False := by omega
-example {a : Nat} (_ : a < min a b) : False := by omega
-example {a : Nat} (_ : max a b < b) : False := by omega
-example {a : Int} : (a.natAbs : Int) ≥ -a := by omega
 example {a b : Int} : (if a < b then a else b - 1) ≤ b := by omega


### PR DESCRIPTION
```
example {a : Nat} (_ : a < min a b) : False := by omega 
example {a : Nat} (_ : max a b < b) : False := by omega 

example {a b : Nat} (_ : a = 7) (_ : b = 3) : min a b = 3 := by omega

example {a b : Nat} (_ : a + b = 9) : (min a b) % 2 + (max a b) % 2 = 1 := by omega

example {a : Int} (_ : a < if a ≤ b then a else b) : False := by omega
example {a b : Int} : (if a < b then a else b - 1) ≤ b := by omega
```

* Upon encountering `min a b`, add the facts `min a b <= a` and `min a b <= b` (similarly for max)
* Upon encountering `natAbs a`, add the facts `a <= natAbs a` and `-a <= natAbs a`
* If `splitMinMax := true`, allow the case split on `min a b = if a <= b then a else b` (similarly for max) as needed
* If `splitNatAbs := true`, allow the case split on `natAbs a = if 0 <= a then a else -a`

By default `splitMinMax := true`, as in interactive mode it may as well try.

When used in automation we will probably just set `disjunctions := false`, which disables all case splits.