### PR TITLE
feat: add toFin_shiftLeft

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -293,6 +293,9 @@ theorem not_def {x : BitVec v} : ~~~x = allOnes v ^^^ x := rfl
     BitVec.toNat (x <<< n) = BitVec.toNat x <<< n % 2^v :=
   BitVec.toNat_ofNat _ _
 
+@[simp] theorem toFin_shiftLeft {n : Nat} (x : BitVec w) :
+    BitVec.toFin (x <<< n) = Fin.ofNat' (x.toNat <<< n) (Nat.two_pow_pos w) := rfl
+
 @[simp] theorem getLsb_shiftLeft (x : BitVec m) (n) :
     getLsb (x <<< n) i = (decide (i < m) && !decide (i < n) && getLsb x (i - n)) := by
   rw [← testBit_toNat, getLsb]


### PR DESCRIPTION
We choose to define the shift on natural numbers and then coercing back to fin with `Fin.ofNat`' to maintain `defeq`.

While shifting is defined on `Fin` [in core](https://github.com/leanprover/lean4/blob/5cc0c3f145ffa623a617ca31387d7f589802c1d3/src/Init/Data/Fin/Basic.lean#L71-L72), the type signature is `Fin -> Fin -> Fin`, while the type signature we want is `Fin -> Nat -> Fin`.

An alternative `rhs` using the `Fin`'s definition of shift would be:

```lean
x.toFin <<< (Fin.ofNat' n (Nat.two_pow_pos _))
```
but this is not a def-eq anymore, so we choose the current implementation instead.
