### PR TITLE
chore: forward port of lean4#10739

### DIFF
--- a/Batteries/Data/Int.lean
+++ b/Batteries/Data/Int.lean
@@ -54,4 +54,5 @@ theorem testBit_ofBits (f : Fin n → Bool) :
     (ofBits f).testBit i = if h : i < n then f ⟨i, h⟩ else decide (ofBits f < 0) := by
   split <;> simp_all
 
+-- Forward port of lean4#10739
 instance {n : Int} : NeZero (n^0) := ⟨Int.one_ne_zero⟩

--- a/Batteries/Data/Nat/Basic.lean
+++ b/Batteries/Data/Nat/Basic.lean
@@ -109,4 +109,5 @@ Construct a natural number from a sequence of bits using little endian conventio
 @[inline] def ofBits (f : Fin n → Bool) : Nat :=
   Fin.foldr n (fun i v => 2 * v + (f i).toNat) 0
 
+-- Forward port of lean4#10739
 instance {n : Nat} : NeZero (n^0) := ⟨Nat.one_ne_zero⟩


### PR DESCRIPTION
This PR adds two missing NeZero instances for n^0 where n : Nat and n : Int.