### PR TITLE
feat: add `Rat.mk_den_one` simp lemma

### DIFF
--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -13,6 +13,7 @@ import Std.Tactic.Ext
 Rational numbers, implemented as a pair of integers `num / den` such that the
 denominator is positive and the numerator and denominator are coprime.
 -/
+-- `Rat` is not tagged with the `ext` attribute, since this is more often than not undesirable
 structure Rat where
   /-- Constructs a rational number from components.
   We rename the constructor to `mk'` to avoid a clash with the smart constructor. -/
@@ -26,10 +27,6 @@ structure Rat where
   /-- The numerator and denominator are coprime: it is in "reduced form". -/
   reduced : num.natAbs.Coprime den := by decide
   deriving DecidableEq
-
--- `Rat` is not tagged with the `ext` attribute, since this is more often than not undesirable
-theorem Rat.ext {p q : Rat} (hn : p.num = q.num) (hd : p.den = q.den) : p = q := by
-  cases p; cases q; subst hn hd; rfl
 
 instance : Inhabited Rat := ⟨{ num := 0 }⟩
 

--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -27,6 +27,10 @@ structure Rat where
   reduced : num.natAbs.Coprime den := by decide
   deriving DecidableEq
 
+-- `Rat` is not tagged with the `ext` attribute, since this is more often than not undesirable
+theorem Rat.ext {p q : Rat} (hn : p.num = q.num) (hd : p.den = q.den) : p = q := by
+  cases p; cases q; subst hn hd; rfl
+
 instance : Inhabited Rat := ⟨{ num := 0 }⟩
 
 instance : ToString Rat where

--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -13,8 +13,7 @@ import Std.Tactic.Ext
 Rational numbers, implemented as a pair of integers `num / den` such that the
 denominator is positive and the numerator and denominator are coprime.
 -/
--- `Rat` is not tagged with the `ext` attribute, since this is more often than not undesirable
-structure Rat where
+@[ext] structure Rat where
   /-- Constructs a rational number from components.
   We rename the constructor to `mk'` to avoid a clash with the smart constructor. -/
   mk' ::

--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -13,7 +13,7 @@ import Std.Tactic.Ext
 Rational numbers, implemented as a pair of integers `num / den` such that the
 denominator is positive and the numerator and denominator are coprime.
 -/
-@[ext] structure Rat where
+structure Rat where
   /-- Constructs a rational number from components.
   We rename the constructor to `mk'` to avoid a clash with the smart constructor. -/
   mk' ::

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -348,7 +348,8 @@ theorem intCast_one : ((1 : Int) : Rat) = (1 : Rat) := rfl
   rw [add_def]
   ext <;> simp [normalize_eq]
 
-@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := rfl
+@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := by
+  ext <;> simp [normalize_eq]
 
 @[simp, norm_cast] theorem intCast_sub (a b : Int) :
     ((a - b : Int) : Rat) = (a : Rat) - (b : Rat) := by

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -16,6 +16,8 @@ namespace Rat
 @[simp] theorem one_num : (1 : Rat).num = 1 := rfl
 @[simp] theorem one_den : (1 : Rat).den = 1 := rfl
 
+@[simp] theorem mk'_one {r : Int} : mk' r 1 Nat.one_ne_zero (Nat.coprime_one_right _) = r := rfl
+
 @[simp] theorem maybeNormalize_eq {num den g} (den_nz reduced) :
     maybeNormalize num den g den_nz reduced =
     { num := num.div g, den := den / g, den_nz, reduced } := by
