### PR TITLE
feat: prove `allOnes _ - x = ~~~x`

### DIFF
--- a/Std/Data/BitVec/Bitblast.lean
+++ b/Std/Data/BitVec/Bitblast.lean
@@ -166,3 +166,7 @@ theorem add_eq_adc (w : Nat) (x y : BitVec w) : x + y = (adc x y false).snd := b
   rw [add_eq_adc, adc, iunfoldr_replace (fun _ => false) (allOnes w)]
   · rfl
   · simp [adcb, atLeastTwo]
+
+/-- Subtracting `x` from the all ones bitvector is equivalent to taking its complement -/
+theorem allOnes_sub_eq_not (x : BitVec w) : allOnes w - x = ~~~x := by
+  rw [← add_not_self x, BitVec.add_comm, add_sub_cancel]

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -437,6 +437,12 @@ theorem sub_toAdd {n} (x y : BitVec n) : x - y = x + - y := by
 
 @[simp] theorem neg_zero (n:Nat) : -0#n = 0#n := by apply eq_of_toNat_eq ; simp
 
+theorem add_sub_cancel (x y : BitVec w) : x + y - y = x := by
+  apply eq_of_toNat_eq
+  have y_toNat_le := Nat.le_of_lt y.toNat_lt
+  rw [toNat_sub, toNat_add, Nat.mod_add_mod, Nat.add_assoc, ← Nat.add_sub_assoc y_toNat_le,
+    Nat.add_sub_cancel_left, Nat.add_mod_right, toNat_mod_cancel]
+
 /-! ### mul -/
 
 theorem mul_def {n} {x y : BitVec n} : x * y = (ofFin <| x.toFin * y.toFin) := by rfl


### PR DESCRIPTION
A corollary of `add_not_self`: subtracting `x` from the all-ones bitvector is the same as taking the complement of `x`