### PR TITLE
chore: Drop Std.Data.Nat.Lemmas from Omega dependencies.

### DIFF
--- a/Std/Data/Int/Init/DivMod.lean
+++ b/Std/Data/Int/Init/DivMod.lean
@@ -3,6 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro
 -/
+import Std.Data.Nat.Init.Dvd
 import Std.Data.Int.Init.Order
 import Std.Tactic.Change
 import Std.Tactic.RCases

--- a/Std/Data/Int/Init/Lemmas.lean
+++ b/Std/Data/Int/Init/Lemmas.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Deniz Aydin, Floris van Doorn, Mario Carneiro
 -/
 import Std.Classes.Cast
-import Std.Data.Nat.Lemmas
+import Std.Data.Nat.Init.Lemmas
 import Std.Data.Int.Basic
 import Std.Tactic.NormCast.Lemmas
 

--- a/Std/Data/Int/Order.lean
+++ b/Std/Data/Int/Order.lean
@@ -8,6 +8,7 @@ import Std.Data.Option.Basic
 import Std.Tactic.RCases
 import Std.Tactic.ByCases
 import Std.Tactic.Omega
+import Std.Data.Nat.Lemmas
 
 /-!
 # Results about the order properties of the integers, and the integers as an ordered ring.

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -204,7 +204,6 @@ def enumFromTR (n : Nat) (l : List α) : List (Nat × α) :=
     | a::as, n => by
       rw [← show _ + as.length = n + (a::as).length from Nat.succ_add .., foldr, go as]
       simp [enumFrom]
-      rfl
   rw [Array.foldr_eq_foldr_data]; simp [go]
 
 theorem replicateTR_loop_eq : ∀ n, replicateTR.loop a n acc = replicate n a ++ acc

--- a/Std/Data/Nat.lean
+++ b/Std/Data/Nat.lean
@@ -1,5 +1,8 @@
 import Std.Data.Nat.Basic
 import Std.Data.Nat.Bitwise
 import Std.Data.Nat.Gcd
+import Std.Data.Nat.Init.Basic
+import Std.Data.Nat.Init.Dvd
+import Std.Data.Nat.Init.Gcd
 import Std.Data.Nat.Init.Lemmas
 import Std.Data.Nat.Lemmas

--- a/Std/Data/Nat/Basic.lean
+++ b/Std/Data/Nat/Basic.lean
@@ -101,12 +101,6 @@ protected def casesDiagOn {motive : Nat → Nat → Sort _} (m n : Nat)
   Nat.recDiag zero_zero (fun _ _ => zero_succ _) (fun _ _ => succ_zero _)
     (fun _ _ _ => succ_succ _ _) m n
 
-/--
-Divisibility of natural numbers. `a ∣ b` (typed as `\|`) says that
-there is some `c` such that `b = a * c`.
--/
-instance : Dvd Nat := ⟨fun a b => ∃ c, b = a * c⟩
-
 /-- The least common multiple of `m` and `n`, defined using `gcd`. -/
 def lcm (m n : Nat) : Nat := m * n / gcd m n
 

--- a/Std/Data/Nat/Gcd.lean
+++ b/Std/Data/Nat/Gcd.lean
@@ -3,6 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 -/
+import Std.Data.Nat.Init.Gcd
 import Std.Data.Nat.Lemmas
 import Std.Tactic.RCases
 
@@ -13,41 +14,10 @@ import Std.Tactic.RCases
 
 namespace Nat
 
-theorem gcd_rec (m n : Nat) : gcd m n = gcd (n % m) m :=
-  match m with
-  | 0 => by have := (mod_zero n).symm; rwa [gcd_zero_right]
-  | _ + 1 => by simp [gcd_succ]
-
-@[elab_as_elim] theorem gcd.induction {P : Nat → Nat → Prop} (m n : Nat)
-    (H0 : ∀n, P 0 n) (H1 : ∀ m n, 0 < m → P (n % m) m → P m n) : P m n :=
-  Nat.strongInductionOn (motive := fun m => ∀ n, P m n) m
-    (fun
-    | 0, _ => H0
-    | _+1, IH => fun _ => H1 _ _ (succ_pos _) (IH _ (mod_lt _ (succ_pos _)) _) )
-    n
-
 /-- `m` and `n` are coprime, or relatively prime, if their `gcd` is 1. -/
 @[reducible] def Coprime (m n : Nat) : Prop := gcd m n = 1
 
 ---
-
-theorem gcd_dvd (m n : Nat) : (gcd m n ∣ m) ∧ (gcd m n ∣ n) := by
-  induction m, n using gcd.induction with
-  | H0 n => rw [gcd_zero_left]; exact ⟨Nat.dvd_zero n, Nat.dvd_refl n⟩
-  | H1 m n _ IH => rw [← gcd_rec] at IH; exact ⟨IH.2, (dvd_mod_iff IH.2).1 IH.1⟩
-
-theorem gcd_dvd_left (m n : Nat) : gcd m n ∣ m := (gcd_dvd m n).left
-
-theorem gcd_dvd_right (m n : Nat) : gcd m n ∣ n := (gcd_dvd m n).right
-
-theorem gcd_le_left (n) (h : 0 < m) : gcd m n ≤ m := le_of_dvd h <| gcd_dvd_left m n
-
-theorem gcd_le_right (n) (h : 0 < n) : gcd m n ≤ n := le_of_dvd h <| gcd_dvd_right m n
-
-theorem dvd_gcd : k ∣ m → k ∣ n → k ∣ gcd m n := by
-  induction m, n using gcd.induction with intro km kn
-  | H0 n => rw [gcd_zero_left]; exact kn
-  | H1 n m _ IH => rw [gcd_rec]; exact IH ((dvd_mod_iff km).2 kn) km
 
 theorem dvd_gcd_iff : k ∣ gcd m n ↔ k ∣ m ∧ k ∣ n :=
   ⟨fun h => let ⟨h₁, h₂⟩ := gcd_dvd m n; ⟨Nat.dvd_trans h h₁, Nat.dvd_trans h h₂⟩,

--- a/Std/Data/Nat/Init/Basic.lean
+++ b/Std/Data/Nat/Init/Basic.lean
@@ -1,0 +1,9 @@
+namespace Nat
+
+/--
+Divisibility of natural numbers. `a ∣ b` (typed as `\|`) says that
+there is some `c` such that `b = a * c`.
+-/
+instance : Dvd Nat := ⟨fun a b => ∃ c, b = a * c⟩
+
+end Nat

--- a/Std/Data/Nat/Init/Basic.lean
+++ b/Std/Data/Nat/Init/Basic.lean
@@ -1,3 +1,10 @@
+/-
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
+-/
+import Std.Classes.Dvd
+
 namespace Nat
 
 /--