@@ -218,7 +220,7 @@ theorem divInt_add_divInt (n₁ n₂ : Int) {d₁ d₂} (z₁ : d₁ ≠ 0) (z�
 @[simp] theorem neg_den (a : Rat) : (-a).den = a.den := rfl
 
 theorem neg_normalize (n d z) : -normalize n d z = normalize (-n) d z := by
-  simp [normalize, maybeNormalize_eq]; ext <;> simp [Int.neg_div]
+  simp [normalize]; rfl
 
 theorem neg_mkRat (n d) : -mkRat n d = mkRat (-n) d := by
   if z : d = 0 then simp [z]; rfl else simp [← normalize_eq_mkRat z, neg_normalize]
@@ -344,17 +346,16 @@ theorem intCast_one : ((1 : Int) : Rat) = (1 : Rat) := rfl
 @[simp, norm_cast] theorem intCast_add (a b : Int) :
     ((a + b : Int) : Rat) = (a : Rat) + (b : Rat) := by
   rw [add_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]
 
-@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := by
-  ext <;> simp [normalize_eq]
+@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := rfl
 
 @[simp, norm_cast] theorem intCast_sub (a b : Int) :
     ((a - b : Int) : Rat) = (a : Rat) - (b : Rat) := by
   rw [sub_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]
 
 @[simp, norm_cast] theorem intCast_mul (a b : Int) :
     ((a * b : Int) : Rat) = (a : Rat) * (b : Rat) := by
   rw [mul_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -10,13 +10,14 @@ import Std.Tactic.SeqFocus
 /-! # Additional lemmas about the Rational Numbers -/
 
 namespace Rat
-attribute [ext] Rat
+
 @[simp] theorem zero_num : (0 : Rat).num = 0 := rfl
 @[simp] theorem zero_den : (0 : Rat).den = 1 := rfl
 @[simp] theorem one_num : (1 : Rat).num = 1 := rfl
 @[simp] theorem one_den : (1 : Rat).den = 1 := rfl
 
-@[simp] theorem mk'_one {r : Int} : mk' r 1 Nat.one_ne_zero (Nat.coprime_one_right _) = r := rfl
+@[simp] theorem mk_den_one {r : Int} :
+    (⟨r, 1, Nat.one_ne_zero, Nat.coprime_one_right _⟩ : Rat) = r := rfl
 
 @[simp] theorem maybeNormalize_eq {num den g} (den_nz reduced) :
     maybeNormalize num den g den_nz reduced =

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -13,6 +13,9 @@ namespace Rat
 
 attribute [local ext] Rat
 
+@[simp] theorem mk_den_one {r : Int} :
+    ⟨r, 1, Nat.one_ne_zero, (Nat.coprime_one_right _)⟩ = (r : Rat) := rfl
+
 @[simp] theorem zero_num : (0 : Rat).num = 0 := rfl
 @[simp] theorem zero_den : (0 : Rat).den = 1 := rfl
 @[simp] theorem one_num : (1 : Rat).num = 1 := rfl
@@ -220,7 +223,7 @@ theorem divInt_add_divInt (n₁ n₂ : Int) {d₁ d₂} (z₁ : d₁ ≠ 0) (z�
 @[simp] theorem neg_den (a : Rat) : (-a).den = a.den := rfl
 
 theorem neg_normalize (n d z) : -normalize n d z = normalize (-n) d z := by
-  simp [normalize, maybeNormalize_eq]; ext <;> simp [Int.neg_div]
+  simp [normalize]; rfl
 
 theorem neg_mkRat (n d) : -mkRat n d = mkRat (-n) d := by
   if z : d = 0 then simp [z]; rfl else simp [← normalize_eq_mkRat z, neg_normalize]
@@ -346,17 +349,16 @@ theorem intCast_one : ((1 : Int) : Rat) = (1 : Rat) := rfl
 @[simp, norm_cast] theorem intCast_add (a b : Int) :
     ((a + b : Int) : Rat) = (a : Rat) + (b : Rat) := by
   rw [add_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]
 
-@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := by
-  ext <;> simp [normalize_eq]
+@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := rfl
 
 @[simp, norm_cast] theorem intCast_sub (a b : Int) :
     ((a - b : Int) : Rat) = (a : Rat) - (b : Rat) := by
   rw [sub_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]
 
 @[simp, norm_cast] theorem intCast_mul (a b : Int) :
     ((a * b : Int) : Rat) = (a : Rat) * (b : Rat) := by
   rw [mul_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -10,13 +10,11 @@ import Std.Tactic.SeqFocus
 /-! # Additional lemmas about the Rational Numbers -/
 
 namespace Rat
-
+attribute [ext] Rat
 @[simp] theorem zero_num : (0 : Rat).num = 0 := rfl
 @[simp] theorem zero_den : (0 : Rat).den = 1 := rfl
 @[simp] theorem one_num : (1 : Rat).num = 1 := rfl
 @[simp] theorem one_den : (1 : Rat).den = 1 := rfl
-
-@[simp] theorem mk'_one {r : Int} : mk' r 1 Nat.one_ne_zero (Nat.coprime_one_right _) = r := rfl
 
 @[simp] theorem maybeNormalize_eq {num den g} (den_nz reduced) :
     maybeNormalize num den g den_nz reduced =
@@ -220,7 +218,7 @@ theorem divInt_add_divInt (n₁ n₂ : Int) {d₁ d₂} (z₁ : d₁ ≠ 0) (z�
 @[simp] theorem neg_den (a : Rat) : (-a).den = a.den := rfl
 
 theorem neg_normalize (n d z) : -normalize n d z = normalize (-n) d z := by
-  simp [normalize]; rfl
+  simp [normalize, maybeNormalize_eq]; ext <;> simp [Int.neg_div]
 
 theorem neg_mkRat (n d) : -mkRat n d = mkRat (-n) d := by
   if z : d = 0 then simp [z]; rfl else simp [← normalize_eq_mkRat z, neg_normalize]
@@ -346,16 +344,17 @@ theorem intCast_one : ((1 : Int) : Rat) = (1 : Rat) := rfl
 @[simp, norm_cast] theorem intCast_add (a b : Int) :
     ((a + b : Int) : Rat) = (a : Rat) + (b : Rat) := by
   rw [add_def]
-  simp [normalize_eq]
+  ext <;> simp [normalize_eq]
 
-@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := rfl
+@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := by
+  ext <;> simp [normalize_eq]
 
 @[simp, norm_cast] theorem intCast_sub (a b : Int) :
     ((a - b : Int) : Rat) = (a : Rat) - (b : Rat) := by
   rw [sub_def]
-  simp [normalize_eq]
+  ext <;> simp [normalize_eq]
 
 @[simp, norm_cast] theorem intCast_mul (a b : Int) :
     ((a * b : Int) : Rat) = (a : Rat) * (b : Rat) := by
   rw [mul_def]
-  simp [normalize_eq]
+  ext <;> simp [normalize_eq]

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -11,8 +11,6 @@ import Std.Tactic.SeqFocus
 
 namespace Rat
 
-attribute [local ext] Rat
-
 @[simp] theorem mk_den_one {r : Int} :
     ⟨r, 1, Nat.one_ne_zero, (Nat.coprime_one_right _)⟩ = (r : Rat) := rfl
 

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -11,13 +11,12 @@ import Std.Tactic.SeqFocus
 
 namespace Rat
 
+attribute [local ext] Rat
+
 @[simp] theorem zero_num : (0 : Rat).num = 0 := rfl
 @[simp] theorem zero_den : (0 : Rat).den = 1 := rfl
 @[simp] theorem one_num : (1 : Rat).num = 1 := rfl
 @[simp] theorem one_den : (1 : Rat).den = 1 := rfl
-
-@[simp] theorem mk_den_one {r : Int} :
-    (⟨r, 1, Nat.one_ne_zero, Nat.coprime_one_right _⟩ : Rat) = r := rfl
 
 @[simp] theorem maybeNormalize_eq {num den g} (den_nz reduced) :
     maybeNormalize num den g den_nz reduced =
@@ -221,7 +220,7 @@ theorem divInt_add_divInt (n₁ n₂ : Int) {d₁ d₂} (z₁ : d₁ ≠ 0) (z�
 @[simp] theorem neg_den (a : Rat) : (-a).den = a.den := rfl
 
 theorem neg_normalize (n d z) : -normalize n d z = normalize (-n) d z := by
-  simp [normalize]; rfl
+  simp [normalize, maybeNormalize_eq]; ext <;> simp [Int.neg_div]
 
 theorem neg_mkRat (n d) : -mkRat n d = mkRat (-n) d := by
   if z : d = 0 then simp [z]; rfl else simp [← normalize_eq_mkRat z, neg_normalize]
@@ -347,16 +346,16 @@ theorem intCast_one : ((1 : Int) : Rat) = (1 : Rat) := rfl
 @[simp, norm_cast] theorem intCast_add (a b : Int) :
     ((a + b : Int) : Rat) = (a : Rat) + (b : Rat) := by
   rw [add_def]
-  simp [normalize_eq]
+  ext <;> simp [normalize_eq]
 
 @[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := rfl
 
 @[simp, norm_cast] theorem intCast_sub (a b : Int) :
     ((a - b : Int) : Rat) = (a : Rat) - (b : Rat) := by
   rw [sub_def]
-  simp [normalize_eq]
+  ext <;> simp [normalize_eq]
 
 @[simp, norm_cast] theorem intCast_mul (a b : Int) :
     ((a * b : Int) : Rat) = (a : Rat) * (b : Rat) := by
   rw [mul_def]
-  simp [normalize_eq]
+  ext <;> simp [normalize_eq]

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -16,6 +16,8 @@ attribute [ext] Rat
 @[simp] theorem one_num : (1 : Rat).num = 1 := rfl
 @[simp] theorem one_den : (1 : Rat).den = 1 := rfl
 
+@[simp] theorem mk'_one {r : Int} : mk' r 1 Nat.one_ne_zero (Nat.coprime_one_right _) = r := rfl
+
 @[simp] theorem maybeNormalize_eq {num den g} (den_nz reduced) :
     maybeNormalize num den g den_nz reduced =
     { num := num.div g, den := den / g, den_nz, reduced } := by
@@ -218,7 +220,7 @@ theorem divInt_add_divInt (n₁ n₂ : Int) {d₁ d₂} (z₁ : d₁ ≠ 0) (z�
 @[simp] theorem neg_den (a : Rat) : (-a).den = a.den := rfl
 
 theorem neg_normalize (n d z) : -normalize n d z = normalize (-n) d z := by
-  simp [normalize, maybeNormalize_eq]; ext <;> simp [Int.neg_div]
+  simp [normalize]; rfl
 
 theorem neg_mkRat (n d) : -mkRat n d = mkRat (-n) d := by
   if z : d = 0 then simp [z]; rfl else simp [← normalize_eq_mkRat z, neg_normalize]
@@ -344,17 +346,16 @@ theorem intCast_one : ((1 : Int) : Rat) = (1 : Rat) := rfl
 @[simp, norm_cast] theorem intCast_add (a b : Int) :
     ((a + b : Int) : Rat) = (a : Rat) + (b : Rat) := by
   rw [add_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]
 
-@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := by
-  ext <;> simp [normalize_eq]
+@[simp, norm_cast] theorem intCast_neg (a : Int) : ((-a : Int) : Rat) = -(a : Rat) := rfl
 
 @[simp, norm_cast] theorem intCast_sub (a b : Int) :
     ((a - b : Int) : Rat) = (a : Rat) - (b : Rat) := by
   rw [sub_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]
 
 @[simp, norm_cast] theorem intCast_mul (a b : Int) :
     ((a * b : Int) : Rat) = (a : Rat) * (b : Rat) := by
   rw [mul_def]
-  ext <;> simp [normalize_eq]
+  simp [normalize_eq]


### PR DESCRIPTION
This PR extracts the new lemma `mk_den_one`, previously introduced in #611 and uses it to golf some proofs.
