### PR TITLE
fix: restrict `Union` and `Inter` instances for `List`

### DIFF
--- a/Batteries/Data/List/Basic.lean
+++ b/Batteries/Data/List/Basic.lean
@@ -79,7 +79,7 @@ will be retained (but order will otherwise be preserved).
 -/
 @[inline] protected def union [BEq α] (l₁ l₂ : List α) : List α := foldr .insert l₂ l₁
 
-instance [BEq α] : Union (List α) := ⟨List.union⟩
+instance [BEq α] [LawfulBEq α] : Union (List α) := ⟨List.union⟩
 
 /--
 Constructs the intersection of two lists, by filtering the elements of `l₁` that are in `l₂`.
@@ -87,7 +87,7 @@ Unlike `bagInter` this does not preserve multiplicity: `[1, 1].inter [1]` is `[1
 -/
 @[inline] protected def inter [BEq α] (l₁ l₂ : List α) : List α := filter (elem · l₂) l₁
 
-instance [BEq α] : Inter (List α) := ⟨List.inter⟩
+instance [BEq α] [LawfulBEq α] : Inter (List α) := ⟨List.inter⟩
 
 /--
 Split a list at an index. Ensures the left list always has the specified length

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -204,25 +204,20 @@ theorem disjoint_of_disjoint_append_right_right (d : Disjoint l (l₁ ++ l₂)) 
 
 /-! ### union -/
 
-section union
+theorem union_def [BEq α] [LawfulBEq α] (l₁ l₂ : List α)  : l₁ ∪ l₂ = foldr .insert l₂ l₁ := rfl
 
-variable [BEq α]
+@[simp, grind =] theorem nil_union [BEq α] [LawfulBEq α] (l : List α) : nil ∪ l = l := by
+  simp [List.union_def, foldr]
 
-theorem union_def (l₁ l₂ : List α)  : l₁ ∪ l₂ = foldr .insert l₂ l₁ := rfl
-
-@[simp, grind =] theorem nil_union (l : List α) : nil ∪ l = l := by simp [List.union_def, foldr]
-
-@[simp, grind =] theorem cons_union (a : α) (l₁ l₂ : List α) :
+@[simp, grind =] theorem cons_union [BEq α] [LawfulBEq α] (a : α) (l₁ l₂ : List α) :
     (a :: l₁) ∪ l₂ = (l₁ ∪ l₂).insert a := by simp [List.union_def, foldr]
 
-@[simp, grind =] theorem mem_union_iff [LawfulBEq α] {x : α} {l₁ l₂ : List α} :
+@[simp, grind =] theorem mem_union_iff [BEq α] [LawfulBEq α] {x : α} {l₁ l₂ : List α} :
     x ∈ l₁ ∪ l₂ ↔ x ∈ l₁ ∨ x ∈ l₂ := by induction l₁ <;> simp [*, or_assoc]
-
-end union
 
 /-! ### inter -/
 
-theorem inter_def [BEq α] (l₁ l₂ : List α)  : l₁ ∩ l₂ = filter (elem · l₂) l₁ := rfl
+theorem inter_def [BEq α] [LawfulBEq α] (l₁ l₂ : List α)  : l₁ ∩ l₂ = filter (elem · l₂) l₁ := rfl
 
 @[simp, grind =] theorem mem_inter_iff [BEq α] [LawfulBEq α] {x : α} {l₁ l₂ : List α} :
     x ∈ l₁ ∩ l₂ ↔ x ∈ l₁ ∧ x ∈ l₂ := by

--- a/Batteries/Data/List/Perm.lean
+++ b/Batteries/Data/List/Perm.lean
@@ -295,7 +295,8 @@ theorem Perm.union [BEq α] [LawfulBEq α] {l₁ l₂ t₁ t₂ : List α} (p₁
     l₁ ∪ t₁ ~ l₂ ∪ t₂ :=
   (p₁.union_right t₁).trans (p₂.union_left l₂)
 
-theorem Perm.inter_right [BEq α] (t₁ : List α) : l₁ ~ l₂ → l₁ ∩ t₁ ~ l₂ ∩ t₁ := .filter _
+theorem Perm.inter_right [BEq α] [LawfulBEq α] (t₁ : List α) :
+    l₁ ~ l₂ → l₁ ∩ t₁ ~ l₂ ∩ t₁ := .filter _
 
 theorem Perm.inter_left [BEq α] [LawfulBEq α] (l : List α) (p : t₁ ~ t₂) : l ∩ t₁ = l ∩ t₂ :=
   filter_congr fun a _ => by simpa using p.mem_iff (a := a)


### PR DESCRIPTION
Closes #1527 