### PR TITLE
feat: RBNode.reverse

### DIFF
--- a/Std/Classes/Order.lean
+++ b/Std/Classes/Order.lean
@@ -88,6 +88,12 @@ theorem cmp_congr_right [TransCmp cmp] (yz : cmp y z = .eq) : cmp x y = cmp x z 
 
 end TransCmp
 
+instance [inst : OrientedCmp cmp] : OrientedCmp (flip cmp) where
+  symm _ _ := inst.symm ..
+
+instance [inst : TransCmp cmp] : TransCmp (flip cmp) where
+  le_trans h1 h2 := inst.le_trans h2 h1
+
 end Std
 
 namespace Ordering

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -696,6 +696,11 @@ theorem getLastD_mem_cons : ∀ (l : List α) (a : α), getLastD l a ∈ a::l
   | [], _ => .head ..
   | _::_, _ => .tail _ <| getLast_mem _
 
+@[simp] theorem getLast?_reverse (l : List α) : l.reverse.getLast? = l.head? := by cases l <;> simp
+
+@[simp] theorem head?_reverse (l : List α) : l.reverse.head? = l.getLast? := by
+  rw [← getLast?_reverse, reverse_reverse]
+
 /-! ### dropLast -/
 
 /-! NB: `dropLast` is the specification for `Array.pop`, so theorems about `List.dropLast`

--- a/Std/Data/RBMap/Basic.lean
+++ b/Std/Data/RBMap/Basic.lean
@@ -267,8 +267,8 @@ def isOrdered (cmp : α → α → Ordering)
 
 /-- The second half of Okasaki's `balance`, concerning red-red sequences in the right child. -/
 @[inline] def balance2 : RBNode α → α → RBNode α → RBNode α
-  | a, x, node red (node red b y c) z d
-  | a, x, node red b y (node red c z d) => node red (node black a x b) y (node black c z d)
+  | a, x, node red b y (node red c z d)
+  | a, x, node red (node red b y c) z d => node red (node black a x b) y (node black c z d)
   | a, x, b                             => node black a x b
 
 /-- Returns `red` if the node is red, otherwise `black`. (Nil nodes are treated as `black`.) -/
@@ -284,10 +284,15 @@ Returns `black` if the node is black, otherwise `red`.
   | node c .. => c
   | _         => red
 
-/-- Change the color of the root to `black`. -/
+/-- Changes the color of the root to `black`. -/
 def setBlack : RBNode α → RBNode α
   | nil          => nil
   | node _ l v r => node black l v r
+
+/-- `O(n)`. Reverses the ordering of the tree without any rebalancing. -/
+@[simp] def reverse : RBNode α → RBNode α
+  | nil          => nil
+  | node c l v r => node c r.reverse v l.reverse
 
 section Insert
 
