### PR TITLE
fix: prevent empty grep pattern from matching all lean-pr-testing branches

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -90,6 +90,17 @@ jobs:
         PRS="${{ steps.get-prs.outputs.prs }}"
         echo "=== PRS ========================="
         echo "$PRS"
+
+        # CRITICAL: If no PRs were found, skip branch matching entirely.
+        # An empty prs.txt causes `grep -f prs.txt` to match ALL lines,
+        # which would incorrectly select every lean-pr-testing branch!
+        if [ -z "$PRS" ]; then
+          echo "No PRs found between old and new nightlies. Skipping branch discovery."
+          echo "branches_exist=false" >> "$GITHUB_ENV"
+          printf "branches<<EOF\n\nEOF" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         echo "$PRS" | tr ' ' '\n' > prs.txt
         echo "=== prs.txt ====================="
         cat prs.txt


### PR DESCRIPTION
This PR fixes a critical bug in the discover-lean-pr-testing workflow.

When no PRs are found between old and new nightlies, the `prs.txt` file becomes empty. An empty file passed to `grep -f` matches ALL lines, causing every lean-pr-testing branch to be selected for merging.

This was discovered when it caused 600+ lean-pr-testing branches to be incorrectly merged into mathlib4's nightly-testing branch. See the corresponding fix in mathlib4: https://github.com/leanprover-community/mathlib4/pull/33546

The fix adds an early exit check when PRS is empty, skipping branch discovery entirely in that case.

🤖 Prepared with Claude Code