### PR TITLE
chore: move theorems RBMap.{Alter -> Lemmas}

### DIFF
--- a/Std/Data/RBMap/Lemmas.lean
+++ b/Std/Data/RBMap/Lemmas.lean
@@ -507,6 +507,20 @@ theorem size_eq {t : RBNode α} : t.size = t.toList.length := by
   induction t <;> simp [*, find?]
   cases cut _ <;> simp [Ordering.swap]
 
+/--
+Auxiliary definition for `zoom_ins`: set the root of the tree to `v`, creating a node if necessary.
+-/
+def setRoot (v : α) : RBNode α → RBNode α
+  | nil => node red nil v nil
+  | node c a _ b => node c a v b
+
+/--
+Auxiliary definition for `zoom_ins`: set the root of the tree to `v`, creating a node if necessary.
+-/
+def delRoot : RBNode α → RBNode α
+  | nil => nil
+  | node _ a _ b => a.append b
+
 namespace Path
 
 attribute [simp] RootOrdered Ordered
@@ -556,6 +570,15 @@ theorem ordered_iff {p : Path α} :
       fun ⟨⟨hL, ⟨hl, lx⟩, Ll, Lx⟩, hR, LR, lR, xR⟩ =>
        ⟨⟨hL, hR, LR⟩, lx, ⟨Lx, xR⟩, ⟨fun _ ha _ hb => Ll _ hb _ ha, lR⟩, hl⟩⟩
 
+theorem zoom_zoomed₁ (e : zoom cut t path = (t', path')) : t'.OnRoot (cut · = .eq) :=
+  match t, e with
+  | nil, rfl => trivial
+  | node .., e => by
+    revert e; unfold zoom; split
+    · exact zoom_zoomed₁
+    · exact zoom_zoomed₁
+    · next H => intro e; cases e; exact H
+
 @[simp] theorem fill_toList {p : Path α} : (p.fill t).toList = p.withList t.toList := by
   induction p generalizing t <;> simp [*]
 
@@ -573,6 +596,85 @@ theorem _root_.Std.RBNode.zoom_toList {t : RBNode α} (eq : t.zoom cut = (t', p'
 theorem insert_toList {p : Path α} :
     (p.insert t v).toList = p.withList (t.setRoot v).toList := by
   simp [insert]; split <;> simp [setRoot]
+
+protected theorem Balanced.insert {path : Path α} (hp : path.Balanced c₀ n₀ c n) :
+    t.Balanced c n → ∃ c n, (path.insert t v).Balanced c n
+  | .nil => ⟨_, hp.insertNew⟩
+  | .red ha hb => ⟨_, _, hp.fill (.red ha hb)⟩
+  | .black ha hb => ⟨_, _, hp.fill (.black ha hb)⟩
+
+theorem Ordered.insert : ∀ {path : Path α} {t : RBNode α},
+    path.Ordered cmp → t.Ordered cmp → t.All (path.RootOrdered cmp) → path.RootOrdered cmp v →
+    t.OnRoot (cmpEq cmp v) → (path.insert t v).Ordered cmp
+  | _, nil, hp, _, _, vp, _ => hp.insertNew vp
+  | _, node .., hp, ⟨ax, xb, ha, hb⟩, ⟨_, ap, bp⟩, vp, xv => Ordered.fill.2
+    ⟨hp, ⟨ax.imp xv.lt_congr_right.2, xb.imp xv.lt_congr_left.2, ha, hb⟩, vp, ap, bp⟩
+
+theorem Ordered.erase : ∀ {path : Path α} {t : RBNode α},
+    path.Ordered cmp → t.Ordered cmp → t.All (path.RootOrdered cmp) → (path.erase t).Ordered cmp
+  | _, nil, hp, ht, tp => Ordered.fill.2 ⟨hp, ht, tp⟩
+  | _, node .., hp, ⟨ax, xb, ha, hb⟩, ⟨_, ap, bp⟩ => hp.del (ha.append ax xb hb) (ap.append bp)
+
+theorem zoom_ins {t : RBNode α} {cmp : α → α → Ordering} :
+    t.zoom (cmp v) path = (t', path') →
+    path.ins (t.ins cmp v) = path'.ins (t'.setRoot v) := by
+  unfold RBNode.ins; split <;> simp [zoom]
+  · intro | rfl, rfl => rfl
+  all_goals
+  · split
+    · exact zoom_ins
+    · exact zoom_ins
+    · intro | rfl => rfl
+
+theorem insertNew_eq_insert (h : zoom (cmp v) t = (nil, path)) :
+    path.insertNew v = (t.insert cmp v).setBlack :=
+  insert_setBlack .. ▸ (zoom_ins h).symm
+
+theorem ins_eq_fill {path : Path α} {t : RBNode α} :
+    path.Balanced c₀ n₀ c n → t.Balanced c n → path.ins t = (path.fill t).setBlack
+  | .root, h => rfl
+  | .redL hb H, ha | .redR ha H, hb => by unfold ins; exact ins_eq_fill H (.red ha hb)
+  | .blackL hb H, ha => by rw [ins, fill, ← ins_eq_fill H (.black ha hb), balance1_eq ha]
+  | .blackR ha H, hb => by rw [ins, fill, ← ins_eq_fill H (.black ha hb), balance2_eq hb]
+
+theorem zoom_insert {path : Path α} {t : RBNode α} (ht : t.Balanced c n)
+    (H : zoom (cmp v) t = (t', path)) :
+    (path.insert t' v).setBlack = (t.insert cmp v).setBlack := by
+  have ⟨_, _, ht', hp'⟩ := ht.zoom .root H
+  cases ht' with simp [insert]
+  | nil => simp [insertNew_eq_insert H, setBlack_idem]
+  | red hl hr => rw [← ins_eq_fill hp' (.red hl hr), insert_setBlack]; exact (zoom_ins H).symm
+  | black hl hr => rw [← ins_eq_fill hp' (.black hl hr), insert_setBlack]; exact (zoom_ins H).symm
+
+theorem zoom_del {t : RBNode α} :
+    t.zoom cut path = (t', path') →
+    path.del (t.del cut) (match t with | node c .. => c | _ => red) =
+    path'.del t'.delRoot (match t' with | node c .. => c | _ => red) := by
+  unfold RBNode.del; split <;> simp [zoom]
+  · intro | rfl, rfl => rfl
+  · next c a y b =>
+    split
+    · have IH := @zoom_del (t := a)
+      match a with
+      | nil => intro | rfl => rfl
+      | node black .. | node red .. => apply IH
+    · have IH := @zoom_del (t := b)
+      match b with
+      | nil => intro | rfl => rfl
+      | node black .. | node red .. => apply IH
+    · intro | rfl => rfl
+
+/-- Asserts that `p` holds on all elements to the left of the hole. -/
+def AllL (p : α → Prop) : Path α → Prop
+  | .root => True
+  | .left _ parent _ _ => parent.AllL p
+  | .right _ a x parent => a.All p ∧ p x ∧ parent.AllL p
+
+/-- Asserts that `p` holds on all elements to the right of the hole. -/
+def AllR (p : α → Prop) : Path α → Prop
+  | .root => True
+  | .left _ parent x b => parent.AllR p ∧ p x ∧ b.All p
+  | .right _ _ _ parent => parent.AllR p
 
 end Path
 


### PR DESCRIPTION
Using #734 , we can find and remove all unnecessary theorems from `Alter.lean`, minimizing the compile load for someone who just wants the `alter` function without proved properties.