### PR TITLE
fix: map_take had unnecessarily specialized universes

### DIFF
--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -890,7 +890,7 @@ theorem take_replicate (a : α) : ∀ n m : Nat, take n (replicate m a) = replic
   | 0, m => by simp [Nat.zero_min]
   | succ n, succ m => by simp [succ_min_succ, take_replicate]
 
-theorem map_take {α β : Type u} (f : α → β) :
+theorem map_take (f : α → β) :
     ∀ (L : List α) (i : Nat), (L.take i).map f = (L.map f).take i
   | [], i => by simp
   | _, 0 => by simp


### PR DESCRIPTION
https://github.com/leanprover/std4/pull/272 unnecessarily specialized the universes of `List.map_take`.

I'm going to merge this immediately, as it's holding up bump Mathlib's Std dependency.