### PR TITLE
feat: omega only replaces mod with div when the modulus is a literal

### DIFF
--- a/Std/Tactic/Omega/Frontend.lean
+++ b/Std/Tactic/Omega/Frontend.lean
@@ -180,7 +180,15 @@ partial def asLinearComboImpl (e : Expr) : OmegaM (LinearCombo × OmegaM Expr ×
     match r? with
     | some r => pure r
     | none => mkAtomLinearCombo e
-  | (``HMod.hMod, #[_, _, _, _, n, k]) => rewrite e (mkApp2 (.const ``Int.emod_def []) n k)
+  | (``HMod.hMod, #[_, _, _, _, n, k]) =>
+    match k.nat? with
+    | some _ => rewrite e (mkApp2 (.const ``Int.emod_def []) n k)
+    | none => match k.getAppFnArgs with
+      | (``Nat.cast, #[.const ``Int [], _, k']) =>
+        match k'.nat? with
+        | some _ => rewrite e (mkApp2 (.const ``Int.emod_def []) n k)
+        | none => mkAtomLinearCombo e
+      | _ => mkAtomLinearCombo e
   | (``HDiv.hDiv, #[_, _, _, _, x, z]) =>
     match intCast? z with
     | some 0 => rewrite e (mkApp (.const ``Int.ediv_zero []) x)

--- a/Std/Tactic/Omega/Frontend.lean
+++ b/Std/Tactic/Omega/Frontend.lean
@@ -181,14 +181,9 @@ partial def asLinearComboImpl (e : Expr) : OmegaM (LinearCombo × OmegaM Expr ×
     | some r => pure r
     | none => mkAtomLinearCombo e
   | (``HMod.hMod, #[_, _, _, _, n, k]) =>
-    match k.nat? with
+    match natCast? k with
     | some _ => rewrite e (mkApp2 (.const ``Int.emod_def []) n k)
-    | none => match k.getAppFnArgs with
-      | (``Nat.cast, #[.const ``Int [], _, k']) =>
-        match k'.nat? with
-        | some _ => rewrite e (mkApp2 (.const ``Int.emod_def []) n k)
-        | none => mkAtomLinearCombo e
-      | _ => mkAtomLinearCombo e
+    | none => mkAtomLinearCombo e
   | (``HDiv.hDiv, #[_, _, _, _, x, z]) =>
     match intCast? z with
     | some 0 => rewrite e (mkApp (.const ``Int.ediv_zero []) x)

--- a/Std/Tactic/Omega/Int.lean
+++ b/Std/Tactic/Omega/Int.lean
@@ -19,6 +19,20 @@ If you do find a use for them, please move them into the appropriate file and na
 
 namespace Std.Tactic.Omega.Int
 
+theorem ofNat_pow (a b : Nat) : ((a ^ b : Nat) : Int) = (a : Int) ^ b := by
+  induction b with
+  | zero => rfl
+  | succ b ih => rw [Nat.pow_succ, Int.ofNat_mul, ih]; rfl
+
+theorem pos_pow_of_pos (a : Int) (b : Nat) (h : 0 < a) : 0 < a ^ b := by
+  rw [Int.eq_natAbs_of_zero_le (Int.le_of_lt h), ← Int.ofNat_zero, ← Int.ofNat_pow, Int.ofNat_lt]
+  exact Nat.pos_pow_of_pos _ (Int.natAbs_pos.mpr (Int.ne_of_gt h))
+
+theorem ofNat_pos {a : Nat} : 0 < (a : Int) ↔ 0 < a := by
+  rw [← Int.ofNat_zero, Int.ofNat_lt]
+
+alias ⟨_, ofNat_pos_of_pos⟩ := Int.ofNat_pos
+
 theorem natCast_ofNat {x : Nat} :
     @Nat.cast Int instNatCastInt (no_index (OfNat.ofNat x)) = OfNat.ofNat x := rfl
 

--- a/Std/Tactic/Omega/OmegaM.lean
+++ b/Std/Tactic/Omega/OmegaM.lean
@@ -162,7 +162,7 @@ def analyzeAtom (e : Expr) : OmegaM (HashSet Expr) := do
         let pow_pos := mkApp3 (.const ``Int.pos_pow_of_pos []) b exp (← mkDecideProof b_pos)
         pure <|
           {mkApp3 (.const ``Int.emod_nonneg []) x k
-              (mkApp3 (.const ``Int.ne_of_lt []) (toExpr (0 : Int)) k pow_pos),
+              (mkApp3 (.const ``Int.ne_of_gt []) k (toExpr (0 : Int)) pow_pos),
             mkApp3 (.const ``Int.emod_lt_of_pos []) x k pow_pos}
     | (``Nat.cast, #[.const ``Int [], _, k']) =>
       match k'.getAppFnArgs with
@@ -176,7 +176,7 @@ def analyzeAtom (e : Expr) : OmegaM (HashSet Expr) := do
           let cast_pos := mkApp2 (.const ``Int.ofNat_pos_of_pos []) k' pow_pos
           pure <|
             {mkApp3 (.const ``Int.emod_nonneg []) x k
-                (mkApp3 (.const ``Int.ne_of_lt []) (toExpr (0 : Int)) k cast_pos),
+                (mkApp3 (.const ``Int.ne_of_gt []) k (toExpr (0 : Int)) cast_pos),
               mkApp3 (.const ``Int.emod_lt_of_pos []) x k cast_pos}
       | _ => pure ∅
     | _ => pure ∅

--- a/test/omega/test.lean
+++ b/test/omega/test.lean
@@ -381,3 +381,5 @@ example (i j : Nat) (p : i ≥ j) : True := by
   trivial
 
 example (i : Fin 7) : (i : Nat) < 8 := by omega
+
+example (x y z i : Nat) (hz : z ≤ 1) : x % 2 ^ i + y % 2 ^ i + z < 2 * 2^ i := by omega


### PR DESCRIPTION
Also, add facts about `x % k ^ i` atoms when `k` is a non-zero literal.

This makes reasoning about `x % 2 ^ i` terms (e.g. in BitVec arguments) much more pleasant.