### PR TITLE
chore: reduce import

### DIFF
--- a/Batteries/CodeAction/Match.lean
+++ b/Batteries/CodeAction/Match.lean
@@ -1,7 +1,7 @@
 module
 
 public meta import Batteries.CodeAction.Misc
-public meta import Batteries.Data.List
+public meta import Batteries.Data.List.Basic
 
 @[expose] public meta section
 


### PR DESCRIPTION
Until we get `shake` running again, reducing an unnecessary import, that was otherwise requiring me to fix things in Batteries for lean4#13283 that don't actually need fixing for Mathlib.