### PR TITLE
chore: refactor Backtrack and SolveByElim to remove Nondet dependency

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -63,6 +63,7 @@ import Std.Lean.Meta.DiscrTree
 import Std.Lean.Meta.Expr
 import Std.Lean.Meta.Inaccessible
 import Std.Lean.Meta.InstantiateMVars
+import Std.Lean.Meta.Iterator
 import Std.Lean.Meta.LazyDiscrTree
 import Std.Lean.Meta.SavedState
 import Std.Lean.Meta.Simp

--- a/Std/Lean/Meta/Iterator.lean
+++ b/Std/Lean/Meta/Iterator.lean
@@ -32,7 +32,7 @@ def ofList (l : List α) : MetaM (Iterator α) := do
 Map and filter results of iterator and returning only those values returned
 by `f`.
 -/
-partial def filterMapM (f :  α → MetaM (Option β)) (L : Iterator α) : Iterator β :=
+partial def filterMapM (f : α → MetaM (Option β)) (L : Iterator α) : Iterator β :=
     { next := _next }
   where _next := do
     match ← L.next with

--- a/Std/Lean/Meta/Iterator.lean
+++ b/Std/Lean/Meta/Iterator.lean
@@ -33,7 +33,8 @@ Map and filter results of iterator and returning only those values returned
 by `f`.
 -/
 partial def filterMapM (f :  α → MetaM (Option β)) (L : Iterator α) : Iterator β :=
-  let rec next := do
+    { next := _next }
+  where _next := do
     match ← L.next with
     | none =>
       pure none
@@ -42,10 +43,9 @@ partial def filterMapM (f :  α → MetaM (Option β)) (L : Iterator α) : Itera
       let r ← f v
       match r with
       | none =>
-        next
+        _next
       | some r =>
         pure <| some (r, ←saveState)
-  { next }
 
 /--
 Find the first alternative in a nondeterministic value, as a monadic value.

--- a/Std/Lean/Meta/Iterator.lean
+++ b/Std/Lean/Meta/Iterator.lean
@@ -1,0 +1,68 @@
+import Lean.Meta.Basic
+
+namespace Lean.Meta
+
+/--
+Provides an iterface for iterating over values that are defined in a particular
+meta state.
+-/
+structure Iterator (α : Type) where
+  /-- Function for getting next value and state pair. -/
+  next : MetaM (Option (α × Meta.SavedState))
+
+namespace Iterator
+
+/--
+Convert a list into an iterator with the current state.
+-/
+def ofList (l : List α) : MetaM (Iterator α) := do
+  let s ← saveState
+  let ref ← IO.mkRef l
+  let next := do
+    restoreState s
+    match ← ref.get with
+    | [] =>
+      pure none
+    | r :: l =>
+      ref.set l
+      pure <| some (r, ←saveState)
+  pure { next }
+
+/--
+Map and filter results of iterator and returning only those values returned
+by `f`.
+-/
+partial def filterMapM (f :  α → MetaM (Option β)) (L : Iterator α) : Iterator β :=
+  let rec next := do
+    match ← L.next with
+    | none =>
+      pure none
+    | some (v, s) =>
+      restoreState s
+      let r ← f v
+      match r with
+      | none =>
+        next
+      | some r =>
+        pure <| some (r, ←saveState)
+  { next }
+
+/--
+Find the first alternative in a nondeterministic value, as a monadic value.
+-/
+def head (L : Iterator α) : MetaM α := do
+  match ← L.next with
+  | none =>
+    failure
+  | some (x, s) =>
+    restoreState s
+    pure x
+
+/--
+Return the first value returned by the iterator that `f` succeeds on.
+-/
+def firstM (L : Iterator α) (f : α → MetaM (Option β)) : MetaM β := L.filterMapM f |>.head
+
+end Iterator
+
+end Lean.Meta

--- a/Std/Lean/Meta/Iterator.lean
+++ b/Std/Lean/Meta/Iterator.lean
@@ -3,10 +3,10 @@ import Lean.Meta.Basic
 namespace Lean.Meta
 
 /--
-Provides an iterface for iterating over values that are defined in a particular
-meta state.
+Provides an iterface for iterating over values that are bundled with the `Meta` state
+they are valid in.
 -/
-structure Iterator (α : Type) where
+protected structure Iterator (α : Type) where
   /-- Function for getting next value and state pair. -/
   next : MetaM (Option (α × Meta.SavedState))
 
@@ -15,7 +15,7 @@ namespace Iterator
 /--
 Convert a list into an iterator with the current state.
 -/
-def ofList (l : List α) : MetaM (Iterator α) := do
+def ofList (l : List α) : MetaM (Meta.Iterator α) := do
   let s ← saveState
   let ref ← IO.mkRef l
   let next := do
@@ -32,7 +32,7 @@ def ofList (l : List α) : MetaM (Iterator α) := do
 Map and filter results of iterator and returning only those values returned
 by `f`.
 -/
