### PR TITLE
Revert "feat: add a syntax linter version of the impossibleInstance and nonClassInstance linters"

### DIFF
--- a/Batteries/Lean/Meta/Expr.lean
+++ b/Batteries/Lean/Meta/Expr.lean
@@ -1,17 +1,15 @@
 /-
 Copyright (c) 2022 Jannis Limperg. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jannis Limperg, Thomas R. Murrills
+Authors: Jannis Limperg
 -/
 module
 
 public import Lean.Expr
 
-public section
+@[expose] public section
 
-namespace Lean
-
-namespace Literal
+namespace Lean.Literal
 
 instance : Ord Literal where
   compare
@@ -19,29 +17,3 @@ instance : Ord Literal where
     | strVal s₁, strVal s₂ => compare s₁ s₂
     | natVal _, strVal _ => .lt
     | strVal _, natVal _ => .gt
-
-end Literal
-
-namespace Expr
-
-/--
-Tests if any of the binders of `(x₀ : A₀) → (x₁ : A₁) → ⋯ → X` which satisfy `p Aᵢ bi` (with `bi`
-the `binderInfo`) are unused in the renainder of the type (i.e. in `(xᵢ₊₁ : Aᵢ₊₁) → ⋯ → X`).
-
-Note that the argument to `p` may have loose bvars. This is a performance optimization.
-
-This function runs `cleanupAnnotations` on each type suffix `(xᵢ₊₁ : Aᵢ₊₁) → ⋯ → X` before
-examining it.
-
-We see through `let`s, and do not report if any of them are unused.
--/
-@[specialize p]
-partial def hasUnusedForallBindersWhere (p : BinderInfo → Expr → Bool) (e : Expr) : Bool :=
-  match e.cleanupAnnotations with
-  | .forallE _ type body bi =>
-    p bi type && !(body.hasLooseBVar 0) || body.hasUnusedForallBindersWhere p
-  /- See through `letE` -/
-  | .letE _ _ _ body _ => body.hasUnusedForallBindersWhere p
-  | _ => false
-
-end Lean.Expr

--- a/Batteries/Tactic/Lint/TypeClass.lean
+++ b/Batteries/Tactic/Lint/TypeClass.lean
@@ -1,28 +1,22 @@
 /-
 Copyright (c) 2022 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Gabriel Ebner, Thomas Murrills, Moritz Roos
+Authors: Gabriel Ebner
 -/
 module
 
-public import Batteries.Tactic.Lint.Basic
-public import Lean.Linter.Basic
-public meta import Lean.Elab.Command
-public meta import Batteries.Lean.Position
-public meta import Batteries.Lean.Meta.Expr
+public meta import Lean.Meta.Instances
+public meta import Batteries.Tactic.Lint.Basic
 
 public meta section
 
-open Lean Meta Elab Command
-
-/-! ### Environment Linters -/
-
 namespace Batteries.Tactic.Lint
+open Lean Meta
 
 /--
 Lints for instances with arguments that cannot be filled in, like
 ```
-instance impossible {α β : Type} [Inhabited α] : Nonempty α := ⟨default⟩
+instance {α β : Type} [Group α] : Mul α where ...
 ```
 -/
 @[env_linter] def impossibleInstance : Linter where
@@ -54,131 +48,3 @@ A linter for checking if any declaration whose type is not a class is marked as 
     let info ← getConstInfo declName
     if !(← isClass? info.type).isSome then return "should not be an instance"
     return none
