### PR TITLE
docs: add further build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can generate `std4`'s documentation with
 build/doc/index.html
 ```
 
+After generating the docs, run `lake build -R` to reset the configuration.
+
 The top-level HTML file will be located at `build/doc/Std.html`, though to actually expose the
 documentation as a server you need to
 


### PR DESCRIPTION
This PR adds the changes requested by @digama0 in #669, explaining how to reset build configuration after creating the docs.