### PR TITLE
feat: `BitVec.toFin_not` lemma

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -285,11 +285,10 @@ theorem not_def {x : BitVec v} : ~~~x = allOnes v ^^^ x := rfl
       · simp
 
 @[simp] theorem toFin_not (x : BitVec w) :
-    (~~~x).toFin = ⟨2^w - 1, Nat.sub_lt (Nat.two_pow_pos _) (Nat.zero_lt_one)⟩ - x.toFin := by
+    (~~~x).toFin = x.toFin.rev := by
   apply Fin.val_inj.mp
-  rw [val_toFin, toNat_not, Fin.coe_sub, ← Nat.sub_add_comm (k:=1) (Nat.two_pow_pos _),
-    Nat.add_sub_assoc, Nat.add_mod_left, Nat.mod_eq_of_lt]
-  <;> omega
+  simp only [val_toFin, toNat_not, Fin.val_rev]
+  omega
 
 @[simp] theorem getLsb_not {x : BitVec v} : (~~~x).getLsb i = (decide (i < v) && ! x.getLsb i) := by
   by_cases h' : i < v <;> simp_all [not_def]

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -284,6 +284,13 @@ theorem not_def {x : BitVec v} : ~~~x = allOnes v ^^^ x := rfl
           _ ≤ 2 ^ i := Nat.pow_le_pow_of_le_right Nat.zero_lt_two w
       · simp
 
+@[simp] theorem toFin_not (x : BitVec w) :
+    (~~~x).toFin = ⟨2^w - 1, Nat.sub_lt (Nat.two_pow_pos _) (Nat.zero_lt_one)⟩ - x.toFin := by
+  apply Fin.val_inj.mp
+  rw [val_toFin, toNat_not, Fin.coe_sub, ← Nat.sub_add_comm (k:=1) (Nat.two_pow_pos _),
+    Nat.add_sub_assoc, Nat.add_mod_left, Nat.mod_eq_of_lt]
+  <;> omega
+
 @[simp] theorem getLsb_not {x : BitVec v} : (~~~x).getLsb i = (decide (i < v) && ! x.getLsb i) := by
   by_cases h' : i < v <;> simp_all [not_def]
 


### PR DESCRIPTION
Adds a lemma to rewrite `toFin (~~~x)`.

There is a slight inconsistency with `toNat_not`, which takes its argument implicitly.
I followed the other `toFin_` lemmas in making the argument explicit, but choose not to change `toNat_not` to keep this PR focussed.

Morally, the result of `toFin (~~~x)` should be `Fin.last _ - x.toFin`. However, this doesn't typecheck, as `Fin.last n` is of type `Fin (n + 1)`. Alternatives that do type-check are:
*  Inline the definition of `Fin.last` to get `⟨2^w - 1, Nat.sub_lt (Nat.two_pow_pos _)⟩`
* Use `Fin.cast`, as in `(Fin.last (2^w-1)).cast (_ : 2^w-1+1 = 2^w)`
* Define `Fin.last' (h : n \neq 0) : Fin n` (using one of the preceding options), and use that

I've chosen to go with the first option (inlining), since it seemed the most straightforward.