### PR TITLE
feat: add Float.ofBits_toBits and Float.toBits_ofBits axioms

### DIFF
--- a/Batteries/Lean/Float.lean
+++ b/Batteries/Lean/Float.lean
@@ -97,7 +97,7 @@ including signed zeros, subnormals, infinities, and all NaN payloads.
 
 See also: IEEE 754-2019 §3.4 (binary interchange format encoding).
 -/
-axiom Float.ofBits_toBits (f : Float) : Float.ofBits f.toBits = f
+axiom ofBits_toBits (f : Float) : Float.ofBits f.toBits = f
 
 /--
 `Float.toBits` and `Float.ofBits` are exact inverses in the other direction:

--- a/Batteries/Lean/Float.lean
+++ b/Batteries/Lean/Float.lean
@@ -75,6 +75,39 @@ def toStringFull (f : Float) : String :=
     if v < 0 then s!"-{s}" else s
   else f.toString -- inf, -inf, nan
 
+/-! ### Trusted bit-roundtrip fact -/
+
+/--
+`Float.ofBits` and `Float.toBits` are exact inverses: encoding a float to its
+IEEE 754 bit pattern and decoding it back yields the original float.
+
+This is stated as an axiom because Lean exposes `Float.ofBits` and
+`Float.toBits` as opaque `@[extern]` primitives compiled to C FFI calls
+(`lean_float_of_bits` / `lean_float_to_bits`).  The kernel has no reduction
+rules for these functions, so the inverse relationship cannot be derived from
+definitional equality or any existing lemma.
+
+The underlying C implementation performs a lossless `memcpy` between `double`
+and `uint64_t`, so the roundtrip holds for every IEEE 754 binary64 value
+including signed zeros, subnormals, infinities, and all NaN payloads.
+
+**Retirement condition:**  This axiom should be removed when either
+(1) upstream Lean adds a kernel-level theorem of this form, or
+(2) the Lean kernel gains reduction rules for `Float.ofBits`/`Float.toBits`.
+
+See also: IEEE 754-2019 §3.4 (binary interchange format encoding).
+-/
+axiom Float.ofBits_toBits (f : Float) : Float.ofBits f.toBits = f
+
+/--
+`Float.toBits` and `Float.ofBits` are exact inverses in the other direction:
+decoding a bit pattern and re-encoding it yields the original `UInt64`.
+
+Same justification as `Float.ofBits_toBits` — the C implementation is a
+lossless `memcpy` between `uint64_t` and `double`.
+-/
+axiom Float.toBits_ofBits (bits : UInt64) : (Float.ofBits bits).toBits = bits
+
 end Float
 
 /--

--- a/Batteries/Lean/Float.lean
+++ b/Batteries/Lean/Float.lean
@@ -106,7 +106,7 @@ decoding a bit pattern and re-encoding it yields the original `UInt64`.
 Same justification as `Float.ofBits_toBits` — the C implementation is a
 lossless `memcpy` between `uint64_t` and `double`.
 -/
-axiom Float.toBits_ofBits (bits : UInt64) : (Float.ofBits bits).toBits = bits
+axiom toBits_ofBits (bits : UInt64) : (Float.ofBits bits).toBits = bits
 
 end Float
 


### PR DESCRIPTION
## Summary

`Float.ofBits` and `Float.toBits` are opaque `@[extern]` primitives compiled to C FFI calls (`lean_float_of_bits` / `lean_float_to_bits`). The Lean kernel has no reduction rules for these functions, so their inverse relationship cannot be derived from definitional equality or any existing lemma.

This PR adds two axioms to `Batteries.Lean.Float`:

- **`Float.ofBits_toBits`**: `∀ (f : Float), Float.ofBits f.toBits = f`
- **`Float.toBits_ofBits`**: `∀ (bits : UInt64), (Float.ofBits bits).toBits = bits`

### Justification

The underlying C implementation performs a lossless `memcpy` between `double` and `uint64_t`, so the roundtrip holds for every IEEE 754 binary64 value including signed zeros, subnormals, infinities, and all NaN payloads (IEEE 754-2019 §3.4).

### Motivation

Any project that encodes floats via their bit pattern (e.g. for a positional codec that preserves `-0.0` and NaN payloads) needs this fact to prove a decode-roundtrip property. Without it, each downstream project must introduce its own axiom.

### Retirement condition

Both axioms should be removed when either:
1. Upstream Lean adds a kernel-level theorem of this form, or
2. The Lean kernel gains reduction rules for `Float.ofBits`/`Float.toBits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)