-
-end Batteries.Tactic.Lint
-
-/-! ### Syntax Linters -/
-
-/-- Pretty-prints a local declaration and its type as a binder,
-using the appropriate brackets given its `BinderInfo`. Example output: `{α : Type}`.
-
-Returns `none` for let decls. -/
-protected def Lean.LocalDecl.ppAsBinder : LocalDecl → Option MessageData
-  | .ldecl .. => none
-  | .cdecl _ fvarId _ type binderInfo _ =>
-    let (lBracket, rBracket) : String × String := match binderInfo with
-      | .implicit       => ("{", "}")
-      | .strictImplicit => ("⦃", "⦄")
-      | .instImplicit   => ("[", "]")
-      | .default        => ("(", ")")
-    some <| .bracket lBracket m!"{mkFVar fvarId} : {type}" rBracket
-
-/-- Pretty-prints a free variable and its type as a binder,
-using the appropriate brackets given its `BinderInfo`. Example output: `{α : Type}`.
-
-Returns `none` for let decls. -/
-@[inline]
-protected def Lean.FVarId.ppAsBinder (fvarId : FVarId) : MetaM (Option MessageData) :=
-  return (← fvarId.getDecl).ppAsBinder
-
-namespace Batteries.Linter
-
-open Linter Std
-
-/-- The `impossibleInstance` linter flags instances that can never be synthesized by typeclass
-synthesis. Setting this option to `false` will disable this linter. -/
-register_option linter.impossibleInstance : Bool := {
-  defValue := true
-  descr := "Warn when an instance is found that can never be synthesized by typeclass synthesis."
-}
-
-/--
-Lints for instances with arguments that cannot be filled in, like
-```
-instance impossible {α β : Type} [Inhabited α] : Nonempty α := ⟨default⟩
-```
--/
-def impossibleInstance : Linter where run := withSetOptionIn fun cmd => do
-  unless getLinterValue linter.impossibleInstance (← getLinterOptions) do
-    return
-  if ← MonadLog.hasErrors then
-    return
-  let some pos := cmd.getPos? | return
-  let env ← getEnv
-  /- We only consider instances created within the current command, and rely on `isInstanceCore` to
-  avoid `liftCoreM`. -/
-  let decls := pos.getDeclsAfter env (← getFileMap) |>.filter (isInstanceCore env)
-  unless decls.isEmpty do
-    /- We do the check for each instance we can find from the current command. Mostly this will
-    only be one name, but for `mutual` blocks this will be more. -/
-    for declName in decls do
-      let cinfo ← getConstInfo declName
-      -- Performantly check if any non-instance binder is unused.
-      if cinfo.type.hasUnusedForallBindersWhere fun bi _ => !bi.isInstImplicit then liftTermElabM do
-        /- If the return type is not class valued (but an instance), the `nonClassInstance`
-        linter will already put a message on this declaration, so we skip it here in that case. -/
-        if (← isClass? cinfo.type).isSome then
-        forallTelescope cinfo.type fun args ty => do
-          -- Find the fvars used in the type and any instance implicit argument, transitively.
-          let getInitialPossibleFVars := do
-            ty.collectFVars
-            for arg in args do
-              if (← arg.fvarId!.getBinderInfo).isInstImplicit then
-                /- The fvarIds in the `CollectFVars.State` should be our possible args. As such, we
-                start by adding the instance arguments to the state, rather than computing the
-                dependencies of their types. -/
-                modifyThe CollectFVars.State (·.add arg.fvarId!)
-          let possibleFVars ← (·.2) <$> getInitialPossibleFVars.run {}
-          -- Transitively include dependencies.
-          let possibleFVars ← possibleFVars.addDependencies
-          let mut impossibleArgMsgs := #[]
-          for arg in args, i in 1...* do
-            unless possibleFVars.fvarSet.contains arg.fvarId! do
-              let some binder ← arg.fvarId!.ppAsBinder | continue
-              impossibleArgMsgs := impossibleArgMsgs.push <|
-                indentD m!"argument {i}: `{binder}`"
-          if impossibleArgMsgs.isEmpty then return -- Should not be reachable.
-          withDeclRef? declName do
-            Linter.logLint linter.impossibleInstance (← getRef) m!"\
-              This instance has {impossibleArgMsgs.size} \
-              argument{if impossibleArgMsgs.size = 1 then "" else "s"} that cannot be \
-              inferred using typeclass synthesis. Specifically\n\
-              {.joinSep impossibleArgMsgs.toList .nil}\n\n\
-              These arguments are not instance-implicit and appear neither in another \
-              instance-implicit argument nor the return type, so they cannot be inferred using \
-              typeclass synthesis."
-
-initialize addLinter impossibleInstance
-
-/-- The `nonClassInstance` linter flags declarations marked as `instance` but whose type
-is not a class. Setting this option to `false` will disable this linter. -/
-register_option linter.nonClassInstance : Bool := {
-  defValue := true
-  descr := "Warn when a declaration is found whose type is not a class but is marked as instance. "
-}
-
-/--
-A linter for checking if any declaration whose type is not a class is marked as an instance.
--/
-def nonClassInstance : Linter where run := withSetOptionIn fun cmd => do
-  unless getLinterValue linter.nonClassInstance (← getLinterOptions) do
-    return
-  if ← MonadLog.hasErrors then
-    return
-  let some pos := cmd.getPos? | return
-  let env ← getEnv
-  /- We do the check for each instance that is associated with the current command.
-  Mostly this will only be one name, but for `mutual` blocks this will be more. We use
-  `isInstanceCore` to avoid a `liftCoreM`. -/
-  let decls := pos.getDeclsAfter env (← getFileMap) |>.filter (isInstanceCore env)
-  unless decls.isEmpty do liftTermElabM do
-    for decl in decls do
-      unless (← isClass? (← getConstInfo decl).type).isSome do
-        withDeclRef? decl do
-          Linter.logLint linter.nonClassInstance (← getRef)
-            m!"The declaration `{.ofConstName decl}` should not be an instance \
-            as it is not class-valued."
-
-initialize addLinter nonClassInstance
-
-end Batteries.Linter

--- a/BatteriesTest/lintTC.lean
+++ b/BatteriesTest/lintTC.lean
@@ -5,95 +5,19 @@ open Batteries.Tactic.Lint
 
 namespace A
 
--- The following two tests test both the `impossibleInstance` linter and also that the
--- `Lean.withDeclRef?` function (used in the implementation of the linter) makes the
--- linter's warning appear on the name of the declaration (if it has one) or the `instance` keyword,
--- instead of at the beginning of the declaration's docstring.
--- It does this by using `(positions := true)` in `guard_msgs`.
 /--