-partial def filterMapM (f : α → MetaM (Option β)) (L : Iterator α) : Iterator β :=
+partial def filterMapM (f : α → MetaM (Option β)) (L : Meta.Iterator α) : Meta.Iterator β :=
     { next := _next }
   where _next := do
     match ← L.next with
@@ -48,9 +48,10 @@ partial def filterMapM (f : α → MetaM (Option β)) (L : Iterator α) : Iterat
         pure <| some (r, ←saveState)
 
 /--
-Find the first alternative in a nondeterministic value, as a monadic value.
+Find the first value in the iterator while resetting state or call `failure`
+if empty.
 -/
-def head (L : Iterator α) : MetaM α := do
+def head (L : Meta.Iterator α) : MetaM α := do
   match ← L.next with
   | none =>
     failure
@@ -61,7 +62,7 @@ def head (L : Iterator α) : MetaM α := do
 /--
 Return the first value returned by the iterator that `f` succeeds on.
 -/
-def firstM (L : Iterator α) (f : α → MetaM (Option β)) : MetaM β := L.filterMapM f |>.head
+def firstM (L : Meta.Iterator α) (f : α → MetaM (Option β)) : MetaM β := L.filterMapM f |>.head
 
 end Iterator
 

--- a/Std/Tactic/SolveByElim.lean
+++ b/Std/Tactic/SolveByElim.lean
@@ -245,10 +245,10 @@ def elabContextLemmas (g : MVarId) (lemmas : List (TermElabM Expr)) (ctx : TermE
 /-- Returns the list of tactics corresponding to applying the available lemmas to the goal. -/
 def applyLemmas (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))
     (g : MVarId)
-    (f : List MVarId → MetaM (Option (List MVarId)))
-    : MetaM (List MVarId) := do
+    : MetaM (Iterator (List MVarId)) := do
   let es ← elabContextLemmas g lemmas ctx
-  (←applyTactics cfg.toApplyConfig cfg.transparency es g).firstM f
+  applyTactics cfg.toApplyConfig cfg.transparency es g
+
 
 /-- Applies the first possible lemma to the goal. -/
 def applyFirstLemma (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))
@@ -296,7 +296,7 @@ where
   /-- Run either backtracking search, or repeated application, on the list of goals. -/
   run (cfg : Config) : List MVarId → MetaM (List MVarId) :=
     if cfg.backtracking then
-      backtrack' cfg `Meta.Tactic.solveByElim (applyLemmas cfg lemmas ctx)
+      backtrack cfg `Meta.Tactic.solveByElim (applyLemmas cfg lemmas ctx)
     else
       repeat1' (maxIters := cfg.maxDepth) (applyFirstLemma cfg lemmas ctx)
 

--- a/Std/Tactic/SolveByElim.lean
+++ b/Std/Tactic/SolveByElim.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, David Renshaw
 -/
 import Lean.Elab.Tactic.Config
+import Std.Lean.Meta.Iterator
 import Std.Data.Sum.Basic
 import Std.Tactic.LabelAttr
 import Std.Tactic.Relation.Symm
@@ -61,8 +62,8 @@ initialize registerTraceClass `Meta.Tactic.solveByElim
 namespace SolveByElim
 
 /--
-`applyTactics lemmas goal` will return a list of tactics,
-corresponding to applying each one of the lemmas to the goal `goal`.
+`applyTactics lemmas goal` will return an iterator that applies the
+lemmas to the goal `goal` and returns ones that succeed.
 
 Providing this to the `backtracking` tactic,
 we can perform backtracking search based on applying a list of lemmas.
@@ -71,16 +72,18 @@ we can perform backtracking search based on applying a list of lemmas.
 calls to `apply` succeeded or failed.
 -/
 def applyTactics (cfg : ApplyConfig := {}) (transparency : TransparencyMode := .default)
-    (lemmas : List Expr) (g : MVarId) : Nondet MetaM (List MVarId) :=
-  (Nondet.ofList lemmas).filterMapM fun e => observing? do
-    withTraceNode `Meta.Tactic.solveByElim (return m!"{Except.emoji ·} trying to apply: {e}") do
-      let goals ← withTransparency transparency (g.apply e cfg)
-      -- When we call `apply` interactively, `Lean.Elab.Tactic.evalApplyLikeTactic`
-      -- deals with closing new typeclass goals by calling
-      -- `Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing`.
-      -- It seems we can't reuse that machinery down here in `MetaM`,
-      -- so we just settle for trying to close each subgoal using `inferInstance`.
-      goals.filterM fun g => try g.inferInstance; pure false catch _ => pure true
+    (lemmas : List Expr) (g : MVarId) : MetaM (Lean.Meta.Iterator (List Lean.MVarId)) := do
+  pure <|
+    (← Meta.Iterator.ofList lemmas).filterMapM (fun e => observing? do
+      withTraceNode `Meta.Tactic.solveByElim (return m!"{Except.emoji ·} trying to apply: {e}") do
+        let goals ← withTransparency transparency (g.apply e cfg)
+        -- When we call `apply` interactively, `Lean.Elab.Tactic.evalApplyLikeTactic`
+        -- deals with closing new typeclass goals by calling
+        -- `Lean.Elab.Term.synthesizeSyntheticMVarsNoPostponing`.
+        -- It seems we can't reuse that machinery down here in `MetaM`,
+        -- so we just settle for trying to close each subgoal using `inferInstance`.
+        goals.filterM fun g => try g.inferInstance; pure false catch _ => pure true)
+
 
 /--
 `applyFirst lemmas goal` applies the first of the `lemmas`
