### PR TITLE
chore: monadic implementation of classical

### DIFF
--- a/Std/Tactic/Classical.lean
+++ b/Std/Tactic/Classical.lean
@@ -28,8 +28,8 @@ macro (name := classical!) "classical!" : tactic =>
 `classical t` runs `t` in a scope where `Classical.propDecidable` is a low priority
 local instance.
 -/
-def classical [Monad m] [MonadEnv m] [MonadFinally m] [MonadLiftT MetaM m] (t : m Unit) :
-    m Unit := do
+def classical [Monad m] [MonadEnv m] [MonadFinally m] [MonadLiftT MetaM m] (t : m α) :
+    m α := do
   modifyEnv Meta.instanceExtension.pushScope
   Meta.addInstance ``Classical.propDecidable .local 10
   try

--- a/Std/Tactic/Classical.lean
+++ b/Std/Tactic/Classical.lean
@@ -8,7 +8,7 @@ import Lean.Elab.ElabRules
 /-! # `classical` and `classical!` tactics -/
 
 namespace Std.Tactic
-open Lean Meta
+open Lean Meta Elab.Tactic
 
 /--
 `classical!` adds a proof of `Classical.propDecidable` as a local variable, which makes it
@@ -23,6 +23,19 @@ Consider using `classical` instead if you want to use the decidable instance whe
 -/
 macro (name := classical!) "classical!" : tactic =>
   `(tactic| have em := Classical.propDecidable)
+
+/--
+`classical t` runs `t` in a scope where `Classical.propDecidable` is a low priority
+local instance.
+-/
+def classical [Monad m] [MonadEnv m] [MonadFinally m] [MonadLiftT MetaM m] (t : m Unit) :
+    m Unit := do
+  modifyEnv Meta.instanceExtension.pushScope
+  Meta.addInstance ``Classical.propDecidable .local 10
+  try
+    t
+  finally
+    modifyEnv Meta.instanceExtension.popScope
 
 /--
 `classical tacs` runs `tacs` in a scope where `Classical.propDecidable` is a low priority
@@ -45,7 +58,4 @@ scope of the tactic.
 -- FIXME: using ppDedent looks good in the common case, but produces the incorrect result when
 -- the `classical` does not scope over the rest of the block.
 elab "classical" tacs:ppDedent(tacticSeq) : tactic => do
-  modifyEnv Meta.instanceExtension.pushScope
-  Meta.addInstance ``Classical.propDecidable .local 10
-  try Elab.Tactic.evalTactic tacs
-  finally modifyEnv Meta.instanceExtension.popScope
+  classical <| Elab.Tactic.evalTactic tacs


### PR DESCRIPTION
Refactor of `classical` so there is a `MetaM` / `TacticM` level interface.

(This I think will allow Mathlib's tauto to use this, instead of `classical!`, thereby removing the last use of `classical!`. It's a positive change regardless.)