@@ -897,7 +902,7 @@ variable {α : Type u} {β : Type v} {σ : Type w} {cmp : α → α → Ordering
 
 /-- `O(n)`. Run monadic function `f` on each element of the tree (in increasing order). -/
 @[inline] def forM [Monad m] (f : α → β → m PUnit) (t : RBMap α β cmp) : m PUnit :=
-  t.foldlM (fun _ k v => f k v) ⟨⟩
+  t.1.forM (fun (a, b) => f a b)
 
 instance : ForIn m (RBMap α β cmp) (α × β) := inferInstanceAs (ForIn _ (RBSet ..) _)
 

--- a/Std/Data/RBMap/Basic.lean
+++ b/Std/Data/RBMap/Basic.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura, Mario Carneiro
 import Std.Classes.Order
 import Std.Control.ForInStep.Basic
 import Std.Tactic.Lint.Misc
+import Std.Tactic.Alias
 
 /-!
 # Red-black trees
@@ -55,16 +56,19 @@ open RBColor
 instance : EmptyCollection (RBNode α) := ⟨nil⟩
 
 /-- The minimum element of a tree is the left-most value. -/
-protected def min : RBNode α → Option α
+protected def min? : RBNode α → Option α
   | nil            => none
   | node _ nil v _ => some v
-  | node _ l _ _   => l.min
+  | node _ l _ _   => l.min?
 
 /-- The maximum element of a tree is the right-most value. -/
-protected def max : RBNode α → Option α
+protected def max? : RBNode α → Option α
   | nil            => none
   | node _ _ v nil => some v
-  | node _ _ _ r   => r.max
+  | node _ _ _ r   => r.max?
+
+@[deprecated] protected alias min := RBNode.min?
+@[deprecated] protected alias max := RBNode.max?
 
 /--
 Fold a function in tree order along the nodes. `v₀` is used at `nil` nodes and
@@ -646,10 +650,13 @@ instance : ToStream (RBSet α cmp) (RBNode.Stream α) := ⟨fun x => x.1.toStrea
 @[inline] def toList (t : RBSet α cmp) : List α := t.1.toList
 
 /-- `O(log n)`. Returns the entry `a` such that `a ≤ k` for all keys in the RBSet. -/
-@[inline] protected def min (t : RBSet α cmp) : Option α := t.1.min
+@[inline] protected def min? (t : RBSet α cmp) : Option α := t.1.min?
 
 /-- `O(log n)`. Returns the entry `a` such that `a ≥ k` for all keys in the RBSet. -/
-@[inline] protected def max (t : RBSet α cmp) : Option α := t.1.max
+@[inline] protected def max? (t : RBSet α cmp) : Option α := t.1.max?
+
+@[deprecated] protected alias min := RBSet.min?
+@[deprecated] protected alias max := RBSet.max?
 
 instance [Repr α] : Repr (RBSet α cmp) where
   reprPrec m prec := Repr.addAppParen ("RBSet.ofList " ++ repr m.toList) prec
@@ -751,10 +758,10 @@ instance [BEq α] : BEq (RBSet α cmp) where
 def size (m : RBSet α cmp) : Nat := m.1.size
 
 /-- `O(log n)`. Returns the minimum element of the tree, or panics if the tree is empty. -/
-@[inline] def min! [Inhabited α] (t : RBSet α cmp) : α := t.min.getD (panic! "tree is empty")
+@[inline] def min! [Inhabited α] (t : RBSet α cmp) : α := t.min?.getD (panic! "tree is empty")
 
 /-- `O(log n)`. Returns the maximum element of the tree, or panics if the tree is empty. -/
-@[inline] def max! [Inhabited α] (t : RBSet α cmp) : α := t.max.getD (panic! "tree is empty")
+@[inline] def max! [Inhabited α] (t : RBSet α cmp) : α := t.max?.getD (panic! "tree is empty")
 
 /--
 `O(log n)`. Attempts to find the value with key `k : α` in `t` and panics if there is no such key.
@@ -1002,10 +1009,13 @@ instance : Stream (Values.Stream α β) β := ⟨Values.Stream.next?⟩
 @[inline] def toList : RBMap α β cmp → List (α × β) := RBSet.toList
 
 /-- `O(log n)`. Returns the key-value pair `(a, b)` such that `a ≤ k` for all keys in the RBMap. -/
-@[inline] protected def min : RBMap α β cmp → Option (α × β) := RBSet.min
+@[inline] protected def min? : RBMap α β cmp → Option (α × β) := RBSet.min?
 
 /-- `O(log n)`. Returns the key-value pair `(a, b)` such that `a ≥ k` for all keys in the RBMap. -/
-@[inline] protected def max : RBMap α β cmp → Option (α × β) := RBSet.max
+@[inline] protected def max? : RBMap α β cmp → Option (α × β) := RBSet.max?
+
+@[deprecated] protected alias min := RBMap.min?
+@[deprecated] protected alias max := RBMap.max?
 
 instance [Repr α] [Repr β] : Repr (RBMap α β cmp) where
   reprPrec m prec := Repr.addAppParen ("RBMap.ofList " ++ repr m.toList) prec


### PR DESCRIPTION
- [ ] Depends on: #735

This adds the function `RBNode.reverse` which left-right reverses an RBNode. This is not order-preserving, but it is still an important symmetry and it simplifies some reasoning about left and right rebalancing. It can even be lifted to an operation on `RBSet` and `RBMap` provided it reverses the comparator.