### PR TITLE
chore: adapt to renamed fields in Subarray

### DIFF
--- a/Std/Data/Array/Basic.lean
+++ b/Std/Data/Array/Basic.lean
@@ -155,11 +155,11 @@ namespace Subarray
 The empty subarray.
 -/
 protected def empty : Subarray α where
-  as := #[]
+  array := #[]
   start := 0
   stop := 0
-  h₁ := Nat.le_refl 0
-  h₂ := Nat.le_refl 0
+  start_le_stop := Nat.le_refl 0
+  stop_le_array_size := Nat.le_refl 0
 
 instance : EmptyCollection (Subarray α) :=
   ⟨Subarray.empty⟩
@@ -192,7 +192,7 @@ def popHead? (as : Subarray α) : Option (α × Subarray α) :=
       let tail :=
         { as with
           start := as.start + 1
-          h₁ := Nat.le_of_lt_succ $ Nat.succ_lt_succ h  }
+          start_le_stop := Nat.le_of_lt_succ $ Nat.succ_lt_succ h  }
       some (head, tail)
     else
       none

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-04-12
+leanprover/lean4-pr-releases:pr-release-3851


### PR DESCRIPTION
https://github.com/leanprover/lean4/pull/3851 renames three of the fields in `Subarray` to more closely match Lean naming conventions. 