### PR TITLE
feat: establish `BitVec.allOnes` as simp normal form

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -234,6 +234,9 @@ private theorem allOnes_def :
   else
     simp [h]
 
+@[simp] theorem negOne_eq_allOnes : -1#w = allOnes w :=
+  rfl
+
 /-! ### or -/
 
 @[simp] theorem toNat_or (x y : BitVec v) :


### PR DESCRIPTION
Adds a lemma `negOne_eq_allOnes`, ensuring that `(-1 : BitVec w)` and `-1#w` are both (transitively) simplified to `allOnes w`.

The choice of `allOnes` as the canonical form was inspired by the fact we already have a few simp-lemmas about it, such as `toNat_allOnes` but also `not_def`. The downside is that `allOnes` is itself defined as `-1`, so we can get a simp loop with `simp [allOnes]`.