### PR TITLE
feat: cleanup PrintPrefix, use ppSignature

### DIFF
--- a/Std/Tactic/PrintPrefix.lean
+++ b/Std/Tactic/PrintPrefix.lean
@@ -5,9 +5,11 @@ Authors: Shing Tak Lam, Daniel Selsam, Mario Carneiro
 -/
 import Std.Lean.Name
 import Std.Lean.Util.EnvSearch
+import Std.Lean.Delaborator
 import Lean.Elab.Tactic.Config
 
-namespace Lean.Elab.Command
+namespace Std.Tactic
+open Lean Elab Command
 
 /--
 Options to control `#print prefix` command and `getMatchingConstants`.
@@ -28,35 +30,6 @@ structure PrintPrefixConfig where
 
 /-- Function elaborating `Config`. -/
 declare_config_elab elabPrintPrefixConfig PrintPrefixConfig
-
-/--
-The command `#print prefix foo` will print all definitions that start with
-the namespace `foo`.
-
-For example, the command below will print out definitions in the `List` namespace:
-
-```lean
-#print prefix List
-```
-
-`#print prefix` can be controlled by flags in `PrintPrefixConfig`.  These provide
-options for filtering names and formatting.   For example,
-`#print prefix` by default excludes internal names, but this can be controlled
-via config:
-```lean
-#print prefix (config:={internals:=true}) List
-```
-
-By default, `#print prefix` prints the type after each name.  This can be controlled
-by setting `showTypes` to `false`:
-```lean
-#print prefix (config:={showTypes:=false}) List
-```
-
-The complete set of flags can be seen in the documentation
-for `Lean.Elab.Command.PrintPrefixConfig`.
--/
-syntax (name := printPrefix) "#print" "prefix" (Lean.Parser.Tactic.config)? ident : command
 
 /--
 `reverseName name` reverses the components of a name.
@@ -88,12 +61,9 @@ private def matchName (opts : PrintPrefixConfig)
   let (root, post) := takeNameSuffix (nameCnt - preCnt) name
   if root ≠ pre then return false
   if !opts.internals && post.isInternalDetail then return false
+  if opts.propositions != opts.propositionsOnly then return opts.propositions
   let isProp := (Expr.isProp <$> Lean.Meta.inferType cinfo.type) <|> pure false
-  if opts.propositions then do
-    if opts.propositionsOnly && !(←isProp) then return false
-  else do
-    if opts.propositionsOnly || (←isProp) then return false
-  pure true
+  pure <| opts.propositionsOnly == (← isProp)
 
 private def lexNameLt : Name -> Name -> Bool
 | _, .anonymous => false
@@ -103,32 +73,58 @@ private def lexNameLt : Name -> Name -> Bool
 | .str _ _, .num _ _ => false
 | .str p m, .str q n => m < n || m == n && lexNameLt p q
 
-private def appendMatchingConstants (msg : String) (opts : PrintPrefixConfig) (pre : Name)
-     : MetaM String := do
+private def appendMatchingConstants (msg : MessageData) (opts : PrintPrefixConfig) (pre : Name)
+     : MetaM MessageData := do
   let cinfos ← getMatchingConstants (matchName opts pre) opts.imported
   let cinfos := cinfos.qsort fun p q => lexNameLt (reverseName p.name) (reverseName q.name)
   let mut msg := msg
-  let ppInfo cinfo :=
-        if opts.showTypes then do
-          pure s!"{cinfo.name} : {← Meta.ppExpr cinfo.type}\n"
-        else
-          pure s!"{cinfo.name}\n"
+  let ppInfo cinfo : MetaM MessageData := do
+    if opts.showTypes then
+      pure <| .ofPPFormat { pp := fun
+        | some ctx => ctx.runMetaM <|
+          withOptions (pp.tagAppFns.set · true) <| PrettyPrinter.ppSignature cinfo.name
+        | none     => return f!"{cinfo.name}"  -- should never happen
+      } ++ "\n"
+    else
+      pure m!"{ppConst (← mkConstWithLevelParams cinfo.name)}\n"
   for cinfo in cinfos do
     msg := msg ++ (← ppInfo cinfo)
   pure msg
 
 /--
