### PR TITLE
fix: Early runLinter exit with IO.Process.exit to avoid deadlock

### DIFF
--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -211,4 +211,7 @@ unsafe def main (args : List String) : IO Unit := do
   let modulesToLint ← determineModulesToLint mod?
 
   modulesToLint.forM <| runLinterOnModule cfg
+  -- TODO: Remove manual Process.exit
+  -- We are doing this to shortcut around a race in Lean's IO finalizers that we have observed in Mathlib CI
+  -- (https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/slow.20linting.20step.20CI.3F/with/568830914)
   IO.Process.exit 0


### PR DESCRIPTION
We have been observing hangs in the runLinter execution where the process seems to be stuck in the Lean's task manager destructor. By calling IO.Process.exit we can bypass the teardown and exit successfully.

See https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/slow.20linting.20step.20CI.3F/with/568830914 for discussion and maybe an explanation of this in https://github.com/leanprover/lean4/pull/12052