### PR TITLE
refactor: deprecate duplicate BitVec lemma

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -13,12 +13,9 @@ namespace Std.BitVec
 theorem eq_of_toNat_eq {n} : ∀ {i j : BitVec n}, i.toNat = j.toNat → i = j
   | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
 
-theorem zero_is_unique (x : BitVec 0) : x = 0#0 := by
-  let ⟨i, lt⟩ := x
-  have p : i < 1 := lt
-  have q : i = 0 := by omega
-  simp [q]
-  rfl
+@[deprecated eq_nil]
+theorem zero_is_unique (x : BitVec 0) : x = 0#0 :=
+  eq_nil _
 
 @[simp] theorem val_toFin (x : BitVec w) : x.toFin.val = x.toNat := rfl
 

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -13,9 +13,8 @@ namespace Std.BitVec
 theorem eq_of_toNat_eq {n} : ∀ {i j : BitVec n}, i.toNat = j.toNat → i = j
   | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
 
-@[deprecated eq_nil]
-theorem zero_is_unique (x : BitVec 0) : x = 0#0 :=
-  eq_nil _
+/-- Replaced 2024-02-07. -/
+@[deprecated] alias zero_is_unique := eq_nil
 
 @[simp] theorem val_toFin (x : BitVec w) : x.toFin.val = x.toNat := rfl
 


### PR DESCRIPTION
`BitVec.zero_is_unique` is a duplicate of `BitVec.eq_nil`, so we deprecate the former as an alias