--- a/Std/Data/Nat/Init/Dvd.lean
+++ b/Std/Data/Nat/Init/Dvd.lean
@@ -1,0 +1,90 @@
+import Std.Data.Nat.Init.Basic
+import Std.Data.Nat.Init.Lemmas
+
+namespace Nat
+
+protected theorem dvd_refl (a : Nat) : a ∣ a := ⟨1, by simp⟩
+
+protected theorem dvd_zero (a : Nat) : a ∣ 0 := ⟨0, by simp⟩
+
+protected theorem dvd_mul_left (a b : Nat) : a ∣ b * a := ⟨b, Nat.mul_comm b a⟩
+
+protected theorem dvd_mul_right (a b : Nat) : a ∣ a * b := ⟨b, rfl⟩
+
+protected theorem dvd_trans {a b c : Nat} (h₁ : a ∣ b) (h₂ : b ∣ c) : a ∣ c :=
+  match h₁, h₂ with
+  | ⟨d, (h₃ : b = a * d)⟩, ⟨e, (h₄ : c = b * e)⟩ =>
+    ⟨d * e, show c = a * (d * e) by simp[h₃,h₄, Nat.mul_assoc]⟩
+
+protected theorem eq_zero_of_zero_dvd {a : Nat} (h : 0 ∣ a) : a = 0 :=
+  let ⟨c, H'⟩ := h; H'.trans c.zero_mul
+
+@[simp] protected theorem zero_dvd {n : Nat} : 0 ∣ n ↔ n = 0 :=
+  ⟨Nat.eq_zero_of_zero_dvd, fun h => h.symm ▸ Nat.dvd_zero 0⟩
+
+protected theorem dvd_add {a b c : Nat} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
+  let ⟨d, hd⟩ := h₁; let ⟨e, he⟩ := h₂; ⟨d + e, by simp [Nat.left_distrib, hd, he]⟩
+
+protected theorem dvd_add_iff_right {k m n : Nat} (h : k ∣ m) : k ∣ n ↔ k ∣ m + n :=
+  ⟨Nat.dvd_add h,
+    match m, h with
+    | _, ⟨d, rfl⟩ => fun ⟨e, he⟩ =>
+      ⟨e - d, by rw [Nat.mul_sub_left_distrib, ← he, Nat.add_sub_cancel_left]⟩⟩
+
+protected theorem dvd_add_iff_left {k m n : Nat} (h : k ∣ n) : k ∣ m ↔ k ∣ m + n := by
+  rw [Nat.add_comm]; exact Nat.dvd_add_iff_right h
+
+theorem dvd_mod_iff {k m n : Nat} (h: k ∣ n) : k ∣ m % n ↔ k ∣ m :=
+  have := Nat.dvd_add_iff_left <| Nat.dvd_trans h <| Nat.dvd_mul_right n (m / n)
+  by rwa [mod_add_div] at this
+
+theorem le_of_dvd {m n : Nat} (h : 0 < n) : m ∣ n → m ≤ n
+  | ⟨k, e⟩ => by
+    revert h
+    rw [e]
+    match k with
+    | 0 => intro hn; simp at hn
+    | pk+1 =>
+      intro
+      have := Nat.mul_le_mul_left m (succ_pos pk)
+      rwa [Nat.mul_one] at this
+
+protected theorem dvd_antisymm : ∀ {m n : Nat}, m ∣ n → n ∣ m → m = n
+  | _, 0, _, h₂ => Nat.eq_zero_of_zero_dvd h₂
+  | 0, _, h₁, _ => (Nat.eq_zero_of_zero_dvd h₁).symm
+  | _+1, _+1, h₁, h₂ => Nat.le_antisymm (le_of_dvd (succ_pos _) h₁) (le_of_dvd (succ_pos _) h₂)
+
+theorem pos_of_dvd_of_pos {m n : Nat} (H1 : m ∣ n) (H2 : 0 < n) : 0 < m :=
+  Nat.pos_of_ne_zero fun m0 => Nat.ne_of_gt H2 <| Nat.eq_zero_of_zero_dvd (m0 ▸ H1)
+
+@[simp] protected theorem one_dvd (n : Nat) : 1 ∣ n := ⟨n, n.one_mul.symm⟩
+
+theorem eq_one_of_dvd_one {n : Nat} (H : n ∣ 1) : n = 1 := Nat.dvd_antisymm H n.one_dvd
+
+theorem mod_eq_zero_of_dvd {m n : Nat} (H : m ∣ n) : n % m = 0 := by
+  let ⟨z, H⟩ := H; rw [H, mul_mod_right]
+
+theorem dvd_of_mod_eq_zero {m n : Nat} (H : n % m = 0) : m ∣ n := by
+  exists n / m
+  have := (mod_add_div n m).symm
+  rwa [H, Nat.zero_add] at this
+
+theorem dvd_iff_mod_eq_zero (m n : Nat) : m ∣ n ↔ n % m = 0 :=
+  ⟨mod_eq_zero_of_dvd, dvd_of_mod_eq_zero⟩
+
+instance decidable_dvd : @DecidableRel Nat (·∣·) :=
+  fun _ _ => decidable_of_decidable_of_iff (dvd_iff_mod_eq_zero _ _).symm
+
+theorem emod_pos_of_not_dvd {a b : Nat} (h : ¬ a ∣ b) : 0 < b % a := by
+  rw [dvd_iff_mod_eq_zero] at h
+  exact Nat.pos_of_ne_zero h
+
+
+protected theorem mul_div_cancel' {n m : Nat} (H : n ∣ m) : n * (m / n) = m := by
+  have := mod_add_div m n
+  rwa [mod_eq_zero_of_dvd H, Nat.zero_add] at this
+
+protected theorem div_mul_cancel {n m : Nat} (H : n ∣ m) : m / n * n = m := by
+  rw [Nat.mul_comm, Nat.mul_div_cancel' H]
+
+end Nat

--- a/Std/Data/Nat/Init/Dvd.lean
+++ b/Std/Data/Nat/Init/Dvd.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
+-/
 import Std.Data.Nat.Init.Basic
 import Std.Data.Nat.Init.Lemmas
 

--- a/Std/Data/Nat/Init/Gcd.lean
+++ b/Std/Data/Nat/Init/Gcd.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
+-/
 import Std.Data.Nat.Init.Basic
 import Std.Data.Nat.Init.Dvd
 

--- a/Std/Data/Nat/Init/Gcd.lean
+++ b/Std/Data/Nat/Init/Gcd.lean
@@ -1,0 +1,37 @@
+import Std.Data.Nat.Init.Basic
+import Std.Data.Nat.Init.Dvd
+
+namespace Nat
+
+theorem gcd_rec (m n : Nat) : gcd m n = gcd (n % m) m :=
+  match m with
+  | 0 => by have := (mod_zero n).symm; rwa [gcd_zero_right]
+  | _ + 1 => by simp [gcd_succ]
+
+@[elab_as_elim] theorem gcd.induction {P : Nat → Nat → Prop} (m n : Nat)
+    (H0 : ∀n, P 0 n) (H1 : ∀ m n, 0 < m → P (n % m) m → P m n) : P m n :=
+  Nat.strongInductionOn (motive := fun m => ∀ n, P m n) m
+    (fun
+    | 0, _ => H0
+    | _+1, IH => fun _ => H1 _ _ (succ_pos _) (IH _ (mod_lt _ (succ_pos _)) _) )
+    n
+
+theorem gcd_dvd (m n : Nat) : (gcd m n ∣ m) ∧ (gcd m n ∣ n) := by
+  induction m, n using gcd.induction with
+  | H0 n => rw [gcd_zero_left]; exact ⟨Nat.dvd_zero n, Nat.dvd_refl n⟩
+  | H1 m n _ IH => rw [← gcd_rec] at IH; exact ⟨IH.2, (dvd_mod_iff IH.2).1 IH.1⟩
+
+theorem gcd_dvd_left (m n : Nat) : gcd m n ∣ m := (gcd_dvd m n).left
+
+theorem gcd_dvd_right (m n : Nat) : gcd m n ∣ n := (gcd_dvd m n).right
+
+theorem gcd_le_left (n) (h : 0 < m) : gcd m n ≤ m := le_of_dvd h <| gcd_dvd_left m n
+
+theorem gcd_le_right (n) (h : 0 < n) : gcd m n ≤ n := le_of_dvd h <| gcd_dvd_right m n
+
+theorem dvd_gcd : k ∣ m → k ∣ n → k ∣ gcd m n := by
+  induction m, n using gcd.induction with intro km kn
+  | H0 n => rw [gcd_zero_left]; exact kn
+  | H1 n m _ IH => rw [gcd_rec]; exact IH ((dvd_mod_iff km).2 kn) km
+
+end Nat

--- a/Std/Data/Nat/Init/Lemmas.lean
+++ b/Std/Data/Nat/Init/Lemmas.lean
@@ -7,13 +7,97 @@ import Std.Logic
 
 namespace Nat
 
+/-! ### le/lt -/
+
+theorem ne_of_gt {a b : Nat} (h : b < a) : a ≠ b := (ne_of_lt h).symm
+
+protected theorem pos_of_ne_zero {n : Nat} : n ≠ 0 → 0 < n := (eq_zero_or_pos n).resolve_left
+
+@[simp] protected theorem not_le {a b : Nat} : ¬ a ≤ b ↔ b < a :=
+  ⟨Nat.gt_of_not_le, Nat.not_le_of_gt⟩
+
+protected alias ⟨lt_of_not_ge, _⟩ := Nat.not_le
+protected alias ⟨lt_of_not_le, not_le_of_lt⟩ := Nat.not_le
+protected alias ⟨_, lt_le_asymm⟩ := Nat.not_le
+
+@[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
+  ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
+
+protected alias ⟨le_of_not_gt, not_lt_of_ge⟩ := Nat.not_lt
+protected alias ⟨le_of_not_lt, not_lt_of_le⟩ := Nat.not_lt
+protected alias ⟨_, le_lt_asymm⟩ := Nat.not_lt
+
+alias ne_of_lt' := ne_of_gt
+
+protected theorem le_of_not_le {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_lt (Nat.not_le.1 h)
+protected alias le_of_not_ge := Nat.le_of_not_le
+
+protected theorem le_antisymm_iff {a b : Nat} : a = b ↔ a ≤ b ∧ b ≤ a :=
+  ⟨fun | rfl => ⟨Nat.le_refl _, Nat.le_refl _⟩, fun ⟨hle, hge⟩ => Nat.le_antisymm hle hge⟩
+protected alias eq_iff_le_and_ge := Nat.le_antisymm_iff
+
+protected theorem lt_or_gt_of_ne {a b : Nat} : a ≠ b → a < b ∨ b < a := by
+  rw [← Nat.not_le, ← Nat.not_le, ← Decidable.not_and_iff_or_not_not, and_comm]
+  exact mt Nat.le_antisymm_iff.2
+protected alias lt_or_lt_of_ne := Nat.lt_or_gt_of_ne
+@[deprecated] protected alias lt_connex := Nat.lt_or_gt_of_ne
+
+
+
+/-! ## zero/one/two -/
+
+protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 := ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
+
+/-! ### succ/pred -/
+
+theorem succ_pred_eq_of_pos : ∀ {n}, 0 < n → succ (pred n) = n
+  | _+1, _ => rfl
+
+theorem exists_eq_succ_of_ne_zero : ∀ {n}, n ≠ 0 → ∃ k, n = succ k
+  | _+1, _ => ⟨_, rfl⟩
+
+/-! ### add -/
+
+protected theorem add_le_add_iff_right {n : Nat} : m + n ≤ k + n ↔ m ≤ k :=
+  ⟨Nat.le_of_add_le_add_right, fun h => Nat.add_le_add_right h _⟩
+
+theorem eq_zero_of_add_eq_zero : ∀ {n m}, n + m = 0 → n = 0 ∧ m = 0
+  | 0, 0, _ => ⟨rfl, rfl⟩
+  | _+1, 0, h => Nat.noConfusion h
+
+protected theorem eq_zero_of_add_eq_zero_left (h : n + m = 0) : m = 0 :=
+  (Nat.eq_zero_of_add_eq_zero h).2
+
+/-! ### sub -/
+
+attribute [simp] Nat.zero_sub Nat.add_sub_cancel succ_sub_succ_eq_sub
+
 theorem succ_sub {m n : Nat} (h : n ≤ m) : succ m - n = succ (m - n) := by
   let ⟨k, hk⟩ := Nat.le.dest h
   rw [← hk, Nat.add_sub_cancel_left, ← add_succ, Nat.add_sub_cancel_left]
 
+protected theorem sub_pos_of_lt (h : m < n) : 0 < n - m :=
+  Nat.pos_iff_ne_zero.2 (Nat.sub_ne_zero_of_lt h)
+
+protected theorem sub_le_sub_left (h : n ≤ m) (k : Nat) : k - m ≤ k - n :=
+  match m, le.dest h with
+  | _, ⟨a, rfl⟩ => by rw [← Nat.sub_sub]; apply sub_le
+
 protected theorem sub_le_sub_right {n m : Nat} (h : n ≤ m) : ∀ k, n - k ≤ m - k
   | 0   => h
   | z+1 => pred_le_pred (Nat.sub_le_sub_right h z)
+
+protected theorem lt_of_sub_ne_zero (h : n - m ≠ 0) : m < n :=
+  Nat.not_le.1 (mt Nat.sub_eq_zero_of_le h)
+
+protected theorem sub_ne_zero_iff_lt : n - m ≠ 0 ↔ m < n :=
+  ⟨Nat.lt_of_sub_ne_zero, Nat.sub_ne_zero_of_lt⟩
+
+protected theorem lt_of_sub_pos (h : 0 < n - m) : m < n :=
+  Nat.lt_of_sub_ne_zero (Nat.pos_iff_ne_zero.1 h)
+
+protected theorem lt_of_sub_eq_succ (h : m - n = succ l) : n < m :=
+  Nat.lt_of_sub_pos (h ▸ Nat.zero_lt_succ _)
 
 protected theorem sub_lt_left_of_lt_add {n k m : Nat} (H : n ≤ k) (h : k < n + m) : k - n < m := by
   have := Nat.sub_le_sub_right (succ_le_of_lt h) n
@@ -22,7 +106,27 @@ protected theorem sub_lt_left_of_lt_add {n k m : Nat} (H : n ≤ k) (h : k < n +
 protected theorem sub_lt_right_of_lt_add {n k m : Nat} (H : n ≤ k) (h : k < m + n) : k - n < m :=
   Nat.sub_lt_left_of_lt_add H (Nat.add_comm .. ▸ h)
 
-protected theorem pos_of_ne_zero {n : Nat} : n ≠ 0 → 0 < n := (eq_zero_or_pos n).resolve_left
+protected theorem le_of_sub_eq_zero : ∀ {n m}, n - m = 0 → n ≤ m
+  | 0, _, _ => Nat.zero_le ..
+  | _+1, _+1, h => Nat.succ_le_succ <| Nat.le_of_sub_eq_zero (Nat.succ_sub_succ .. ▸ h)
+
+protected theorem le_of_sub_le_sub_right : ∀ {n m k : Nat}, k ≤ m → n - k ≤ m - k → n ≤ m
+  | 0, _, _, _, _ => Nat.zero_le ..
+  | _+1, _, 0, _, h₁ => h₁
+  | _+1, _+1, _+1, h₀, h₁ => by
+    simp only [Nat.succ_sub_succ] at h₁
+    exact succ_le_succ <| Nat.le_of_sub_le_sub_right (le_of_succ_le_succ h₀) h₁
+
+protected theorem sub_le_sub_iff_right {n : Nat} (h : k ≤ m) : n - k ≤ m - k ↔ n ≤ m :=
+  ⟨Nat.le_of_sub_le_sub_right h, fun h => Nat.sub_le_sub_right h _⟩
+
+protected theorem sub_eq_iff_eq_add {c : Nat} (h : b ≤ a) : a - b = c ↔ a = c + b :=
+  ⟨fun | rfl => by rw [Nat.sub_add_cancel h], fun heq => by rw [heq, Nat.add_sub_cancel]⟩
+
+protected theorem sub_eq_iff_eq_add' {c : Nat} (h : b ≤ a) : a - b = c ↔ a = b + c := by
+  rw [Nat.add_comm, Nat.sub_eq_iff_eq_add h]
+
+/-! ### min/max -/
 
 protected theorem min_eq_min (a : Nat) : Nat.min a b = min a b := rfl
 
@@ -52,15 +156,6 @@ protected theorem le_max_left (a b : Nat) : a ≤ max a b := by rw [Nat.max_def]
 
 protected theorem le_max_right (a b : Nat) : b ≤ max a b := Nat.max_comm .. ▸ Nat.le_max_left ..
 
-protected theorem two_pow_pos (w : Nat) : 0 < 2^w := Nat.pos_pow_of_pos _ (by decide)
-@[deprecated] alias pow_two_pos := Nat.two_pow_pos -- deprecated 2024-02-09
-
-@[simp] protected theorem not_le {a b : Nat} : ¬ a ≤ b ↔ b < a :=
-  ⟨Nat.gt_of_not_le, Nat.not_le_of_gt⟩
-
-@[simp] protected theorem not_lt {a b : Nat} : ¬ a < b ↔ b ≤ a :=
-  ⟨Nat.ge_of_not_lt, flip Nat.not_le_of_gt⟩
-
 protected theorem le_min_of_le_of_le {a b c : Nat} : a ≤ b → a ≤ c → a ≤ min b c := by
   intros; cases Nat.le_total b c with
   | inl h => rw [Nat.min_eq_left h]; assumption
@@ -71,3 +166,133 @@ protected theorem le_min {a b c : Nat} : a ≤ min b c ↔ a ≤ b ∧ a ≤ c :
    fun ⟨h₁, h₂⟩ => Nat.le_min_of_le_of_le h₁ h₂⟩
 
 protected theorem lt_min {a b c : Nat} : a < min b c ↔ a < b ∧ a < c := Nat.le_min
+
+/-! ### div/mod -/
+
+theorem div_eq_sub_div (h₁ : 0 < b) (h₂ : b ≤ a) : a / b = (a - b) / b + 1 := by
+ rw [div_eq a, if_pos]; constructor <;> assumption
+
+
+theorem mod_add_div (m k : Nat) : m % k + k * (m / k) = m := by
+  induction m, k using mod.inductionOn with rw [div_eq, mod_eq]
+  | base x y h => simp [h]
+  | ind x y h IH => simp [h]; rw [Nat.mul_succ, ← Nat.add_assoc, IH, Nat.sub_add_cancel h.2]
+
+@[simp] protected theorem div_one (n : Nat) : n / 1 = n := by
+  have := mod_add_div n 1
+  rwa [mod_one, Nat.zero_add, Nat.one_mul] at this
+
+@[simp] protected theorem div_zero (n : Nat) : n / 0 = 0 := by
+  rw [div_eq]; simp [Nat.lt_irrefl]
+
+@[simp] protected theorem zero_div (b : Nat) : 0 / b = 0 :=
+  (div_eq 0 b).trans <| if_neg <| And.rec Nat.not_le_of_gt
+
+theorem le_div_iff_mul_le (k0 : 0 < k) : x ≤ y / k ↔ x * k ≤ y := by
+  induction y, k using mod.inductionOn generalizing x with
+    (rw [div_eq]; simp [h]; cases x with | zero => simp [zero_le] | succ x => ?_)
+  | base y k h =>
+    simp [not_succ_le_zero x, succ_mul, Nat.add_comm]
+    refine Nat.lt_of_lt_of_le ?_ (Nat.le_add_right ..)
+    exact Nat.not_le.1 fun h' => h ⟨k0, h'⟩
+  | ind y k h IH =>
+    rw [← add_one, Nat.add_le_add_iff_right, IH k0, succ_mul,
+        ← Nat.add_sub_cancel (x*k) k, Nat.sub_le_sub_iff_right h.2, Nat.add_sub_cancel]
+
+theorem div_mul_le_self : ∀ (m n : Nat), m / n * n ≤ m
+  | m, 0   => by simp
+  | m, n+1 => (le_div_iff_mul_le (Nat.succ_pos _)).1 (Nat.le_refl _)
+
+theorem div_lt_iff_lt_mul (Hk : 0 < k) : x / k < y ↔ x < y * k := by
+  rw [← Nat.not_le, ← Nat.not_le]; exact not_congr (le_div_iff_mul_le Hk)
+
+@[simp] theorem add_div_right (x : Nat) {z : Nat} (H : 0 < z) : (x + z) / z = succ (x / z) := by
+  rw [div_eq_sub_div H (Nat.le_add_left _ _), Nat.add_sub_cancel]
+
+@[simp] theorem add_div_left (x : Nat) {z : Nat} (H : 0 < z) : (z + x) / z = succ (x / z) := by
+  rw [Nat.add_comm, add_div_right x H]
+
+theorem add_mul_div_left (x z : Nat) {y : Nat} (H : 0 < y) : (x + y * z) / y = x / y + z := by
+  induction z with
+  | zero => rw [Nat.mul_zero, Nat.add_zero, Nat.add_zero]
+  | succ z ih => rw [mul_succ, ← Nat.add_assoc, add_div_right _ H, ih]; rfl
+
+theorem add_mul_div_right (x y : Nat) {z : Nat} (H : 0 < z) : (x + y * z) / z = x / z + y := by
+  rw [Nat.mul_comm, add_mul_div_left _ _ H]
+
+@[simp] theorem add_mod_right (x z : Nat) : (x + z) % z = x % z := by
+  rw [mod_eq_sub_mod (Nat.le_add_left ..), Nat.add_sub_cancel]
+
+@[simp] theorem add_mod_left (x z : Nat) : (x + z) % x = z % x := by
+  rw [Nat.add_comm, add_mod_right]
+
+@[simp] theorem add_mul_mod_self_left (x y z : Nat) : (x + y * z) % y = x % y := by
+  match z with
+  | 0 => rw [Nat.mul_zero, Nat.add_zero]
+  | succ z => rw [mul_succ, ← Nat.add_assoc, add_mod_right, add_mul_mod_self_left (z := z)]
+
+@[simp] theorem add_mul_mod_self_right (x y z : Nat) : (x + y * z) % z = x % z := by
+  rw [Nat.mul_comm, add_mul_mod_self_left]
+
+@[simp] theorem mul_mod_right (m n : Nat) : (m * n) % m = 0 := by
+  rw [← Nat.zero_add (m * n), add_mul_mod_self_left, zero_mod]
+
+@[simp] theorem mul_mod_left (m n : Nat) : (m * n) % n = 0 := by
+  rw [Nat.mul_comm, mul_mod_right]
+
+protected theorem div_eq_of_lt_le (lo : k * n ≤ m) (hi : m < succ k * n) : m / n = k :=
+have npos : 0 < n := (eq_zero_or_pos _).resolve_left fun hn => by
+  rw [hn, Nat.mul_zero] at hi lo; exact absurd lo (Nat.not_le_of_gt hi)
+Nat.le_antisymm
+  (le_of_lt_succ ((Nat.div_lt_iff_lt_mul npos).2 hi))
+  ((Nat.le_div_iff_mul_le npos).2 lo)
+
+theorem sub_mul_div (x n p : Nat) (h₁ : n*p ≤ x) : (x - n*p) / n = x / n - p := by
+  match eq_zero_or_pos n with
+  | .inl h₀ => rw [h₀, Nat.div_zero, Nat.div_zero, Nat.zero_sub]
+  | .inr h₀ => induction p with
+    | zero => rw [Nat.mul_zero, Nat.sub_zero, Nat.sub_zero]
+    | succ p IH =>
+      have h₂ : n * p ≤ x := Nat.le_trans (Nat.mul_le_mul_left _ (le_succ _)) h₁
+      have h₃ : x - n * p ≥ n := by
+        apply Nat.le_of_add_le_add_right
+        rw [Nat.sub_add_cancel h₂, Nat.add_comm]
+        rw [mul_succ] at h₁
+        exact h₁
+      rw [sub_succ, ← IH h₂, div_eq_sub_div h₀ h₃]
+      simp [add_one, Nat.pred_succ, mul_succ, Nat.sub_sub]
+
+theorem mul_sub_div (x n p : Nat) (h₁ : x < n*p) : (n * p - succ x) / n = p - succ (x / n) := by
+  have npos : 0 < n := (eq_zero_or_pos _).resolve_left fun n0 => by
+    rw [n0, Nat.zero_mul] at h₁; exact not_lt_zero _ h₁
+  apply Nat.div_eq_of_lt_le
+  · rw [Nat.mul_sub_right_distrib, Nat.mul_comm]
+    exact Nat.sub_le_sub_left ((div_lt_iff_lt_mul npos).1 (lt_succ_self _)) _
+  · show succ (pred (n * p - x)) ≤ (succ (pred (p - x / n))) * n
+    rw [succ_pred_eq_of_pos (Nat.sub_pos_of_lt h₁),
+      fun h => succ_pred_eq_of_pos (Nat.sub_pos_of_lt h)] -- TODO: why is the function needed?
+    · rw [Nat.mul_sub_right_distrib, Nat.mul_comm]
+      exact Nat.sub_le_sub_left (div_mul_le_self ..) _
+    · rwa [div_lt_iff_lt_mul npos, Nat.mul_comm]
+
+theorem mul_mod_mul_left (z x y : Nat) : (z * x) % (z * y) = z * (x % y) :=
+  if y0 : y = 0 then by
+    rw [y0, Nat.mul_zero, mod_zero, mod_zero]
+  else if z0 : z = 0 then by
+    rw [z0, Nat.zero_mul, Nat.zero_mul, Nat.zero_mul, mod_zero]
+  else by
+    induction x using Nat.strongInductionOn with
+    | _ n IH =>
+      have y0 : y > 0 := Nat.pos_of_ne_zero y0
+      have z0 : z > 0 := Nat.pos_of_ne_zero z0
+      cases Nat.lt_or_ge n y with
+      | inl yn => rw [mod_eq_of_lt yn, mod_eq_of_lt (Nat.mul_lt_mul_of_pos_left yn z0)]
+      | inr yn =>
+        rw [mod_eq_sub_mod yn, mod_eq_sub_mod (Nat.mul_le_mul_left z yn),
+          ← Nat.mul_sub_left_distrib]
+        exact IH _ (sub_lt (Nat.lt_of_lt_of_le y0 yn) y0)
+
+/-! ### pow -/
+
+protected theorem two_pow_pos (w : Nat) : 0 < 2^w := Nat.pos_pow_of_pos _ (by decide)
+@[deprecated] alias pow_two_pos := Nat.two_pow_pos -- deprecated 2024-02-09

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -7,6 +7,7 @@ import Std.Logic
 import Std.Tactic.Alias
 import Std.Tactic.RCases
 import Std.Data.Nat.Init.Lemmas
+import Std.Data.Nat.Init.Dvd
 import Std.Data.Nat.Basic
 import Std.Data.Ord
 
@@ -142,20 +143,6 @@ theorem recDiagOn_succ_succ {motive : Nat → Nat → Sort _} (zero_zero : motiv
 
 /-! ### le/lt -/
 
-theorem ne_of_gt {a b : Nat} (h : b < a) : a ≠ b := (ne_of_lt h).symm
-alias ne_of_lt' := ne_of_gt
-
-protected alias ⟨lt_of_not_ge, _⟩ := Nat.not_le
-protected alias ⟨lt_of_not_le, not_le_of_lt⟩ := Nat.not_le
-protected alias ⟨_, lt_le_asymm⟩ := Nat.not_le
-
-protected alias ⟨le_of_not_gt, not_lt_of_ge⟩ := Nat.not_lt
-protected alias ⟨le_of_not_lt, not_lt_of_le⟩ := Nat.not_lt
-protected alias ⟨_, le_lt_asymm⟩ := Nat.not_lt
-
-protected theorem le_of_not_le {a b : Nat} (h : ¬ b ≤ a) : a ≤ b := Nat.le_of_lt (Nat.not_le.1 h)
-protected alias le_of_not_ge := Nat.le_of_not_le
-
 protected theorem lt_asymm {a b : Nat} (h : a < b) : ¬ b < a := Nat.not_lt.2 (Nat.le_of_lt h)
 protected alias not_lt_of_gt := Nat.lt_asymm
 protected alias not_lt_of_lt := Nat.lt_asymm
@@ -166,16 +153,6 @@ protected alias lt_iff_le_and_not_ge := Nat.lt_iff_le_not_le
 
 protected theorem lt_iff_le_and_ne {m n : Nat} : m < n ↔ m ≤ n ∧ m ≠ n :=
   ⟨fun h => ⟨Nat.le_of_lt h, Nat.ne_of_lt h⟩, fun h => Nat.lt_of_le_of_ne h.1 h.2⟩
-
-protected theorem le_antisymm_iff {a b : Nat} : a = b ↔ a ≤ b ∧ b ≤ a :=
-  ⟨fun | rfl => ⟨Nat.le_refl _, Nat.le_refl _⟩, fun ⟨hle, hge⟩ => Nat.le_antisymm hle hge⟩
-protected alias eq_iff_le_and_ge := Nat.le_antisymm_iff
-
-protected theorem lt_or_gt_of_ne {a b : Nat} : a ≠ b → a < b ∨ b < a := by
-  rw [← Nat.not_le, ← Nat.not_le, ← Decidable.not_and_iff_or_not_not, and_comm]
-  exact mt Nat.le_antisymm_iff.2
-protected alias lt_or_lt_of_ne := Nat.lt_or_gt_of_ne
-@[deprecated] protected alias lt_connex := Nat.lt_or_gt_of_ne
 
 protected theorem ne_iff_lt_or_gt {a b : Nat} : a ≠ b ↔ a < b ∨ b < a :=
   ⟨Nat.lt_or_gt_of_ne, fun | .inl h => Nat.ne_of_lt h | .inr h => Nat.ne_of_gt h⟩
@@ -265,8 +242,6 @@ protected def sum_trichotomy (a b : Nat) : a < b ⊕' a = b ⊕' b < a :=
 
 /-! ## zero/one/two -/
 
-protected theorem pos_iff_ne_zero : 0 < n ↔ n ≠ 0 := ⟨ne_of_gt, Nat.pos_of_ne_zero⟩
-
 theorem le_zero : i ≤ 0 ↔ i = 0 := ⟨Nat.eq_zero_of_le_zero, fun | rfl => Nat.le_refl _⟩
 
 protected alias one_pos := Nat.zero_lt_one
@@ -296,18 +271,12 @@ theorem lt_succ : m < succ n ↔ m ≤ n := ⟨le_of_lt_succ, lt_succ_of_le⟩
 
 theorem lt_succ_of_lt (h : a < b) : a < succ b := le_succ_of_le h
 
-theorem succ_pred_eq_of_pos : ∀ {n}, 0 < n → succ (pred n) = n
-  | _+1, _ => rfl
-
 theorem succ_pred_eq_of_ne_zero : ∀ {n}, n ≠ 0 → succ (pred n) = n
   | _+1, _ => rfl
 
 theorem eq_zero_or_eq_succ_pred : ∀ n, n = 0 ∨ n = succ (pred n)
   | 0 => .inl rfl
   | _+1 => .inr rfl
-
-theorem exists_eq_succ_of_ne_zero : ∀ {n}, n ≠ 0 → ∃ k, n = succ k
-  | _+1, _ => ⟨_, rfl⟩
 
 theorem succ_inj' : succ a = succ b ↔ a = b := ⟨succ.inj, congrArg _⟩
 
@@ -363,15 +332,8 @@ theorem succ_eq_one_add (n) : succ n = 1 + n := (one_add _).symm
 theorem succ_add_eq_add_succ (a b) : succ a + b = a + succ b := Nat.succ_add ..
 @[deprecated] alias succ_add_eq_succ_add := Nat.succ_add_eq_add_succ
 
-theorem eq_zero_of_add_eq_zero : ∀ {n m}, n + m = 0 → n = 0 ∧ m = 0
-  | 0, 0, _ => ⟨rfl, rfl⟩
-  | _+1, 0, h => Nat.noConfusion h
-
 protected theorem eq_zero_of_add_eq_zero_right (h : n + m = 0) : n = 0 :=
   (Nat.eq_zero_of_add_eq_zero h).1
-
-protected theorem eq_zero_of_add_eq_zero_left (h : n + m = 0) : m = 0 :=
-  (Nat.eq_zero_of_add_eq_zero h).2
 
 protected theorem add_eq_zero_iff : n + m = 0 ↔ n = 0 ∧ m = 0 :=
   ⟨Nat.eq_zero_of_add_eq_zero, fun ⟨h₁, h₂⟩ => h₂.symm ▸ h₁⟩
@@ -384,9 +346,6 @@ protected theorem add_right_cancel_iff {n : Nat} : m + n = k + n ↔ m = k :=
 
 protected theorem add_le_add_iff_left {n : Nat} : n + m ≤ n + k ↔ m ≤ k :=
   ⟨Nat.le_of_add_le_add_left, fun h => Nat.add_le_add_left h _⟩
-
-protected theorem add_le_add_iff_right {n : Nat} : m + n ≤ k + n ↔ m ≤ k :=
-  ⟨Nat.le_of_add_le_add_right, fun h => Nat.add_le_add_right h _⟩
 
 protected theorem lt_of_add_lt_add_right : ∀ {n : Nat}, k + n < m + n → k < m
   | 0, h => h
@@ -444,8 +403,6 @@ protected theorem add_self_ne_one : ∀ n, n + n ≠ 1
 
 /-! ## sub -/
 
-attribute [simp] Nat.zero_sub Nat.add_sub_cancel succ_sub_succ_eq_sub
-
 protected theorem sub_one (n) : n - 1 = pred n := rfl
 
 protected theorem one_sub : ∀ n, 1 - n = if n = 0 then 1 else 0
@@ -469,12 +426,6 @@ protected theorem add_one_sub_one (n : Nat) : (n + 1) - 1 = n := rfl
 
 protected theorem one_add_sub_one (n : Nat) : (1 + n) - 1 = n := Nat.add_sub_cancel_left 1 _
 
-protected theorem sub_eq_iff_eq_add {c : Nat} (h : b ≤ a) : a - b = c ↔ a = c + b :=
-  ⟨fun | rfl => by rw [Nat.sub_add_cancel h], fun heq => by rw [heq, Nat.add_sub_cancel]⟩
-
-protected theorem sub_eq_iff_eq_add' {c : Nat} (h : b ≤ a) : a - b = c ↔ a = b + c := by
-  rw [Nat.add_comm, Nat.sub_eq_iff_eq_add h]
-
 protected theorem sub_sub_self {n m : Nat} (h : m ≤ n) : n - (n - m) = m :=
   (Nat.sub_eq_iff_eq_add (Nat.sub_le ..)).2 (Nat.add_sub_of_le h).symm
 
@@ -482,30 +433,11 @@ protected theorem sub_add_comm {n m k : Nat} (h : k ≤ n) : n + m - k = n - k +
   rw [Nat.sub_eq_iff_eq_add (Nat.le_trans h (Nat.le_add_right ..))]
   rwa [Nat.add_right_comm, Nat.sub_add_cancel]
 
-protected theorem le_of_sub_eq_zero : ∀ {n m}, n - m = 0 → n ≤ m
-  | 0, _, _ => Nat.zero_le ..
-  | _+1, _+1, h => Nat.succ_le_succ <| Nat.le_of_sub_eq_zero (Nat.succ_sub_succ .. ▸ h)
-
 protected theorem sub_eq_zero_iff_le : n - m = 0 ↔ n ≤ m :=
   ⟨Nat.le_of_sub_eq_zero, Nat.sub_eq_zero_of_le⟩
 
-protected theorem lt_of_sub_ne_zero (h : n - m ≠ 0) : m < n :=
-  Nat.not_le.1 (mt Nat.sub_eq_zero_of_le h)
-
-protected theorem sub_ne_zero_iff_lt : n - m ≠ 0 ↔ m < n :=
-  ⟨Nat.lt_of_sub_ne_zero, Nat.sub_ne_zero_of_lt⟩
-
-protected theorem sub_pos_of_lt (h : m < n) : 0 < n - m :=
-  Nat.pos_iff_ne_zero.2 (Nat.sub_ne_zero_of_lt h)
-
-protected theorem lt_of_sub_pos (h : 0 < n - m) : m < n :=
-  Nat.lt_of_sub_ne_zero (Nat.pos_iff_ne_zero.1 h)
-
 protected theorem sub_pos_iff_lt : 0 < n - m ↔ m < n :=
   ⟨Nat.lt_of_sub_pos, Nat.sub_pos_of_lt⟩
-
-protected theorem lt_of_sub_eq_succ (h : m - n = succ l) : n < m :=
-  Nat.lt_of_sub_pos (h ▸ Nat.zero_lt_succ _)
 
 protected theorem sub_le_iff_le_add {a b c : Nat} : a - b ≤ c ↔ a ≤ c + b :=
   ⟨Nat.le_add_of_sub_le, sub_le_of_le_add⟩
@@ -533,20 +465,7 @@ protected theorem le_sub_of_add_le' {n k m : Nat} : m + n ≤ k → n ≤ k - m 
 protected theorem le_sub_iff_add_le' {n : Nat} (h : k ≤ m) : n ≤ m - k ↔ k + n ≤ m :=
   ⟨Nat.add_le_of_le_sub' h, Nat.le_sub_of_add_le'⟩
 
-protected theorem le_of_sub_le_sub_right : ∀ {n m k : Nat}, k ≤ m → n - k ≤ m - k → n ≤ m
-  | 0, _, _, _, _ => Nat.zero_le ..
-  | _+1, _, 0, _, h₁ => h₁
-  | _+1, _+1, _+1, h₀, h₁ => by
-    simp only [Nat.succ_sub_succ] at h₁
-    exact succ_le_succ <| Nat.le_of_sub_le_sub_right (le_of_succ_le_succ h₀) h₁
 @[deprecated] protected alias le_of_le_of_sub_le_sub_right := Nat.le_of_sub_le_sub_right
-
-protected theorem sub_le_sub_iff_right {n : Nat} (h : k ≤ m) : n - k ≤ m - k ↔ n ≤ m :=
-  ⟨Nat.le_of_sub_le_sub_right h, fun h => Nat.sub_le_sub_right h _⟩
-
-protected theorem sub_le_sub_left (h : n ≤ m) (k : Nat) : k - m ≤ k - n :=
-  match m, le.dest h with
-  | _, ⟨a, rfl⟩ => by rw [← Nat.sub_sub]; apply sub_le
 
 protected theorem le_of_sub_le_sub_left : ∀ {n k m : Nat}, n ≤ k → k - m ≤ k - n → n ≤ m
   | 0, _, _, _, _ => Nat.zero_le ..
@@ -884,32 +803,6 @@ protected theorem pos_of_mul_pos_right {a b : Nat} (h : 0 < a * b) : 0 < a := by
 
 -- TODO div_core_congr, div_def
 
-theorem mod_add_div (m k : Nat) : m % k + k * (m / k) = m := by
-  induction m, k using mod.inductionOn with rw [div_eq, mod_eq]
-  | base x y h => simp [h]
-  | ind x y h IH => simp [h]; rw [Nat.mul_succ, ← Nat.add_assoc, IH, Nat.sub_add_cancel h.2]
-
-@[simp] protected theorem div_one (n : Nat) : n / 1 = n := by
-  have := mod_add_div n 1
-  rwa [mod_one, Nat.zero_add, Nat.one_mul] at this
-
-@[simp] protected theorem div_zero (n : Nat) : n / 0 = 0 := by
-  rw [div_eq]; simp [Nat.lt_irrefl]
-
-@[simp] protected theorem zero_div (b : Nat) : 0 / b = 0 :=
-  (div_eq 0 b).trans <| if_neg <| And.rec Nat.not_le_of_gt
-
-theorem le_div_iff_mul_le (k0 : 0 < k) : x ≤ y / k ↔ x * k ≤ y := by
-  induction y, k using mod.inductionOn generalizing x with
-    (rw [div_eq]; simp [h]; cases x with | zero => simp [zero_le] | succ x => ?_)
-  | base y k h =>
-    simp [not_succ_le_zero x, succ_mul, Nat.add_comm]
-    refine Nat.lt_of_lt_of_le ?_ (Nat.le_add_right ..)
-    exact Nat.not_le.1 fun h' => h ⟨k0, h'⟩
-  | ind y k h IH =>
-    rw [← add_one, Nat.add_le_add_iff_right, IH k0, succ_mul,
-        ← Nat.add_sub_cancel (x*k) k, Nat.sub_le_sub_iff_right h.2, Nat.add_sub_cancel]
-
 protected theorem div_le_of_le_mul {m n : Nat} : ∀ {k}, m ≤ k * n → m / k ≤ n
   | 0, _ => by simp [Nat.div_zero, n.zero_le]
   | succ k, h => by
@@ -921,41 +814,10 @@ protected theorem div_le_of_le_mul {m n : Nat} : ∀ {k}, m ≤ k * n → m / k 
     rw [← h2] at h3
     exact Nat.le_trans h1 h3
 
-theorem div_eq_sub_div (h₁ : 0 < b) (h₂ : b ≤ a) : a / b = (a - b) / b + 1 := by
- rw [div_eq a, if_pos]; constructor <;> assumption
-
 theorem div_eq_of_lt (h₀ : a < b) : a / b = 0 := by
   rw [div_eq a, if_neg]
   intro h₁
   apply Nat.not_le_of_gt h₀ h₁.right
-
-theorem div_lt_iff_lt_mul (Hk : 0 < k) : x / k < y ↔ x < y * k := by
-  rw [← Nat.not_le, ← Nat.not_le]; exact not_congr (le_div_iff_mul_le Hk)
-
-theorem sub_mul_div (x n p : Nat) (h₁ : n*p ≤ x) : (x - n*p) / n = x / n - p := by
-  match eq_zero_or_pos n with
-  | .inl h₀ => rw [h₀, Nat.div_zero, Nat.div_zero, Nat.zero_sub]
-  | .inr h₀ => induction p with
-    | zero => rw [Nat.mul_zero, Nat.sub_zero, Nat.sub_zero]
-    | succ p IH =>
-      have h₂ : n * p ≤ x := Nat.le_trans (Nat.mul_le_mul_left _ (le_succ _)) h₁
-      have h₃ : x - n * p ≥ n := by
-        apply Nat.le_of_add_le_add_right
-        rw [Nat.sub_add_cancel h₂, Nat.add_comm]
-        rw [mul_succ] at h₁
-        exact h₁
-      rw [sub_succ, ← IH h₂, div_eq_sub_div h₀ h₃]
-      simp [add_one, Nat.pred_succ, mul_succ, Nat.sub_sub]
-
-theorem div_mul_le_self : ∀ (m n : Nat), m / n * n ≤ m
-  | m, 0   => by simp
-  | m, n+1 => (le_div_iff_mul_le (Nat.succ_pos _)).1 (Nat.le_refl _)
-
-@[simp] theorem add_div_right (x : Nat) {z : Nat} (H : 0 < z) : (x + z) / z = succ (x / z) := by
-  rw [div_eq_sub_div H (Nat.le_add_left _ _), Nat.add_sub_cancel]
-
-@[simp] theorem add_div_left (x : Nat) {z : Nat} (H : 0 < z) : (z + x) / z = succ (x / z) := by
-  rw [Nat.add_comm, add_div_right x H]
 
 @[simp] theorem mul_div_right (n : Nat) {m : Nat} (H : 0 < m) : m * n / m = n := by
   induction n <;> simp_all [mul_succ]
@@ -966,14 +828,6 @@ theorem div_mul_le_self : ∀ (m n : Nat), m / n * n ≤ m
 protected theorem div_self (H : 0 < n) : n / n = 1 := by
   let t := add_div_right 0 H
   rwa [Nat.zero_add, Nat.zero_div] at t
-
-theorem add_mul_div_left (x z : Nat) {y : Nat} (H : 0 < y) : (x + y * z) / y = x / y + z := by
-  induction z with
-  | zero => rw [Nat.mul_zero, Nat.add_zero, Nat.add_zero]
-  | succ z ih => rw [mul_succ, ← Nat.add_assoc, add_div_right _ H, ih]; rfl
-
-theorem add_mul_div_right (x y : Nat) {z : Nat} (H : 0 < z) : (x + y * z) / z = x / z + y := by
-  rw [Nat.mul_comm, add_mul_div_left _ _ H]
 
 protected theorem mul_div_cancel (m : Nat) {n : Nat} (H : 0 < n) : m * n / n = m := by
   let t := add_mul_div_right 0 m H
@@ -987,26 +841,6 @@ by rw [H2, Nat.mul_div_cancel _ H1]
 
 protected theorem div_eq_of_eq_mul_right (H1 : 0 < n) (H2 : m = n * k) : m / n = k :=
 by rw [H2, Nat.mul_div_cancel_left _ H1]
-
-protected theorem div_eq_of_lt_le (lo : k * n ≤ m) (hi : m < succ k * n) : m / n = k :=
-have npos : 0 < n := (eq_zero_or_pos _).resolve_left fun hn => by
-  rw [hn, Nat.mul_zero] at hi lo; exact absurd lo (Nat.not_le_of_gt hi)
-Nat.le_antisymm
-  (le_of_lt_succ ((Nat.div_lt_iff_lt_mul npos).2 hi))
-  ((Nat.le_div_iff_mul_le npos).2 lo)
-
-theorem mul_sub_div (x n p : Nat) (h₁ : x < n*p) : (n * p - succ x) / n = p - succ (x / n) := by
-  have npos : 0 < n := (eq_zero_or_pos _).resolve_left fun n0 => by
-    rw [n0, Nat.zero_mul] at h₁; exact not_lt_zero _ h₁
-  apply Nat.div_eq_of_lt_le
-  · rw [Nat.mul_sub_right_distrib, Nat.mul_comm]
-    exact Nat.sub_le_sub_left ((div_lt_iff_lt_mul npos).1 (lt_succ_self _)) _
-  · show succ (pred (n * p - x)) ≤ (succ (pred (p - x / n))) * n
-    rw [succ_pred_eq_of_pos (Nat.sub_pos_of_lt h₁),
-      fun h => succ_pred_eq_of_pos (Nat.sub_pos_of_lt h)] -- TODO: why is the function needed?
-    · rw [Nat.mul_sub_right_distrib, Nat.mul_comm]
-      exact Nat.sub_le_sub_left (div_mul_le_self ..) _
-    · rwa [div_lt_iff_lt_mul npos, Nat.mul_comm]
 
 protected theorem div_div_eq_div_mul (m n k : Nat) : m / n / k = m / (n * k) := by
   cases eq_zero_or_pos k with
@@ -1043,43 +877,6 @@ theorem mod_two_eq_zero_or_one (n : Nat) : n % 2 = 0 ∨ n % 2 = 1 :=
 
 theorem le_of_mod_lt {a b : Nat} (h : a % b < a) : b ≤ a :=
   Nat.not_lt.1 fun hf => (ne_of_lt h).elim (Nat.mod_eq_of_lt hf)
-
-@[simp] theorem add_mod_right (x z : Nat) : (x + z) % z = x % z := by
-  rw [mod_eq_sub_mod (Nat.le_add_left ..), Nat.add_sub_cancel]
-
-@[simp] theorem add_mod_left (x z : Nat) : (x + z) % x = z % x := by
-  rw [Nat.add_comm, add_mod_right]
-
-@[simp] theorem add_mul_mod_self_left (x y z : Nat) : (x + y * z) % y = x % y := by
-  match z with
-  | 0 => rw [Nat.mul_zero, Nat.add_zero]
-  | succ z => rw [mul_succ, ← Nat.add_assoc, add_mod_right, add_mul_mod_self_left (z := z)]
-
-@[simp] theorem add_mul_mod_self_right (x y z : Nat) : (x + y * z) % z = x % z := by
-  rw [Nat.mul_comm, add_mul_mod_self_left]
-
-@[simp] theorem mul_mod_right (m n : Nat) : (m * n) % m = 0 := by
-  rw [← Nat.zero_add (m * n), add_mul_mod_self_left, zero_mod]
-
-@[simp] theorem mul_mod_left (m n : Nat) : (m * n) % n = 0 := by
-  rw [Nat.mul_comm, mul_mod_right]
-
-theorem mul_mod_mul_left (z x y : Nat) : (z * x) % (z * y) = z * (x % y) :=
-  if y0 : y = 0 then by
-    rw [y0, Nat.mul_zero, mod_zero, mod_zero]
-  else if z0 : z = 0 then by
-    rw [z0, Nat.zero_mul, Nat.zero_mul, Nat.zero_mul, mod_zero]
-  else by
-    induction x using Nat.strongInductionOn with
-    | _ n IH =>
-      have y0 : y > 0 := Nat.pos_of_ne_zero y0
-      have z0 : z > 0 := Nat.pos_of_ne_zero z0
-      cases Nat.lt_or_ge n y with
-      | inl yn => rw [mod_eq_of_lt yn, mod_eq_of_lt (Nat.mul_lt_mul_of_pos_left yn z0)]
-      | inr yn =>
-        rw [mod_eq_sub_mod yn, mod_eq_sub_mod (Nat.mul_le_mul_left z yn),
-          ← Nat.mul_sub_left_distrib]
-        exact IH _ (sub_lt (Nat.lt_of_lt_of_le y0 yn) y0)
 
 theorem mul_mod_mul_right (z x y : Nat) : (x * z) % (y * z) = (x % y) * z := by
   rw [Nat.mul_comm x z, Nat.mul_comm y z, Nat.mul_comm (x % y) z]; apply mul_mod_mul_left
@@ -1277,37 +1074,6 @@ theorem lt_log2_self : n < 2 ^ (n.log2 + 1) :=
 
 /-! ### dvd -/
 
-protected theorem dvd_refl (a : Nat) : a ∣ a := ⟨1, by simp⟩
-
-protected theorem dvd_zero (a : Nat) : a ∣ 0 := ⟨0, by simp⟩
-
-protected theorem dvd_mul_left (a b : Nat) : a ∣ b * a := ⟨b, Nat.mul_comm b a⟩
-
-protected theorem dvd_mul_right (a b : Nat) : a ∣ a * b := ⟨b, rfl⟩
-
-protected theorem dvd_trans {a b c : Nat} (h₁ : a ∣ b) (h₂ : b ∣ c) : a ∣ c :=
-  match h₁, h₂ with
-  | ⟨d, (h₃ : b = a * d)⟩, ⟨e, (h₄ : c = b * e)⟩ =>
-    ⟨d * e, show c = a * (d * e) by simp[h₃,h₄, Nat.mul_assoc]⟩
-
-protected theorem eq_zero_of_zero_dvd {a : Nat} (h : 0 ∣ a) : a = 0 :=
-  let ⟨c, H'⟩ := h; H'.trans c.zero_mul
-
-@[simp] protected theorem zero_dvd {n : Nat} : 0 ∣ n ↔ n = 0 :=
-  ⟨Nat.eq_zero_of_zero_dvd, fun h => h.symm ▸ Nat.dvd_zero 0⟩
-
-protected theorem dvd_add {a b c : Nat} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
-  let ⟨d, hd⟩ := h₁; let ⟨e, he⟩ := h₂; ⟨d + e, by simp [Nat.left_distrib, hd, he]⟩
-
-protected theorem dvd_add_iff_right {k m n : Nat} (h : k ∣ m) : k ∣ n ↔ k ∣ m + n :=
-  ⟨Nat.dvd_add h,
-    match m, h with
-    | _, ⟨d, rfl⟩ => fun ⟨e, he⟩ =>
-      ⟨e - d, by rw [Nat.mul_sub_left_distrib, ← he, Nat.add_sub_cancel_left]⟩⟩
-
-protected theorem dvd_add_iff_left {k m n : Nat} (h : k ∣ n) : k ∣ m ↔ k ∣ m + n := by
-  rw [Nat.add_comm]; exact Nat.dvd_add_iff_right h
-
 theorem dvd_sub {k m n : Nat} (H : n ≤ m) (h₁ : k ∣ m) (h₂ : k ∣ n) : k ∣ m - n :=
   (Nat.dvd_add_iff_left h₂).2 <| by rwa [Nat.sub_add_cancel H]
 
@@ -1321,61 +1087,8 @@ protected theorem mul_dvd_mul_left (a : Nat) (h : b ∣ c) : a * b ∣ a * c :=
 protected theorem mul_dvd_mul_right (h: a ∣ b) (c : Nat) : a * c ∣ b * c :=
   Nat.mul_dvd_mul h (Nat.dvd_refl c)
 
-theorem dvd_mod_iff {k m n : Nat} (h: k ∣ n) : k ∣ m % n ↔ k ∣ m :=
-  have := Nat.dvd_add_iff_left <| Nat.dvd_trans h <| Nat.dvd_mul_right n (m / n)
-  by rwa [mod_add_div] at this
-
-theorem le_of_dvd {m n : Nat} (h : 0 < n) : m ∣ n → m ≤ n
-  | ⟨k, e⟩ => by
-    revert h
-    rw [e]
-    match k with
-    | 0 => intro hn; simp at hn
-    | pk+1 =>
-      intro
-      have := Nat.mul_le_mul_left m (succ_pos pk)
-      rwa [Nat.mul_one] at this
-
-protected theorem dvd_antisymm : ∀ {m n : Nat}, m ∣ n → n ∣ m → m = n
-  | _, 0, _, h₂ => Nat.eq_zero_of_zero_dvd h₂
-  | 0, _, h₁, _ => (Nat.eq_zero_of_zero_dvd h₁).symm
-  | _+1, _+1, h₁, h₂ => Nat.le_antisymm (le_of_dvd (succ_pos _) h₁) (le_of_dvd (succ_pos _) h₂)
-
-theorem pos_of_dvd_of_pos {m n : Nat} (H1 : m ∣ n) (H2 : 0 < n) : 0 < m :=
-  Nat.pos_of_ne_zero fun m0 => Nat.ne_of_gt H2 <| Nat.eq_zero_of_zero_dvd (m0 ▸ H1)
-
-@[simp] protected theorem one_dvd (n : Nat) : 1 ∣ n := ⟨n, n.one_mul.symm⟩
-
-theorem eq_one_of_dvd_one {n : Nat} (H : n ∣ 1) : n = 1 :=
-  Nat.dvd_antisymm H n.one_dvd
-
 @[simp] theorem dvd_one {n : Nat} : n ∣ 1 ↔ n = 1 :=
   ⟨eq_one_of_dvd_one, fun h => h.symm ▸ Nat.dvd_refl _⟩
-
-theorem dvd_of_mod_eq_zero {m n : Nat} (H : n % m = 0) : m ∣ n := by
-  exists n / m
-  have := (mod_add_div n m).symm
-  rwa [H, Nat.zero_add] at this
-
-theorem mod_eq_zero_of_dvd {m n : Nat} (H : m ∣ n) : n % m = 0 := by
-  let ⟨z, H⟩ := H; rw [H, mul_mod_right]
-
-theorem dvd_iff_mod_eq_zero (m n : Nat) : m ∣ n ↔ n % m = 0 :=
-  ⟨mod_eq_zero_of_dvd, dvd_of_mod_eq_zero⟩
-
-theorem emod_pos_of_not_dvd {a b : Nat} (h : ¬ a ∣ b) : 0 < b % a := by
-  rw [dvd_iff_mod_eq_zero] at h
-  exact Nat.pos_of_ne_zero h
-
-instance decidable_dvd : @DecidableRel Nat (·∣·) :=
-  fun _ _ => decidable_of_decidable_of_iff (dvd_iff_mod_eq_zero _ _).symm
-
-protected theorem mul_div_cancel' {n m : Nat} (H : n ∣ m) : n * (m / n) = m := by
-  have := mod_add_div m n
-  rwa [mod_eq_zero_of_dvd H, Nat.zero_add] at this
-
-protected theorem div_mul_cancel {n m : Nat} (H : n ∣ m) : m / n * n = m := by
-  rw [Nat.mul_comm, Nat.mul_div_cancel' H]
 
 protected theorem mul_div_assoc (m : Nat) (H : k ∣ n) : m * n / k = m * (n / k) := by
   match Nat.eq_zero_or_pos k with

--- a/Std/Tactic/Omega/Constraint.lean
+++ b/Std/Tactic/Omega/Constraint.lean
@@ -5,8 +5,8 @@ Authors: Scott Morrison
 -/
 import Std.Classes.Order
 import Std.Tactic.RCases
+import Std.Data.Option.Lemmas
 import Std.Tactic.Omega.Coeffs.IntList
-
 /-!
 A `Constraint` consists of an optional lower and upper bound (inclusive),
 constraining a value to a set of the form `∅`, `{x}`, `[x, y]`, `[x, ∞)`, `(-∞, y]`, or `(-∞, ∞)`.

--- a/Std/Tactic/Omega/IntList.lean
+++ b/Std/Tactic/Omega/IntList.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import Std.Data.List.Init.Lemmas
-import Std.Data.Nat.Gcd
+import Std.Data.Nat.Init.Gcd
 import Std.Data.Int.Init.DivMod
-import Std.Data.Option.Lemmas
+import Std.Data.Option.Init.Lemmas
 import Std.Tactic.Replace
 import Std.Tactic.Simpa
 

--- a/Std/Tactic/Omega/MinNatAbs.lean
+++ b/Std/Tactic/Omega/MinNatAbs.lean
@@ -6,6 +6,7 @@ Authors: Scott Morrison
 import Std.Data.List.Init.Lemmas
 import Std.Data.Int.Init.Order
 import Std.Data.Option.Lemmas
+import Std.Tactic.Init
 import Std.Tactic.LeftRight
 
 /-!


### PR DESCRIPTION
This moves a bunch of lemmas around to remove the remaining lemmas in Std.Data.Nat.Lemmas from Omega's dependencies.

It may lose some organization, but at least the remaining lemmas could potentially use Omega.