### PR TITLE
chore: use BEq instead of DecidableEq in List additional ops

### DIFF
--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -391,17 +391,17 @@ Constructs the union of two lists, by inserting the elements of `l₁` in revers
 As a result, `l₂` will always be a suffix, but only the last occurrence of each element in `l₁`
 will be retained (but order will otherwise be preserved).
 -/
-@[inline] protected def union [DecidableEq α] (l₁ l₂ : List α) : List α := foldr .insert l₂ l₁
+@[inline] protected def union [BEq α] (l₁ l₂ : List α) : List α := foldr .insert l₂ l₁
 
-instance [DecidableEq α] : Union (List α) := ⟨List.union⟩
+instance [BEq α] : Union (List α) := ⟨List.union⟩
 
 /--
 Constructs the intersection of two lists, by filtering the elements of `l₁` that are in `l₂`.
 Unlike `bagInter` this does not preserve multiplicity: `[1, 1].inter [1]` is `[1, 1]`.
 -/
-@[inline] protected def inter [DecidableEq α] (l₁ l₂ : List α) : List α := filter (· ∈ l₂) l₁
+@[inline] protected def inter [BEq α] (l₁ l₂ : List α) : List α := filter (elem · l₂) l₁
 
-instance [DecidableEq α] : Inter (List α) := ⟨List.inter⟩
+instance [BEq α] : Inter (List α) := ⟨List.inter⟩
 
 /-- `l₁ <+ l₂`, or `Sublist l₁ l₂`, says that `l₁` is a (non-contiguous) subsequence of `l₂`. -/
 inductive Sublist {α} : List α → List α → Prop
@@ -415,11 +415,11 @@ inductive Sublist {α} : List α → List α → Prop
 @[inherit_doc] scoped infixl:50 " <+ " => Sublist
 
 /-- True if the first list is a potentially non-contiguous sub-sequence of the second list. -/
-def isSublist [DecidableEq α] : List α → List α → Bool
+def isSublist [BEq α] : List α → List α → Bool
   | [], _ => true
   | _, [] => false
   | l₁@(hd₁::tl₁), hd₂::tl₂ =>
-    if hd₁ = hd₂
+    if hd₁ == hd₂
     then tl₁.isSublist tl₂
     else l₁.isSublist tl₂
 
@@ -1100,7 +1100,7 @@ instance nodupDecidable [DecidableEq α] : ∀ l : List α, Decidable (Nodup l) 
 Defined as `pwFilter (≠)`.
 
     eraseDup [1, 0, 2, 2, 1] = [0, 2, 1] -/
-@[inline] def eraseDup [DecidableEq α] : List α → List α := pwFilter (· ≠ ·)
+@[inline] def eraseDup [BEq α] : List α → List α := pwFilter (· != ·)
 
 /-- `range' start len step` is the list of numbers `[start, start+step, ..., start+(len-1)*step]`.
   It is intended mainly for proving properties of `range` and `iota`. -/

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -98,9 +98,7 @@ theorem elem_iff [BEq α] [LawfulBEq α] {a : α} {as : List α} :
     elem a as = true ↔ a ∈ as := ⟨mem_of_elem_eq_true, elem_eq_true_of_mem⟩
 
 @[simp] theorem elem_eq_mem [BEq α] [LawfulBEq α] (a : α) (as : List α) :
-    elem a as = decide (a ∈ as) := by
-    apply Bool.eq_iff_iff.mpr
-    simp only [decide_eq_true_eq, elem_iff]
+    elem a as = decide (a ∈ as) := by rw [Bool.eq_iff_iff, elem_iff, decide_eq_true_iff]
 
 theorem mem_of_ne_of_mem {a y : α} {l : List α} (h₁ : a ≠ y) (h₂ : a ∈ y :: l) : a ∈ l :=
   Or.elim (mem_cons.mp h₂) (absurd · h₁) (·)

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -619,7 +619,8 @@ theorem Sublist.eq_of_length_le (s : l₁ <+ l₂) (h : length l₂ ≤ length l
     | refl => apply Sublist.refl
     | step => simp [*, replicate, Sublist.cons]
 
-theorem isSublist_iff_sublist [BEq α] [LawfulBEq α] {l₁ l₂ : List α} : l₁.isSublist l₂ ↔ l₁ <+ l₂ := by
+theorem isSublist_iff_sublist [BEq α] [LawfulBEq α] {l₁ l₂ : List α} :
+    l₁.isSublist l₂ ↔ l₁ <+ l₂ := by
   cases l₁ <;> cases l₂ <;> simp [isSublist]
   case cons.cons hd₁ tl₁ hd₂ tl₂ =>
     if h_eq : hd₁ = hd₂ then

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -94,8 +94,13 @@ theorem append_of_mem {a : α} {l : List α} : a ∈ l → ∃ s t : List α, l 
   | .head l => ⟨[], l, rfl⟩
   | .tail b h => let ⟨s, t, h'⟩ := append_of_mem h; ⟨b::s, t, by rw [h', cons_append]⟩
 
