### PR TITLE
chore: add `Union` and `SDiff` instances for `Std.RBSet`

### DIFF
--- a/Std/Data/RBMap/Basic.lean
+++ b/Std/Data/RBMap/Basic.lean
@@ -822,6 +822,8 @@ If equal keys exist in both, the key from `t₂` is preferred.
 def union (t₁ t₂ : RBSet α cmp) : RBSet α cmp :=
   t₂.foldl .insert t₁
 
+instance : Union (RBSet α cmp) := ⟨RBSet.union⟩
+
 /--
 `O(n₂ * log (n₁ + n₂))`. Merges the maps `t₁` and `t₂`. If equal keys exist in both,
 then use `mergeFn a₁ a₂` to produce the new merged value.
@@ -856,6 +858,8 @@ def map (t : RBSet α cmpα) (f : α → β) : RBSet β cmpβ :=
 `O(n₁ * (log n₁ + log n₂))`. Constructs the set of all elements of `t₁` that are not in `t₂`.
 -/
 def sdiff (t₁ t₂ : RBSet α cmp) : RBSet α cmp := t₁.filter (!t₂.contains ·)
+
+instance : SDiff (Std.RBSet α cmp) := ⟨RBSet.sdiff⟩
 
 end RBSet
 


### PR DESCRIPTION
There are `union` and `sdiff` function implementations for `Std.RBSet`. But there are no `Union` and `SDiff` class instances, which I find inconsistent.

Is there any reason behind this? I tried asking in Zulip ([thread](https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/Union.20and.20SDiff.20instances.20for.20Std.2ERBSet)). Got no answers so far, prohibiting having these instances. So, I am making this PR.