### PR TITLE
chore: lemma for BitVec.ofFin to .ofNat

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -15,6 +15,12 @@ import Std.Util.ProofWanted
 
 namespace Std.BitVec
 
+/--
+This normalized a bitvec using `ofFin` to `ofNat`.
+-/
+theorem ofFin_eq_ofNat : @BitVec.ofFin w (Fin.mk x lt) = BitVec.ofNat w x := by
+  simp only [BitVec.ofNat, Fin.ofNat', lt, Nat.mod_eq_of_lt]
+
 /-- Prove equality of bitvectors in terms of nat operations. -/
 theorem eq_of_toNat_eq {n} : ∀ {i j : BitVec n}, i.toNat = j.toNat → i = j
   | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl

--- a/test/bitvec.lean
+++ b/test/bitvec.lean
@@ -114,3 +114,8 @@ def testMatch8 (i : BitVec 32) :=
 #guard toString 5#13 = "0x0005#13"
 #guard toString 5#12 = "0x005#12"
 #guard toString 5#13 = "0x0005#13"
+
+-- Simp
+
+example (n w : Nat) (p : n < 2^w) : { toFin := { val := n, isLt := p } : BitVec w} = .ofNat w n := by
+  simp only [ofFin_eq_ofNat]


### PR DESCRIPTION
I think readability is improved if we make this a simp rule, but it is currently too easy to create simp loops with it on.