### PR TITLE
fix: Data.List.Lemmas shoud import Data.List.Init.Lemmas on nightly-testing

### DIFF
--- a/Std/Data/Array/Lemmas.lean
+++ b/Std/Data/Array/Lemmas.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 Authors: Mario Carneiro, Gabriel Ebner
 -/
-import Std.Data.List.Init.Lemmas
 import Std.Data.List.Lemmas
 import Std.Data.Array.Init.Lemmas
 import Std.Data.Array.Basic

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn, M
 -/
 import Std.Control.ForInStep.Lemmas
 import Std.Data.Nat.Basic
+import Std.Data.List.Init.Lemmas
 import Std.Data.List.Basic
 import Std.Tactic.Init
 import Std.Tactic.Alias


### PR DESCRIPTION
See [here](https://github.com/leanprover/std4/commit/27766a2bb4a2c743197bcaf56e205b097669f47e#diff-4236f31530e7cfa1ed2974fdb2f8c4d8fbac8cce221f2661b74913ffd6a86bffR10). This was incorrectly merged by the bot in f612c2224402d04fc4aba252296441f7310046dd. The commit 92a9edabd60c57b7652d3237cfcd146190089cd4 fixes the build, but right now on `nightly-testing` the results from `Data.List.Init.Lemmas` are not available when imorting `Data.List.Lemmas`, which I believe is wrong.