### PR TITLE
fix: code action for match

### DIFF
--- a/Batteries/Tactic/NoMatch.lean
+++ b/Batteries/Tactic/NoMatch.lean
@@ -32,7 +32,7 @@ elab (name := funDot) (priority := low) tk:"fun" "." : term <= expectedType? => 
   elabTerm (← `(nofun)) expectedType?
 
 /-- The syntax `λ.` has been deprecated in favor of `nofun`. -/
-elab (name := lambdaDot) (priority := low) tk:"fun" "." : term <= expectedType? => do
+elab (name := lambdaDot) (priority := low) tk:"λ" "." : term <= expectedType? => do
   logWarningAt tk (← findDocString? (← getEnv) ``lambdaDot).get!
   elabTerm (← `(nofun)) expectedType?
 


### PR DESCRIPTION
This PR fixes the code action for match by adjusting the priority of the syntax `match _ with .` from `Batteries.Tactic.NoMatch`.
Discussion at https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60match.60.20code.20action.20not.20working/with/569709068