### PR TITLE
feat: apply dupNamespace linter to instances

### DIFF
--- a/Std/Tactic/Lint/Misc.lean
+++ b/Std/Tactic/Lint/Misc.lean
@@ -24,7 +24,6 @@ This file defines several small linters.
   errorsFound := "DUPLICATED NAMESPACES IN NAME:"
   test declName := do
     if ← isAutoDecl declName then return none
-    if isGlobalInstance (← getEnv) declName then return none
     let nm := declName.components
     let some (dup, _) := nm.zip nm.tail! |>.find? fun (x, y) => x == y
       | return none


### PR DESCRIPTION
This caught 14 bugs with no false positives over in https://github.com/leanprover-community/mathlib4/pull/10899