### PR TITLE
feat: ∀(x : BitVec w.succ), msb x = 1 iff x >= 2^w

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -117,6 +117,22 @@ private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) :
   else
     simp [h]
 
+
+/-! ### msb -/
+
+theorem msb_decide (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (x.toNat ≥ 2^w) := by
+  simp only [BitVec.msb, getMsb, Nat.zero_lt_succ, decide_True, getLsb, Nat.testBit, Nat.succ_sub_succ_eq_sub, 
+    Nat.sub_zero, Nat.and_one_is_mod, Bool.true_and, ge_iff_le]
+  rw [Nat.shiftRight_eq_div_pow]
+  rcases (Nat.lt_or_ge (BitVec.toNat x) (2 ^ w)) with h | h
+  · simp [Nat.div_eq_of_lt h, h]
+  · simp only [h, decide_True, bne_iff_ne, ne_eq]
+    rw [Nat.div_eq_sub_div (Nat.two_pow_pos _) (by omega), Nat.div_eq_of_lt]
+    · decide
+    · have hxmax : BitVec.toNat x < 2^(Nat.succ w) := x.isLt
+      rw [Nat.pow_succ, Nat.mul_two] at hxmax
+      omega
+
 /-! ### cast -/
 
 @[simp] theorem toNat_cast (e : m = n) (x : BitVec m) : (cast e x).toNat = x.toNat := rfl

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -120,7 +120,7 @@ private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) :
 
 /-! ### msb -/
 
-theorem msb_eq (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (2 ^ w ≤ x.toNat) := by
+theorem msb_eq_decide (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (2 ^ w ≤ x.toNat) := by
   simp only [BitVec.msb, getMsb, Nat.zero_lt_succ,
     decide_True, getLsb, Nat.testBit, Nat.succ_sub_succ_eq_sub,
     Nat.sub_zero, Nat.and_one_is_mod, Bool.true_and, Nat.shiftRight_eq_div_pow]

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -120,7 +120,7 @@ private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) :
 
 /-! ### msb -/
 
-theorem msb_eq_decide (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (2 ^ w ≤ x.toNat) := by
+theorem msb_eq (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (2 ^ w ≤ x.toNat) := by
   simp only [BitVec.msb, getMsb, Nat.zero_lt_succ,
     decide_True, getLsb, Nat.testBit, Nat.succ_sub_succ_eq_sub,
     Nat.sub_zero, Nat.and_one_is_mod, Bool.true_and, Nat.shiftRight_eq_div_pow]

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -121,7 +121,8 @@ private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) :
 /-! ### msb -/
 
 theorem msb_decide (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (x.toNat ≥ 2^w) := by
-  simp only [BitVec.msb, getMsb, Nat.zero_lt_succ, decide_True, getLsb, Nat.testBit, Nat.succ_sub_succ_eq_sub, 
+  simp only [BitVec.msb, getMsb, Nat.zero_lt_succ,
+    decide_True, getLsb, Nat.testBit, Nat.succ_sub_succ_eq_sub,
     Nat.sub_zero, Nat.and_one_is_mod, Bool.true_and, ge_iff_le]
   rw [Nat.shiftRight_eq_div_pow]
   rcases (Nat.lt_or_ge (BitVec.toNat x) (2 ^ w)) with h | h

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -123,15 +123,13 @@ private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) :
 theorem msb_eq_decide (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (2 ^ w ≤ x.toNat) := by
   simp only [BitVec.msb, getMsb, Nat.zero_lt_succ,
     decide_True, getLsb, Nat.testBit, Nat.succ_sub_succ_eq_sub,
-    Nat.sub_zero, Nat.and_one_is_mod, Bool.true_and, ge_iff_le]
-  rw [Nat.shiftRight_eq_div_pow]
+    Nat.sub_zero, Nat.and_one_is_mod, Bool.true_and, Nat.shiftRight_eq_div_pow]
   rcases (Nat.lt_or_ge (BitVec.toNat x) (2 ^ w)) with h | h
   · simp [Nat.div_eq_of_lt h, h]
-  · simp only [h, decide_True, bne_iff_ne, ne_eq]
-    rw [Nat.div_eq_sub_div (Nat.two_pow_pos _) (by omega), Nat.div_eq_of_lt]
+  · simp only [h]
+    rw [Nat.div_eq_sub_div (Nat.two_pow_pos w) h, Nat.div_eq_of_lt]
     · decide
-    · have hxmax : BitVec.toNat x < 2^(Nat.succ w) := x.isLt
-      rw [Nat.pow_succ, Nat.mul_two] at hxmax
+    · have : BitVec.toNat x < 2^w + 2^w := by simpa [Nat.pow_succ, Nat.mul_two] using x.isLt
       omega
 
 /-! ### cast -/

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -120,7 +120,7 @@ private theorem lt_two_pow_of_le {x m n : Nat} (lt : x < 2 ^ m) (le : m ≤ n) :
 
 /-! ### msb -/
 
-theorem msb_decide (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (x.toNat ≥ 2^w) := by
+theorem msb_eq_decide (x : BitVec (Nat.succ w)) : BitVec.msb x = decide (2 ^ w ≤ x.toNat) := by
   simp only [BitVec.msb, getMsb, Nat.zero_lt_succ,
     decide_True, getLsb, Nat.testBit, Nat.succ_sub_succ_eq_sub,
     Nat.sub_zero, Nat.and_one_is_mod, Bool.true_and, ge_iff_le]


### PR DESCRIPTION
This characterizes when the `msb` is 1 in terms of an arithmetic inequality.