### PR TITLE
chore: remove triv tactic

### DIFF
--- a/Std/Tactic/Init.lean
+++ b/Std/Tactic/Init.lean
@@ -92,13 +92,6 @@ example (h : ∀ x : Nat, x = x → True) : True := by
 elab "eapply " e:term : tactic =>
   evalApplyLikeTactic (·.apply (cfg := {newGoals := .nonDependentOnly})) e
 
-/--
-Tries to solve the goal using a canonical proof of `True`, or the `rfl` tactic.
-Unlike `trivial` or `trivial'`, does not use the `contradiction` tactic.
--/
-macro (name := triv) "triv" : tactic =>
-  `(tactic| first | exact trivial | rfl | fail "triv tactic failed")
-
 /-- `conv` tactic to close a goal using an equality theorem. -/
 macro (name := Conv.exact) "exact " t:term : conv => `(conv| tactic => exact $t)
 

--- a/Std/Tactic/Init.lean
+++ b/Std/Tactic/Init.lean
@@ -92,6 +92,9 @@ example (h : ∀ x : Nat, x = x → True) : True := by
 elab "eapply " e:term : tactic =>
   evalApplyLikeTactic (·.apply (cfg := {newGoals := .nonDependentOnly})) e
 
+/-- Deprecated variant of `trivial`. -/
+elab (name := triv) "triv" : tactic => throwError "`triv` has been removed; use `trivial` instead"
+
 /-- `conv` tactic to close a goal using an equality theorem. -/
 macro (name := Conv.exact) "exact " t:term : conv => `(conv| tactic => exact $t)
 


### PR DESCRIPTION
This is not used in Mathlib; all uses can just become `trivial`. Let's remove the unnecessary duplication.

https://github.com/leanprover-community/mathlib4/pull/11679