### PR TITLE
fix: make library_note deprecation warnings appear

### DIFF
--- a/Batteries/Classes/Cast.lean
+++ b/Batteries/Classes/Cast.lean
@@ -9,8 +9,7 @@ public import Batteries.Util.LibraryNote
 
 @[expose] public section
 
-library_note "coercion into rings"
-/--
+library_note «coercion into rings» /--
 Coercions such as `Nat.castCoe` that go from a concrete structure such as
 `Nat` to an arbitrary ring `R` should be set up as follows:
 ```lean

--- a/Batteries/Tactic/Lint/Simp.lean
+++ b/Batteries/Tactic/Lint/Simp.lean
@@ -217,7 +217,7 @@ and https://lean-lang.org/doc/reference/latest/The-Simplifier/Simp-Normal-Forms/
         else
           return none
 
-library_note "simp-normal form" /--
+library_note «simp-normal form» /--
 This note gives you some tips to debug any errors that the simp-normal form linter raises.
 
 The reason that a lemma was considered faulty is because its left-hand side is not in simp-normal

--- a/Batteries/Util/LibraryNote.lean
+++ b/Batteries/Util/LibraryNote.lean
@@ -84,25 +84,25 @@ elab "library_note " name:ident ppSpace dc:docComment : command => do
 open Elab Command in
 /-- Support the old `library_note "foo"` syntax, with a deprecation warning. -/
 elab "library_note " name:str ppSpace dc:docComment : command => do
+  let name' := Name.mkSimple name.getString
+  let stx ← `(library_note $(mkIdent name'):ident $dc:docComment)
+  elabCommandTopLevel stx
   logWarningAt name <|
     "deprecation warning: library_note now takes an identifier instead of a string.\n" ++
     "Hint: replace the double quotes with «french quotes»."
-  let name := Name.mkSimple name.getString
-  let stx ← `(library_note $(mkIdent name):ident $dc:docComment)
-  elabCommandTopLevel stx
 
 open Elab Command in
 /-- Support the old `library_note2 «foo»` syntax, with a deprecation warning. -/
 elab "library_note2 " name:ident ppSpace dc:docComment : command => do
-  logWarningAt name <|
-    "deprecation warning: library_note2 has been replaced with library_note."
   let stx ← `(library_note $name:ident $dc:docComment)
   elabCommandTopLevel stx
+  logWarningAt name <|
+    "deprecation warning: library_note2 has been replaced with library_note."
 
 open Elab Command in
 /-- Support the old `library_note2 "foo"` syntax, with a deprecation warning. -/
 elab "library_note2 " name:str ppSpace dc:docComment : command => do
-  logWarningAt name <|
-    "deprecation warning: library_note2 has been replaced with library_note."
   let stx ← `(library_note name $dc:docComment)
   elabCommandTopLevel stx
+  logWarningAt name <|
+    "deprecation warning: library_note2 has been replaced with library_note."

--- a/BatteriesTest/Internal/DummyLibraryNote.lean
+++ b/BatteriesTest/Internal/DummyLibraryNote.lean
@@ -1,14 +1,14 @@
 import Batteries.Util.LibraryNote
 
-library_note "test1" /--
+library_note «test1» /--
 1: This is a testnote for testing the library note feature of batteries.
 The `#help note` command should be able to find this note when imported.
 -/
 
-library_note "test2" /--
+library_note «test2» /--
 2: This is a second testnote for testing the library note feature of batteries.
 -/
 
-library_note "temporary note" /--
+library_note «temporary note» /--
 1: This is a testnote whose label also starts with "te", but gets sorted before "test"
 -/

--- a/BatteriesTest/Internal/DummyLibraryNote2.lean
+++ b/BatteriesTest/Internal/DummyLibraryNote2.lean
@@ -1,15 +1,15 @@
 import BatteriesTest.Internal.DummyLibraryNote
 
-library_note "test3" /--
+library_note «test3» /--
 3: this is a note in a different file importing the above testnotes,
 but still imported by the actual testfile.
 -/
 
-library_note "Test" /--
+library_note «Test» /--
 1: this is a testnote with a label starting with "Te"
 -/
 
-library_note "Other" /--
+library_note «Other» /--
 1: this is a testnote with a label not starting with "te",
 so it shouldn't appear when looking for notes with label starting with "te".
 -/

--- a/BatteriesTest/library_note.lean
+++ b/BatteriesTest/library_note.lean
@@ -15,11 +15,11 @@ so it shouldn't appear when looking for notes with label starting with "te". -/
 #guard_msgs in
 #help note "Other"
 
-library_note "test4"/--
+library_note «test4» /--
 4: This note was not imported, and therefore appears below the imported notes.
 -/
 
-library_note "test5"/--
+library_note «test5» /--
 5: This note was also not imported, and therefore appears below the imported notes,
 and the previously added note.
 -/


### PR DESCRIPTION
Apparently they need to be logged after `elabCommandTopLevel stx`, or they just get swallowed.