-Implementation for #print prefix
+The command `#print prefix foo` will print all definitions that start with
+the namespace `foo`.
+
+For example, the command below will print out definitions in the `List` namespace:
+
+```lean
+#print prefix List
+```
+
+`#print prefix` can be controlled by flags in `PrintPrefixConfig`.  These provide
+options for filtering names and formatting.   For example,
+`#print prefix` by default excludes internal names, but this can be controlled
+via config:
+```lean
+#print prefix (config := {internals := true}) List
+```
+
+By default, `#print prefix` prints the type after each name.  This can be controlled
+by setting `showTypes` to `false`:
+```lean
+#print prefix (config := {showTypes := false}) List
+```
+
+The complete set of flags can be seen in the documentation
+for `Lean.Elab.Command.PrintPrefixConfig`.
 -/
-@[command_elab printPrefix] def elabPrintPrefix : CommandElab
-| `(#print prefix%$tk $[$cfg:config]? $name:ident) => do
+elab (name := printPrefix) "#print" tk:"prefix"
+    cfg:(Lean.Parser.Tactic.config)? name:ident : command => liftTermElabM do
   let nameId := name.getId
-  liftTermElabM do
-    let opts ← elabPrintPrefixConfig (mkOptionalNode cfg)
-    let mut msg ← appendMatchingConstants "" opts nameId
-    if msg.isEmpty then
-      if let [name] ← resolveGlobalConst name then
-        msg ← appendMatchingConstants msg opts name
-    if !msg.isEmpty then
-      logInfoAt tk msg
-| _ => throwUnsupportedSyntax
+  let opts ← elabPrintPrefixConfig (mkOptionalNode cfg)
+  let mut msg ← appendMatchingConstants "" opts nameId
+  if msg.isEmpty then
+    if let [name] ← resolveGlobalConst name then
+      msg ← appendMatchingConstants msg opts name
+  if !msg.isEmpty then
+    logInfoAt tk msg

--- a/test/print_prefix.lean
+++ b/test/print_prefix.lean
@@ -3,11 +3,11 @@ import Std.Tactic.PrintPrefix
 inductive TEmpty : Type
 /--
 info: TEmpty : Type
-TEmpty.casesOn : (motive : TEmpty → Sort u) → (t : TEmpty) → motive t
-TEmpty.noConfusion : {P : Sort u} → {v1 v2 : TEmpty} → v1 = v2 → TEmpty.noConfusionType P v1 v2
-TEmpty.noConfusionType : Sort u → TEmpty → TEmpty → Sort u
-TEmpty.rec : (motive : TEmpty → Sort u) → (t : TEmpty) → motive t
-TEmpty.recOn : (motive : TEmpty → Sort u) → (t : TEmpty) → motive t
+TEmpty.casesOn.{u} (motive : TEmpty → Sort u) (t : TEmpty) : motive t
+TEmpty.noConfusion.{u} {P : Sort u} {v1 v2 : TEmpty} (h12 : v1 = v2) : TEmpty.noConfusionType P v1 v2
+TEmpty.noConfusionType.{u} (P : Sort u) (v1 v2 : TEmpty) : Sort u
+TEmpty.rec.{u} (motive : TEmpty → Sort u) (t : TEmpty) : motive t
+TEmpty.recOn.{u} (motive : TEmpty → Sort u) (t : TEmpty) : motive t
 -/
 #guard_msgs in
 #print prefix TEmpty -- Test type that probably won't change much.
@@ -15,7 +15,7 @@ TEmpty.recOn : (motive : TEmpty → Sort u) → (t : TEmpty) → motive t
 /--
 -/
 #guard_msgs in
-#print prefix (config:={imported:=false}) Empty
+#print prefix (config := {imported := false}) Empty
 
 namespace EmptyPrefixTest
 
@@ -35,9 +35,7 @@ def foo (_l:List String) : Int := 0
 
 end Prefix.Test
 
-/--
-info: Prefix.Test.foo : List String → Int
--/
+/-- info: Prefix.Test.foo (_l : List String) : Int -/
 #guard_msgs in
 #print prefix Prefix.Test
 
@@ -50,44 +48,52 @@ structure TestStruct where
 
 /--
 info: TestStruct : Type
-TestStruct.bar : TestStruct → Int
-TestStruct.casesOn : {motive : TestStruct → Sort u} → (t : TestStruct) → ((foo bar : Int) → motive { foo := foo, bar := bar }) → motive t
-TestStruct.foo : TestStruct → Int
-TestStruct.mk : Int → Int → TestStruct
-TestStruct.mk.inj : ∀ {foo bar foo_1 bar_1 : Int}, { foo := foo, bar := bar } = { foo := foo_1, bar := bar_1 } → foo = foo_1 ∧ bar = bar_1
-TestStruct.mk.injEq : ∀ (foo bar foo_1 bar_1 : Int),
-  ({ foo := foo, bar := bar } = { foo := foo_1, bar := bar_1 }) = (foo = foo_1 ∧ bar = bar_1)
-TestStruct.mk.sizeOf_spec : ∀ (foo bar : Int), sizeOf { foo := foo, bar := bar } = 1 + sizeOf foo + sizeOf bar
-TestStruct.noConfusion : {P : Sort u} → {v1 v2 : TestStruct} → v1 = v2 → TestStruct.noConfusionType P v1 v2
-TestStruct.noConfusionType : Sort u → TestStruct → TestStruct → Sort u
-TestStruct.rec : {motive : TestStruct → Sort u} → ((foo bar : Int) → motive { foo := foo, bar := bar }) → (t : TestStruct) → motive t
-TestStruct.recOn : {motive : TestStruct → Sort u} → (t : TestStruct) → ((foo bar : Int) → motive { foo := foo, bar := bar }) → motive t
+TestStruct.bar (self : TestStruct) : Int
+TestStruct.casesOn.{u} {motive : TestStruct → Sort u} (t : TestStruct)
+  (mk : (foo bar : Int) → motive { foo := foo, bar := bar }) : motive t
+TestStruct.foo (self : TestStruct) : Int
+TestStruct.mk (foo bar : Int) : TestStruct
+TestStruct.mk.inj {foo bar foo bar : Int} (x✝ : { foo := foo, bar := bar } = { foo := foo, bar := bar }) :
+  foo = foo ∧ bar = bar
+TestStruct.mk.injEq (foo bar foo bar : Int) :
+  ({ foo := foo, bar := bar } = { foo := foo, bar := bar }) = (foo = foo ∧ bar = bar)
+TestStruct.mk.sizeOf_spec (foo bar : Int) : sizeOf { foo := foo, bar := bar } = 1 + sizeOf foo + sizeOf bar
+TestStruct.noConfusion.{u} {P : Sort u} {v1 v2 : TestStruct} (h12 : v1 = v2) : TestStruct.noConfusionType P v1 v2
+TestStruct.noConfusionType.{u} (P : Sort u) (v1 v2 : TestStruct) : Sort u
+TestStruct.rec.{u} {motive : TestStruct → Sort u} (mk : (foo bar : Int) → motive { foo := foo, bar := bar })
+  (t : TestStruct) : motive t
+TestStruct.recOn.{u} {motive : TestStruct → Sort u} (t : TestStruct)
+  (mk : (foo bar : Int) → motive { foo := foo, bar := bar }) : motive t
 -/
 #guard_msgs in
 #print prefix TestStruct
 
 /--
 info: TestStruct : Type
-TestStruct.bar : TestStruct → Int
-TestStruct.casesOn : {motive : TestStruct → Sort u} → (t : TestStruct) → ((foo bar : Int) → motive { foo := foo, bar := bar }) → motive t
-TestStruct.foo : TestStruct → Int
-TestStruct.mk : Int → Int → TestStruct
-TestStruct.noConfusion : {P : Sort u} → {v1 v2 : TestStruct} → v1 = v2 → TestStruct.noConfusionType P v1 v2
-TestStruct.noConfusionType : Sort u → TestStruct → TestStruct → Sort u
-TestStruct.rec : {motive : TestStruct → Sort u} → ((foo bar : Int) → motive { foo := foo, bar := bar }) → (t : TestStruct) → motive t
-TestStruct.recOn : {motive : TestStruct → Sort u} → (t : TestStruct) → ((foo bar : Int) → motive { foo := foo, bar := bar }) → motive t
+TestStruct.bar (self : TestStruct) : Int
+TestStruct.casesOn.{u} {motive : TestStruct → Sort u} (t : TestStruct)
+  (mk : (foo bar : Int) → motive { foo := foo, bar := bar }) : motive t
+TestStruct.foo (self : TestStruct) : Int
+TestStruct.mk (foo bar : Int) : TestStruct
+TestStruct.noConfusion.{u} {P : Sort u} {v1 v2 : TestStruct} (h12 : v1 = v2) : TestStruct.noConfusionType P v1 v2
+TestStruct.noConfusionType.{u} (P : Sort u) (v1 v2 : TestStruct) : Sort u
+TestStruct.rec.{u} {motive : TestStruct → Sort u} (mk : (foo bar : Int) → motive { foo := foo, bar := bar })
+  (t : TestStruct) : motive t
+TestStruct.recOn.{u} {motive : TestStruct → Sort u} (t : TestStruct)
+  (mk : (foo bar : Int) → motive { foo := foo, bar := bar }) : motive t
 -/
 #guard_msgs in
-#print prefix (config:={propositions:=false}) TestStruct
+#print prefix (config := {propositions := false}) TestStruct
 
 /--
-info: TestStruct.mk.inj : ∀ {foo bar foo_1 bar_1 : Int}, { foo := foo, bar := bar } = { foo := foo_1, bar := bar_1 } → foo = foo_1 ∧ bar = bar_1
-TestStruct.mk.injEq : ∀ (foo bar foo_1 bar_1 : Int),
-  ({ foo := foo, bar := bar } = { foo := foo_1, bar := bar_1 }) = (foo = foo_1 ∧ bar = bar_1)
-TestStruct.mk.sizeOf_spec : ∀ (foo bar : Int), sizeOf { foo := foo, bar := bar } = 1 + sizeOf foo + sizeOf bar
+info: TestStruct.mk.inj {foo bar foo bar : Int} (x✝ : { foo := foo, bar := bar } = { foo := foo, bar := bar }) :
+  foo = foo ∧ bar = bar
+TestStruct.mk.injEq (foo bar foo bar : Int) :
+  ({ foo := foo, bar := bar } = { foo := foo, bar := bar }) = (foo = foo ∧ bar = bar)
+TestStruct.mk.sizeOf_spec (foo bar : Int) : sizeOf { foo := foo, bar := bar } = 1 + sizeOf foo + sizeOf bar
 -/
 #guard_msgs in
-#print prefix (config:={propositionsOnly:=true}) TestStruct
+#print prefix (config := {propositionsOnly := true}) TestStruct
 
 /--
 info: TestStruct
@@ -104,7 +110,7 @@ TestStruct.rec
 TestStruct.recOn
 -/
 #guard_msgs in
-#print prefix (config:={showTypes:=false}) TestStruct
+#print prefix (config := {showTypes := false}) TestStruct
 
 /--
 Artificial test function to show #print prefix filters out internals
@@ -118,52 +124,49 @@ def testMatchProof : (n : Nat) → Fin n → Unit
   | _,  ⟨0, _⟩ => ()
   | Nat.succ as, ⟨Nat.succ i, h⟩ => testMatchProof as ⟨i, Nat.le_of_succ_le_succ h⟩
 
-/--
-info: testMatchProof : (n : Nat) → Fin n → Unit
--/
+/-- info: testMatchProof (n : Nat) (a✝ : Fin n) : Unit -/
 #guard_msgs in
 #print prefix testMatchProof
 
 /--
-info: testMatchProof : (n : Nat) → Fin n → Unit
-testMatchProof._cstage1 : (n : Nat) → Fin n → Unit
-testMatchProof._cstage2 : _obj → _obj → _obj
-testMatchProof._sunfold : (n : Nat) → Fin n → Unit
-testMatchProof._unsafe_rec : (n : Nat) → Fin n → Unit
-testMatchProof.match_1 : (motive : (x : Nat) → Fin x → Sort u_1) →
-  (x : Nat) →
-    (x_1 : Fin x) →
-      ((n : Nat) → (isLt : 0 < n) → motive n { val := 0, isLt := isLt }) →
-        ((as i : Nat) → (h : Nat.succ i < Nat.succ as) → motive (Nat.succ as) { val := Nat.succ i, isLt := h }) →
-          motive x x_1
-testMatchProof.match_1._cstage1 : (motive : (x : Nat) → Fin x → Sort u_1) →
-  (x : Nat) →
-    (x_1 : Fin x) →
-      ((n : Nat) → (isLt : 0 < n) → motive n { val := 0, isLt := isLt }) →
-        ((as i : Nat) → (h : Nat.succ i < Nat.succ as) → motive (Nat.succ as) { val := Nat.succ i, isLt := h }) →
-          motive x x_1
-testMatchProof.proof_1 : ∀ (as i : Nat), Nat.succ i < Nat.succ as → Nat.succ i ≤ as
-testMatchProof.proof_2 : ∀ (as i : Nat), Nat.succ i < Nat.succ as → Nat.succ i ≤ as
+info: testMatchProof (n : Nat) (a✝ : Fin n) : Unit
+testMatchProof._cstage1 (n : Nat) (a✝ : Fin n) : Unit
+testMatchProof._cstage2 (x✝x✝¹ : _obj) : _obj
+testMatchProof._sunfold (n : Nat) (a✝ : Fin n) : Unit
+testMatchProof._unsafe_rec (n : Nat) (a✝ : Fin n) : Unit
+testMatchProof.match_1.{u_1} (motive : (x : Nat) → Fin x → Sort u_1) (x✝ : Nat) (x✝¹ : Fin x✝)
+  (h_1 : (n : Nat) → (isLt : 0 < n) → motive n { val := 0, isLt := isLt })
+  (h_2 : (as i : Nat) → (h : Nat.succ i < Nat.succ as) → motive (Nat.succ as) { val := Nat.succ i, isLt := h }) :
+  motive x✝ x✝¹
+testMatchProof.match_1._cstage1.{u_1} (motive : (x : Nat) → Fin x → Sort u_1) (x✝ : Nat) (x✝¹ : Fin x✝)
+  (h_1 : (n : Nat) → (isLt : 0 < n) → motive n { val := 0, isLt := isLt })
+  (h_2 : (as i : Nat) → (h : Nat.succ i < Nat.succ as) → motive (Nat.succ as) { val := Nat.succ i, isLt := h }) :
+  motive x✝ x✝¹
+testMatchProof.proof_1 (as i : Nat) (h : Nat.succ i < Nat.succ as) : Nat.succ i ≤ as
+testMatchProof.proof_2 (as i : Nat) (h : Nat.succ i < Nat.succ as) : Nat.succ i ≤ as
 -/
 #guard_msgs in
-#print prefix (config:={internals:=true}) testMatchProof
+#print prefix (config := {internals := true}) testMatchProof
 
 private inductive TestInd where
 | foo : TestInd
 | bar : TestInd
 
 /--
-info: _private.test.print_prefix.0.TestInd : Type
-_private.test.print_prefix.0.TestInd.bar : TestInd
-_private.test.print_prefix.0.TestInd.bar.sizeOf_spec : sizeOf TestInd.bar = 1
-_private.test.print_prefix.0.TestInd.casesOn : {motive : TestInd → Sort u} → (t : TestInd) → motive TestInd.foo → motive TestInd.bar → motive t
-_private.test.print_prefix.0.TestInd.foo : TestInd
-_private.test.print_prefix.0.TestInd.foo.sizeOf_spec : sizeOf TestInd.foo = 1
-_private.test.print_prefix.0.TestInd.noConfusion : {P : Sort v✝} → {x y : TestInd} → x = y → TestInd.noConfusionType P x y
-_private.test.print_prefix.0.TestInd.noConfusionType : Sort v✝ → TestInd → TestInd → Sort v✝
-_private.test.print_prefix.0.TestInd.rec : {motive : TestInd → Sort u} → motive TestInd.foo → motive TestInd.bar → (t : TestInd) → motive t
-_private.test.print_prefix.0.TestInd.recOn : {motive : TestInd → Sort u} → (t : TestInd) → motive TestInd.foo → motive TestInd.bar → motive t
-_private.test.print_prefix.0.TestInd.toCtorIdx : TestInd → Nat
+info: TestInd : Type
+TestInd.bar : TestInd
+TestInd.bar.sizeOf_spec : sizeOf TestInd.bar = 1
+TestInd.casesOn.{u} {motive : TestInd → Sort u} (t : TestInd) (foo : motive TestInd.foo) (bar : motive TestInd.bar) :
+  motive t
+TestInd.foo : TestInd
+TestInd.foo.sizeOf_spec : sizeOf TestInd.foo = 1
+TestInd.noConfusion.{v✝} {P : Sort v✝} {x y : TestInd} (h : x = y) : TestInd.noConfusionType P x y
+TestInd.noConfusionType.{v✝} (P : Sort v✝) (x y : TestInd) : Sort v✝
+TestInd.rec.{u} {motive : TestInd → Sort u} (foo : motive TestInd.foo) (bar : motive TestInd.bar) (t : TestInd) :
+  motive t
+TestInd.recOn.{u} {motive : TestInd → Sort u} (t : TestInd) (foo : motive TestInd.foo) (bar : motive TestInd.bar) :
+  motive t
+TestInd.toCtorIdx (x✝ : TestInd) : Nat
 -/
 #guard_msgs in
 #print prefix TestInd


### PR DESCRIPTION
Minor cleanup of `PrintPrefix.lean`, plus using `ppSignature` for showing the results (with `pp.tagAppFns` so that the constants are clickable).