@@ -89,8 +92,8 @@ which can be successfully applied to `goal`, and fails if none apply.
 We use this in `apply_rules` and `apply_assumption` where backtracking is not needed.
 -/
 def applyFirst (cfg : ApplyConfig := {}) (transparency : TransparencyMode := .default)
-    (lemmas : List Expr) (g : MVarId) : MetaM (List MVarId) :=
-  (applyTactics cfg transparency lemmas g).head
+    (lemmas : List Expr) (g : MVarId) : MetaM (List MVarId) := do
+  (←applyTactics cfg transparency lemmas g).head
 
 /-- The default `maxDepth` for `apply_rules` is higher. -/
 structure ApplyRulesConfig extends BacktrackConfig, ApplyConfig where
@@ -241,9 +244,11 @@ def elabContextLemmas (g : MVarId) (lemmas : List (TermElabM Expr)) (ctx : TermE
 
 /-- Returns the list of tactics corresponding to applying the available lemmas to the goal. -/
 def applyLemmas (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))
-    (g : MVarId) : Nondet MetaM (List MVarId) := Nondet.squash fun _ => do
+    (g : MVarId)
+    (f : List MVarId → MetaM (Option (List MVarId)))
+    : MetaM (List MVarId) := do
   let es ← elabContextLemmas g lemmas ctx
-  return applyTactics cfg.toApplyConfig cfg.transparency es g
+  (←applyTactics cfg.toApplyConfig cfg.transparency es g).firstM f
 
 /-- Applies the first possible lemma to the goal. -/
 def applyFirstLemma (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))
@@ -291,7 +296,7 @@ where
   /-- Run either backtracking search, or repeated application, on the list of goals. -/
   run (cfg : Config) : List MVarId → MetaM (List MVarId) :=
     if cfg.backtracking then
-      backtrack cfg `Meta.Tactic.solveByElim (applyLemmas cfg lemmas ctx)
+      backtrack' cfg `Meta.Tactic.solveByElim (applyLemmas cfg lemmas ctx)
     else
       repeat1' (maxIters := cfg.maxDepth) (applyFirstLemma cfg lemmas ctx)
 

--- a/Std/Tactic/SolveByElim.lean
+++ b/Std/Tactic/SolveByElim.lean
@@ -245,10 +245,9 @@ def elabContextLemmas (g : MVarId) (lemmas : List (TermElabM Expr)) (ctx : TermE
 /-- Returns the list of tactics corresponding to applying the available lemmas to the goal. -/
 def applyLemmas (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))
     (g : MVarId)
-    : MetaM (Iterator (List MVarId)) := do
+    : MetaM (Meta.Iterator (List MVarId)) := do
   let es ← elabContextLemmas g lemmas ctx
   applyTactics cfg.toApplyConfig cfg.transparency es g
-
 
 /-- Applies the first possible lemma to the goal. -/
 def applyFirstLemma (cfg : Config) (lemmas : List (TermElabM Expr)) (ctx : TermElabM (List Expr))

--- a/Std/Tactic/SolveByElim/Backtrack.lean
+++ b/Std/Tactic/SolveByElim/Backtrack.lean
@@ -217,5 +217,5 @@ in `Config`. In the default configuration, `backtrack` will either return an emp
 def backtrack (cfg : BacktrackConfig := {}) (trace : Name := .anonymous)
     (alternatives : MVarId → Nondet MetaM (List MVarId))
     (goals : List MVarId) : MetaM (List MVarId) := do
-  let next (g : MVarId) (fn : List MVarId → MetaM (Option (List MVarId))) := alternatives g |>.firstM fn
+  let next g fn := alternatives g |>.firstM fn
   backtrack' cfg trace next goals

--- a/Std/Tactic/SolveByElim/Backtrack.lean
+++ b/Std/Tactic/SolveByElim/Backtrack.lean
@@ -198,7 +198,7 @@ Returns a list of subgoals which were "suspended" via the `suspend` or
 will either return an empty list or fail.
 -/
 def backtrack (cfg : BacktrackConfig := {}) (trace : Name := .anonymous)
-    (next : MVarId → MetaM (Iterator (List MVarId)))
+    (next : MVarId → MetaM (Meta.Iterator (List MVarId)))
     (goals : List MVarId) : MetaM (List MVarId) := do
   let resolve g f := do (←next g).firstM f
   Backtrack.processIndependentGoals cfg trace resolve goals goals goals


### PR DESCRIPTION
This doesn't remove the import so an existing signature is unchanged, but it effectively replaces the Nondet and implicit MLList dependency in Backtrack and SolveByElim with an iterator.

The iterator has a narrower interface, but a simpler design.

This is a step towards upstreaming library search to Lean 4.