-@ +2:29...30
 warning: unused variable `β`
 
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
----
-@ +2:15...25
-warning: This instance has 1 argument that cannot be inferred using typeclass synthesis. Specifically
-
-  argument 2: `{β : Type}`
-
-These arguments are not instance-implicit and appear neither in another instance-implicit argument nor the return type, so they cannot be inferred using typeclass synthesis.
-
-Note: This linter can be disabled with `set_option linter.impossibleInstance false`
 -/
-#guard_msgs (positions := true) in
-/-- This is a doc string needed for testing the `withDeclRef` function. -/
+#guard_msgs in
 local instance impossible {α β : Type} [Inhabited α] : Nonempty α := ⟨default⟩
 
--- Version of the above without a name (see comment above for why this exists).
-/--
-@ +2:18...19
-warning: unused variable `β`
-
-Note: This linter can be disabled with `set_option linter.unusedVariables false`
----
-@ +2:6...14
-warning: This instance has 1 argument that cannot be inferred using typeclass synthesis. Specifically
-
-  argument 2: `{β : Type}`
-
-These arguments are not instance-implicit and appear neither in another instance-implicit argument nor the return type, so they cannot be inferred using typeclass synthesis.
-
-Note: This linter can be disabled with `set_option linter.impossibleInstance false`
--/
-#guard_msgs (positions := true) in
-/-- This is a doc string needed for testing the `withDeclRef` function. -/
-local instance {α β : Type} [Inhabited α] : Nonempty α := ⟨default⟩
-
 run_meta guard (← impossibleInstance.test ``impossible).isSome
-
-/--
-warning: declaration uses `sorry`
----
-warning: This instance has 4 arguments that cannot be inferred using typeclass synthesis. Specifically
-
-  argument 2: `{β : Type}`
-  argument 3: `(b : Array β)`
-  argument 4: `(a : Array α)`
-  argument 6: `⦃h : b = b⦄`
-
-These arguments are not instance-implicit and appear neither in another instance-implicit argument nor the return type, so they cannot be inferred using typeclass synthesis.
-
-Note: This linter can be disabled with `set_option linter.impossibleInstance false`
--/
-#guard_msgs in
-local instance impossibleWithChain {α β : Type} (b : Array β) (a : Array α) [Inhabited α]
-    ⦃h : b = b⦄
-    -- Note: `usedA` is a dependency of a dependency of a dependency of the return type
-    (usedA : Array α) (i : Fin usedA.size) (j : Fin i.val) :
-    Nonempty { a : Array α // a.size = j.val } := sorry
-
--- The following tests that the impossibleInstance syntax and environment linter
--- only fire on instances. So the following theorem should not be linted by them.
-/--
-warning: unused variable `β`
-
-Note: This linter can be disabled with `set_option linter.unusedVariables false`
--/
-#guard_msgs in
-theorem okayAsThm {α β : Type} [Inhabited α] : Nonempty α := ⟨default⟩
-
-run_meta guard (← impossibleInstance.test ``okayAsThm).isNone
 
 end A
 
 namespace B
-
-/--
-warning: The declaration `bad` should not be an instance as it is not class-valued.
-
-Note: This linter can be disabled with `set_option linter.nonClassInstance false`
--/
-#guard_msgs in
 instance bad : Nat := 1
 
 run_meta guard (← nonClassInstance.test ``bad).isSome
@@ -101,48 +25,3 @@ instance good : Inhabited Nat := ⟨1⟩
 
 run_meta guard (← nonClassInstance.test ``good).isNone
 end B
-
-section setOptionIn
-
-/--
-warning: unused variable `β`
-
-Note: This linter can be disabled with `set_option linter.unusedVariables false`
--/
-#guard_msgs in
-set_option linter.impossibleInstance false in
-local instance impossible' {α β : Type} [Inhabited α] : Nonempty α := ⟨default⟩
-
-/--
-warning: unused variable `β`
-
-Note: This linter can be disabled with `set_option linter.unusedVariables false`
----
-warning: This instance has 1 argument that cannot be inferred using typeclass synthesis. Specifically
-
-  argument 2: `{β : Type}`
-
-These arguments are not instance-implicit and appear neither in another instance-implicit argument nor the return type, so they cannot be inferred using typeclass synthesis.
-
-Note: This linter can be disabled with `set_option linter.impossibleInstance false`
--/
-#guard_msgs in
-set_option linter.impossibleInstance true in
-local instance impossibleControl {α β : Type} [Inhabited α] : Nonempty α := ⟨default⟩
-
-#guard_msgs in
-set_option linter.nonClassInstance false in
-instance bad' : Nat := 1
-
-/--
-@ +3:9...19
-warning: The declaration `badControl` should not be an instance as it is not class-valued.
-
-Note: This linter can be disabled with `set_option linter.nonClassInstance false`
--/
-#guard_msgs (positions := true) in
-set_option linter.nonClassInstance true in
-/-- This is a doc string needed for testing the `withDeclRef` function. -/
-instance badControl : Nat := 1
-
-end setOptionIn


### PR DESCRIPTION
Reverts leanprover-community/batteries#1717

Covered by [lean4#13389](https://github.com/leanprover/lean4/pull/13389)