### PR TITLE
fix: address minor breakage after renaming `Std.Iterators.Iterator` to `Std.Iterator`

### DIFF
--- a/Batteries/Data/Array/Match.lean
+++ b/Batteries/Data/Array/Match.lean
@@ -105,7 +105,7 @@ partial def Matcher.next? [BEq α] [Std.Stream σ α] (m : Matcher α) (stream :
       next? { m with state } stream
 
 namespace Matcher
-open Std.Iterators
+open Std Std.Iterators
 
 /-- Iterator transformer for KMP matcher. -/
 protected structure Iterator (σ n α) [BEq α] (m : Matcher α) [Iterator σ n α] where


### PR DESCRIPTION
This PR opens `Std` in `Batteries.Data.Array.Match`. This is necessary because `Std.Iterators.Iterator` is being renamed to `Std.Iterator` and said module, having opened only `Std.Iterators`, refers to it simply as `Iterator`.