-@[simp] theorem elem_iff [b : BEq α] [LawfulBEq α] {a : α} {as : List α} :
-    @elem _ b a as ↔ a ∈ as := ⟨mem_of_elem_eq_true, elem_eq_true_of_mem⟩
+theorem elem_iff [BEq α] [LawfulBEq α] {a : α} {as : List α} :
+    elem a as = true ↔ a ∈ as := ⟨mem_of_elem_eq_true, elem_eq_true_of_mem⟩
+
+@[simp] theorem elem_eq_mem [BEq α] [LawfulBEq α] (a : α) (as : List α) :
+    elem a as = decide (a ∈ as) := by
+    apply Bool.eq_iff_iff.mpr
+    simp only [decide_eq_true_eq, elem_iff]
 
 theorem mem_of_ne_of_mem {a y : α} {l : List α} (h₁ : a ≠ y) (h₂ : a ∈ y :: l) : a ∈ l :=
   Or.elim (mem_cons.mp h₂) (absurd · h₁) (·)
@@ -1374,11 +1379,10 @@ section insert
 variable [BEq α] [LawfulBEq α]
 
 @[simp] theorem insert_of_mem {l : List α}  (h : a ∈ l) : l.insert a = l := by
-  simp only [List.insert, elem_iff, if_pos h]
+  simp [List.insert, h]
 
 @[simp] theorem insert_of_not_mem {l : List α} (h : a ∉ l) : l.insert a = a :: l := by
-  simp only [List.insert,  elem_iff, if_neg h]
-
+  simp [List.insert, h]
 
 @[simp] theorem mem_insert_iff {l : List α} : a ∈ l.insert b ↔ a = b ∨ a ∈ l := by
   if h : b ∈ l then

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -94,8 +94,8 @@ theorem append_of_mem {a : α} {l : List α} : a ∈ l → ∃ s t : List α, l 
   | .head l => ⟨[], l, rfl⟩
   | .tail b h => let ⟨s, t, h'⟩ := append_of_mem h; ⟨b::s, t, by rw [h', cons_append]⟩
 
-@[simp] theorem elem_iff {_ : DecidableEq α} {a : α} {as : List α} :
-    elem a as ↔ a ∈ as := ⟨mem_of_elem_eq_true, elem_eq_true_of_mem⟩
+@[simp] theorem elem_iff [b : BEq α] [LawfulBEq α] {a : α} {as : List α} :
+    @elem _ b a as ↔ a ∈ as := ⟨mem_of_elem_eq_true, elem_eq_true_of_mem⟩
 
 theorem mem_of_ne_of_mem {a y : α} {l : List α} (h₁ : a ≠ y) (h₂ : a ∈ y :: l) : a ∈ l :=
   Or.elim (mem_cons.mp h₂) (absurd · h₁) (·)
