### PR TITLE
Rat: remove `ext` attribute

### DIFF
--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -13,7 +13,8 @@ import Std.Tactic.Ext
 Rational numbers, implemented as a pair of integers `num / den` such that the
 denominator is positive and the numerator and denominator are coprime.
 -/
-@[ext] structure Rat where
+-- `Rat` is not tagged with the `ext` attribute, since this is more often than not undesirable
+structure Rat where
   /-- Constructs a rational number from components.
   We rename the constructor to `mk'` to avoid a clash with the smart constructor. -/
   mk' ::

--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -28,6 +28,9 @@ structure Rat where
   reduced : num.natAbs.Coprime den := by decide
   deriving DecidableEq
 
+theorem Rat.ext : {p q : Rat} → p.num = q.num → p.den = q.den → p = q
+  | ⟨_,_,_,_⟩, ⟨_,_,_,_⟩, rfl, rfl => rfl
+
 instance : Inhabited Rat := ⟨{ num := 0 }⟩
 
 instance : ToString Rat where

--- a/Std/Data/Rat/Basic.lean
+++ b/Std/Data/Rat/Basic.lean
@@ -28,9 +28,6 @@ structure Rat where
   reduced : num.natAbs.Coprime den := by decide
   deriving DecidableEq
 
-theorem Rat.ext : {p q : Rat} → p.num = q.num → p.den = q.den → p = q
-  | ⟨_,_,_,_⟩, ⟨_,_,_,_⟩, rfl, rfl => rfl
-
 instance : Inhabited Rat := ⟨{ num := 0 }⟩
 
 instance : ToString Rat where

--- a/Std/Data/Rat/Lemmas.lean
+++ b/Std/Data/Rat/Lemmas.lean
@@ -11,6 +11,9 @@ import Std.Tactic.SeqFocus
 
 namespace Rat
 
+theorem ext : {p q : Rat} → p.num = q.num → p.den = q.den → p = q
+  | ⟨_,_,_,_⟩, ⟨_,_,_,_⟩, rfl, rfl => rfl
+
 @[simp] theorem mk_den_one {r : Int} :
     ⟨r, 1, Nat.one_ne_zero, (Nat.coprime_one_right _)⟩ = (r : Rat) := rfl
 


### PR DESCRIPTION
Following [this discussion](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Compute.20roots.20of.20polynomials/near/420643573)*, I would like to remove the `ext` attribute from `Rat` (and manually add the `Rat.ext` lemma).

* The discussion was essentially that `ext` digging into ℚ is like `ext` digging into ℂ and ℂ's `ext` was removed.

  In the specific case, calling `ext` on an equality of polynomials with rational coefficients entered the polynomials through the equality of their coefficients (expected and desirable) and then broke up the (rational) coefficients into their numerators and denominators (undesirable). This leads you astray more often than it is helpful.

This uncovered that `local ext` does not really make the attribute local -- #618.  However, with the refactor introduced in #617 that is now merged, there is no need for `Std` to use the `ext` attribute for `Rat`.  Still, according to a local build, `Mathlib` may need the `Rat.ext` lemma in one file.