### PR TITLE
chore: pre-emptive fixes for nightly-2024-05-01

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-04-30
+leanprover/lean4:nightly-2024-05-01


### PR DESCRIPTION
These are pre-emptive fixes for nightly-2024-05-01 (which doesn't exist yet) prepared using a local toolchain. We can merge into `nightly-testing` as soon as it lands.