@@ -619,13 +619,13 @@ theorem Sublist.eq_of_length_le (s : l₁ <+ l₂) (h : length l₂ ≤ length l
     | refl => apply Sublist.refl
     | step => simp [*, replicate, Sublist.cons]
 
-theorem isSublist_iff_sublist [DecidableEq α] {l₁ l₂ : List α} : l₁.isSublist l₂ ↔ l₁ <+ l₂ := by
+theorem isSublist_iff_sublist [BEq α] [LawfulBEq α] {l₁ l₂ : List α} : l₁.isSublist l₂ ↔ l₁ <+ l₂ := by
   cases l₁ <;> cases l₂ <;> simp [isSublist]
   case cons.cons hd₁ tl₁ hd₂ tl₂ =>
     if h_eq : hd₁ = hd₂ then
       simp [h_eq, cons_sublist_cons, isSublist_iff_sublist]
     else
-      simp only [h_eq]
+      simp only [beq_iff_eq, h_eq]
       constructor
       · intro h_sub
         apply Sublist.cons
@@ -1370,13 +1370,14 @@ theorem all_eq_not_any_not (l : List α) (p : α → Bool) : l.all p = !l.any (!
 /-! ### insert -/
 
 section insert
-variable [DecidableEq α]
+variable [BEq α] [LawfulBEq α]
 
-@[simp] theorem insert_of_mem {l : List α} (h : a ∈ l) : l.insert a = l := by
+@[simp] theorem insert_of_mem {l : List α}  (h : a ∈ l) : l.insert a = l := by
   simp only [List.insert, elem_iff, if_pos h]
 
 @[simp] theorem insert_of_not_mem {l : List α} (h : a ∉ l) : l.insert a = a :: l := by
   simp only [List.insert,  elem_iff, if_neg h]
+
 
 @[simp] theorem mem_insert_iff {l : List α} : a ∈ l.insert b ↔ a = b ∨ a ∈ l := by
   if h : b ∈ l then
@@ -2002,25 +2003,25 @@ theorem foldr_hom (f : β₁ → β₂) (g₁ : α → β₁ → β₁) (g₂ : 
 
 section union
 
-variable [DecidableEq α]
+variable [BEq α]
 
-theorem union_def [DecidableEq α] (l₁ l₂ : List α)  : l₁ ∪ l₂ = foldr .insert l₂ l₁ := rfl
+theorem union_def [BEq α] (l₁ l₂ : List α)  : l₁ ∪ l₂ = foldr .insert l₂ l₁ := rfl
 
 @[simp] theorem nil_union (l : List α) : nil ∪ l = l := by simp [List.union_def, foldr]
 
 @[simp] theorem cons_union (a : α) (l₁ l₂ : List α) :
     (a :: l₁) ∪ l₂ = (l₁ ∪ l₂).insert a := by simp [List.union_def, foldr]
 
-@[simp] theorem mem_union_iff {_ : DecidableEq α} {x : α} {l₁ l₂ : List α} :
+@[simp] theorem mem_union_iff [LawfulBEq α] {x : α} {l₁ l₂ : List α} :
     x ∈ l₁ ∪ l₂ ↔ x ∈ l₁ ∨ x ∈ l₂ := by induction l₁ <;> simp [*, or_assoc]
 
 end union
 
 /-! ### inter -/
 
-theorem inter_def [DecidableEq α] (l₁ l₂ : List α)  : l₁ ∩ l₂ = filter (· ∈ l₂) l₁ := rfl
+theorem inter_def [BEq α] (l₁ l₂ : List α)  : l₁ ∩ l₂ = filter (elem · l₂) l₁ := rfl
 
-@[simp] theorem mem_inter_iff {_ : DecidableEq α} {x : α} {l₁ l₂ : List α} :
+@[simp] theorem mem_inter_iff [BEq α] [LawfulBEq α]  {x : α} {l₁ l₂ : List α} :
     x ∈ l₁ ∩ l₂ ↔ x ∈ l₁ ∧ x ∈ l₂ := by
   cases l₁ <;> simp [List.inter_def, mem_filter]
 
@@ -2066,13 +2067,14 @@ theorem forIn_eq_bindList [Monad m] [LawfulMonad m]
 /-! ### diff -/
 
 section Diff
--- TODO: theorems about `BEq`
-variable [DecidableEq α]
+variable [BEq α]
+variable [LawfulBEq α]
 
 @[simp] theorem diff_nil (l : List α) : l.diff [] = l := rfl
 
 @[simp] theorem diff_cons (l₁ l₂ : List α) (a : α) : l₁.diff (a :: l₂) = (l₁.erase a).diff l₂ := by
   simp_all [List.diff, erase_of_not_mem]
+
 
 theorem diff_cons_right (l₁ l₂ : List α) (a : α) : l₁.diff (a :: l₂) = (l₁.diff l₂).erase a := by
   apply Eq.symm; induction l₂ generalizing l₁ <;> simp [erase_comm, *]

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -1378,7 +1378,7 @@ theorem all_eq_not_any_not (l : List α) (p : α → Bool) : l.all p = !l.any (!
 section insert
 variable [BEq α] [LawfulBEq α]
 
-@[simp] theorem insert_of_mem {l : List α}  (h : a ∈ l) : l.insert a = l := by
+@[simp] theorem insert_of_mem {l : List α} (h : a ∈ l) : l.insert a = l := by
   simp [List.insert, h]
 
 @[simp] theorem insert_of_not_mem {l : List α} (h : a ∉ l) : l.insert a = a :: l := by
@@ -2026,7 +2026,7 @@ end union
 
 theorem inter_def [BEq α] (l₁ l₂ : List α)  : l₁ ∩ l₂ = filter (elem · l₂) l₁ := rfl
 
-@[simp] theorem mem_inter_iff [BEq α] [LawfulBEq α]  {x : α} {l₁ l₂ : List α} :
+@[simp] theorem mem_inter_iff [BEq α] [LawfulBEq α] {x : α} {l₁ l₂ : List α} :
     x ∈ l₁ ∩ l₂ ↔ x ∈ l₁ ∧ x ∈ l₂ := by
   cases l₁ <;> simp [List.inter_def, mem_filter]
 
@@ -2079,7 +2079,6 @@ variable [LawfulBEq α]
 
 @[simp] theorem diff_cons (l₁ l₂ : List α) (a : α) : l₁.diff (a :: l₂) = (l₁.erase a).diff l₂ := by
   simp_all [List.diff, erase_of_not_mem]
-
 
 theorem diff_cons_right (l₁ l₂ : List α) (a : α) : l₁.diff (a :: l₂) = (l₁.diff l₂).erase a := by
   apply Eq.symm; induction l₂ generalizing l₁ <;> simp [erase_comm, *]

--- a/Std/Data/List/Perm.lean
+++ b/Std/Data/List/Perm.lean
@@ -497,19 +497,15 @@ theorem Perm.diff {l₁ l₂ t₁ t₂ : List α} (hl : l₁ ~ l₂) (ht : t₁ 
 
 theorem Subperm.diff_right {l₁ l₂ : List α} (h : l₁ <+~ l₂) (t : List α) :
     l₁.diff t <+~ l₂.diff t := by
-  induction t generalizing l₁ l₂ h with
-  | nil => simp only [List.diff]; exact h
+  induction t generalizing l₁ l₂ h with simp [List.diff, elem_eq_mem, *]
   | cons x t ih =>
-    simp only [List.diff]; split <;> rename_i hx1
-    · have : x ∈ l₂ := h.subset (mem_of_elem_eq_true hx1)
-      simp [this]
-      apply ih
-      apply h.erase
-    · split <;> rename_i hx2
-      · apply ih
-        have := h.erase x
-        simpa [erase_of_not_mem (hx1 ∘ elem_eq_true_of_mem)] using this
-      · apply ih h
+    split <;> rename_i hx1
+    · simp [h.subset hx1]
+      exact ih (h.erase _)
+    · split
+      · rw [← erase_of_not_mem hx1]
+        exact ih (h.erase _)
+      · exact ih h
 
 theorem erase_cons_subperm_cons_erase (a b : α) (l : List α) :
     (a :: l).erase b <+~ a :: l.erase b := by

--- a/Std/Data/List/Perm.lean
+++ b/Std/Data/List/Perm.lean
@@ -476,14 +476,10 @@ theorem Perm.diff_right {l₁ l₂ : List α} (t : List α) (h : l₁ ~ l₂) : 
   induction t generalizing l₁ l₂ h with simp only [List.diff]
   | nil => exact h
   | cons x t ih =>
-    simp only [elem_eq_mem, decide_eq_true_eq]
-    split <;> rename_i hx
-    · simp only [Perm.mem_iff h] at hx
-      simp [hx]
-      exact ih (h.erase _)
-    · simp only [Perm.mem_iff h] at hx
-      simp [hx]
-      exact ih h
+    simp only [elem_eq_mem, decide_eq_true_eq, Perm.mem_iff h]
+    split
+    · exact ih (h.erase _)
+    · exact ih h
 
 theorem Perm.diff_left (l : List α) {t₁ t₂ : List α} (h : t₁ ~ t₂) : l.diff t₁ = l.diff t₂ := by
   induction h generalizing l with try simp [List.diff]

--- a/Std/Data/List/Perm.lean
+++ b/Std/Data/List/Perm.lean
@@ -476,12 +476,13 @@ theorem Perm.diff_right {l₁ l₂ : List α} (t : List α) (h : l₁ ~ l₂) : 
   induction t generalizing l₁ l₂ h with simp only [List.diff]
   | nil => exact h
   | cons x t ih =>
+    simp only [elem_eq_mem, decide_eq_true_eq]
     split <;> rename_i hx
-    · simp [elem_eq_true_of_mem (h.subset (mem_of_elem_eq_true hx))]
+    · simp only [Perm.mem_iff h] at hx
+      simp [hx]
       exact ih (h.erase _)
-    · have : ¬elem x l₂ = true := fun contra =>
-        hx <| elem_eq_true_of_mem <| h.symm.subset <| mem_of_elem_eq_true contra
-      simp [this]
+    · simp only [Perm.mem_iff h] at hx
+      simp [hx]
       exact ih h
 
 theorem Perm.diff_left (l : List α) {t₁ t₂ : List α} (h : t₁ ~ t₂) : l.diff t₁ = l.diff t₂ := by
@@ -504,9 +505,7 @@ theorem Subperm.diff_right {l₁ l₂ : List α} (h : l₁ <+~ l₂) (t : List �
   | nil => simp only [List.diff]; exact h
   | cons x t ih =>
     simp only [List.diff]; split <;> rename_i hx1
-    · have : elem x l₂ = true := by
-        apply elem_eq_true_of_mem
-        apply h.subset (mem_of_elem_eq_true hx1)
+    · have : x ∈ l₂ := h.subset (mem_of_elem_eq_true hx1)
       simp [this]
       apply ih
       apply h.erase


### PR DESCRIPTION
I've aimed to more consistently use BEq instead of DecidableEq where that is feasible and rely on a LawfulBEq for proofs where needed.