### PR TITLE
chore: move AlternativeMonad MetaM, to reduce Mathlib imports

### DIFF
--- a/Batteries/Control/AlternativeMonad.lean
+++ b/Batteries/Control/AlternativeMonad.lean
@@ -11,6 +11,7 @@ import all Init.Control.Option
 import all Init.Control.State
 import all Init.Control.Reader
 import all Init.Control.StateRef
+public import Lean.Meta.Basic
 
 @[expose] public section
 
@@ -203,3 +204,5 @@ instance [AlternativeMonad m] : LawfulAlternativeLift m (StateRefT' ω σ m) :=
   inferInstanceAs (LawfulAlternativeLift m (ReaderT (ST.Ref ω σ) m))
 
 end StateRefT'
+
+instance : AlternativeMonad Lean.Meta.MetaM where

--- a/Batteries/Lean/Meta/Basic.lean
+++ b/Batteries/Lean/Meta/Basic.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro, Jannis Limperg
 module
 
 public import Lean.Meta.Tactic.Intro
-public import Batteries.Control.AlternativeMonad
 import Lean.Meta.SynthInstance
 
 public section
@@ -23,8 +22,6 @@ result is unspecified.
 def Meta.sortFVarsByContextOrder [Monad m] [MonadLCtx m]
     (hyps : Array FVarId) : m (Array FVarId) :=
   return (← getLCtx).sortFVarsByContextOrder hyps
-
-instance : AlternativeMonad Lean.Meta.MetaM where
 
 namespace MetavarContext
 


### PR DESCRIPTION
Currently Aesop needs to import Batteries.Lean.Meta.Basic, which transitively brings in SatisfiesM, which is otherwise unneeded in Mathlib; I just ran into "needing" to fix SatisfiesM on the lean-pr-testing-13283 branch, and would prefer to avoid this.