### PR TITLE
docs: fix documentation build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ You can generate `std4`'s documentation with
 
 ```text
 # if you're generating documentation for the first time
-> lake -Kdoc=on update
+> lake -R -Kdoc=on update
 ...
 # actually generate the documentation
-> lake -Kdoc=on build Std:docs
+> lake -R -Kdoc=on build Std:docs
 ...
 > ls build/doc/index.html
 build/doc/index.html

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can generate `std4`'s documentation with
 # actually generate the documentation
 > lake -R -Kdoc=on build Std:docs
 ...
-> ls build/doc/index.html
+> open build/doc/index.html
 build/doc/index.html
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can generate `std4`'s documentation with
 # actually generate the documentation
 > lake -R -Kdoc=on build Std:docs
 ...
-> open build/doc/index.html
+> ls build/doc/index.html
 build/doc/index.html
 ```
 


### PR DESCRIPTION
The README documentation build instructions are missing the `-R` flag that needs to be passed to `lake`. This generates configuration files that are read by [doc-gen4](https://github.com/leanprover/doc-gen4).