### PR TITLE
chore: clean up `Batteries.Tactic.Lint`

### DIFF
--- a/Batteries/Tactic/Lint.lean
+++ b/Batteries/Tactic/Lint.lean
@@ -1,6 +1,7 @@
 module
 
-public meta import Batteries.Tactic.Lint.Misc
-public meta import Batteries.Tactic.Lint.Simp
-public meta import Batteries.Tactic.Lint.TypeClass
-public meta import Batteries.Tactic.Lint.Frontend
+public import Batteries.Tactic.Lint.Basic
+public import Batteries.Tactic.Lint.Misc
+public import Batteries.Tactic.Lint.Simp
+public import Batteries.Tactic.Lint.TypeClass
+public import Batteries.Tactic.Lint.Frontend


### PR DESCRIPTION
It did not list `.Basic` and the `meta`s are a porting artifact. This confused Shake at https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.23lint.20is.20broken.