### PR TITLE
chore: remove unneeded experimental.module option

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -5,7 +5,6 @@ defaultTargets = ["Batteries", "runLinter"]
 
 [leanOptions]
 linter.missingDocs = true
-experimental.module = true
 # We prefix this with `weak.` so that running `lake new my_project math`
 # with an older default toolchain doesn't fail when running the Mathlib post update hook.
 # This option should be removed entirely once Batteries stops using `backward.privateInPublic`.


### PR DESCRIPTION
The `experimental.module` option is no longer necessary with v4.27.0-rc1.