### PR TITLE
feat: `#print instances` command

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -92,6 +92,7 @@ import Std.Tactic.NoMatch
 import Std.Tactic.OpenPrivate
 import Std.Tactic.PermuteGoals
 import Std.Tactic.PrintDependents
+import Std.Tactic.PrintInstances
 import Std.Tactic.PrintPrefix
 import Std.Tactic.Relation.Rfl
 import Std.Tactic.SeqFocus

--- a/Std/Tactic/PrintInstances.lean
+++ b/Std/Tactic/PrintInstances.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2024 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import Std.Lean.Name
+import Std.Lean.Util.EnvSearch
+import Lean.Elab.Tactic.Config
+
+namespace Std.Tactic
+open Lean Elab Command Meta
+
+/--
+Options to control `#print instances` command.
+-/
+structure PrintInstancesConfig where
+
+/-- Function elaborating `Config`. -/
+declare_config_elab elabPrintInstancesConfig PrintInstancesConfig
+
+/--
+The command `#print instances foo` will print all definitions that would unify with `foo`
+as the first step in an instance synthesis (see `#synth`). Unlike `#synth`, it allows `_`
+placeholders and will show all matching instances, not just the highest priority instance.
+
+For example, the command below will print out all registered `Monad` instances in the environment:
+
+```lean
+#print instances Monad _
+```
+-/
+elab (name := printInstances) "#print" tk:&"instances"
+    cfg:(Lean.Parser.Tactic.config)? type:term : command =>
+  withoutModifyingEnv <| runTermElabM fun _ => Term.withDeclName `_print_instances_cmd do
+    let {} ← elabPrintInstancesConfig (mkOptionalNode cfg)
+    let type ← Term.elabTerm type none
+    Term.synthesizeSyntheticMVarsNoPostponing
+    show MetaM _ from do
+    let (args, _, _) ← forallMetaTelescope (← inferType type)
+    let type ← instantiateMVars (mkAppN type args)
+    unless ← isType type do throwError "expected a type, got{indentExpr type}"
+    let mvar ← mkFreshExprMVar type
+    let insts ← (← SynthInstance.getInstances type).filterM fun inst => do
+      let s ← saveState
+      try
+        pure (← SynthInstance.tryResolve mvar inst).isSome
+      finally
+        restoreState s
+    let mut msg := m!""
+    for inst in insts.reverse do
+      if let .const c .. := inst.val.getAppFn then
+        msg := msg ++ .ofPPFormat { pp := fun
+          | some ctx => ctx.runMetaM <|
+            withOptions (pp.tagAppFns.set · true) <| PrettyPrinter.ppSignature c
+          | none     => return f!"{c}"  -- should never happen
+        } ++ "\n"
+      else
+        msg := msg ++ m!"{inst.val} : {← inferType inst.val}\n"
+    if !msg.isEmpty then
+      logInfoAt tk msg

--- a/test/print_instances.lean
+++ b/test/print_instances.lean
@@ -1,0 +1,17 @@
+import Std.Tactic.PrintInstances
+
+class Foo (α : Type) : Type
+
+instance fooNat1 : Foo Nat := {}
+instance fooNat2 : Foo Nat := {}
+instance (priority := low) fooProd [Foo α] : Foo (α × α) := {}
+
+variable [localVar : Foo α]
+
+/--
+info: localVar : Foo α
+fooNat2 : Foo Nat
+fooNat1 : Foo Nat
+fooProd {α : Type} [inst✝ : Foo α] : Foo (α × α)
+-/
+#guard_msgs in #print instances Foo


### PR DESCRIPTION
This implements the command `#print instances Foo`, which is similar to `#synth` but shows all matching instances instead of just the first one. (It also only performs one step of instance synthesis instead of iterating.) Instances are shown in priority order (from highest to lowest priority).