### PR TITLE
feat: linter accepts multiple modules to lint

### DIFF
--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -180,7 +180,7 @@ unsafe def runLinterOnModule (cfg : LinterConfig) (module : Name) : IO Unit := d
       IO.println s!"-- Linting passed for {module}."
 
 /--
-Usage: `runLinter [--update] [--trace | -v] [--no-build][Batteries.Data.Nat.Basic]...`
+Usage: `runLinter [--update] [--trace | -v] [--no-build] [Batteries.Data.Nat.Basic]...`
 
 Runs the linters on all declarations in the given modules
 (or all root modules of Lake `lean_lib` and `lean_exe` default targets if no module is specified).


### PR DESCRIPTION
Since the linter can lint multiple targets when there are multiple `defaultTargets`, it feels reasonable to also make it accept multiple modules on the command-line.

This is particularly useful in the CI when I want to lint multiple targets that are not part of `defaultTargets`.