### PR TITLE
fix: Remove redundant attribute declaration

### DIFF
--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -346,9 +346,6 @@ theorem pairwise_cons_cons :
 
 /-! ### IsChain -/
 
-attribute [simp, grind ←] IsChain.nil
-attribute [simp, grind ←] IsChain.singleton
-
 @[deprecated (since := "2025-09-19")]
 alias chain_cons := isChain_cons_cons
 


### PR DESCRIPTION
We seem to declare these in Data/List/Basic.lean, which this file imports. Therefore I think these are redundant.