### PR TITLE
chore: disable `checkType` env_linter by default

### DIFF
--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -135,9 +135,9 @@ has been used. -/
 /-- A linter for checking whether statements of declarations are well-typed.
 
 This linter is disabled by default: declarations are already type-checked when added to the
-environment, so re-checking every statement here is redundant in normal use, and accounts for
-a substantial fraction of `#lint` running time. As a defence-in-depth measure for catching
-kernel/elaborator bugs, prefer running an external checker such as `lean4checker` or `trepplein`.
+environment, so re-checking every statement is redundant in normal use. As an alternative 
+defence-in-depth measure for catching kernel/elaborator bugs, prefer running an external 
+checker such as `lean4checker` or `trepplein`.
 -/
 @[env_linter disabled] def checkType : Linter where
   noErrorsFound :=

--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -132,8 +132,14 @@ has been used. -/
     | false, true => pure "is a def, should be lemma/theorem"
     | _, _ => return none
 
-/-- A linter for checking whether statements of declarations are well-typed. -/
-@[env_linter] def checkType : Linter where
+/-- A linter for checking whether statements of declarations are well-typed.
+
+This linter is disabled by default: declarations are already type-checked when added to the
+environment, so re-checking every statement here is redundant in normal use, and accounts for
+a substantial fraction of `#lint` running time. As a defence-in-depth measure for catching
+kernel/elaborator bugs, prefer running an external checker such as `lean4checker` or `trepplein`.
+-/
+@[env_linter disabled] def checkType : Linter where
   noErrorsFound :=
     "The statements of all declarations type-check with default reducibility settings."
   errorsFound := "THE STATEMENTS OF THE FOLLOWING DECLARATIONS DO NOT TYPE-CHECK."

--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -135,8 +135,8 @@ has been used. -/
 /-- A linter for checking whether statements of declarations are well-typed.
 
 This linter is disabled by default: declarations are already type-checked when added to the
-environment, so re-checking every statement is redundant in normal use. As an alternative 
-defence-in-depth measure for catching kernel/elaborator bugs, prefer running an external 
+environment, so re-checking every statement is redundant in normal use. As an alternative
+defence-in-depth measure for catching kernel/elaborator bugs, prefer running an external
 checker such as `lean4checker` or `trepplein`.
 -/
 @[env_linter disabled] def checkType : Linter where


### PR DESCRIPTION
This PR moves the `checkType` env_linter to the disabled-by-default set (via `@[env_linter disabled]`).

`checkType` re-runs `isTypeCorrect` on the type of every declaration in the environment. Since declarations are already type-checked when added to the environment, this is redundant in normal use, and in mathlib it accounts for ~44% of total `#lint` running time. No one on Zulip recalls ever seeing it fire in practice.

For defence-in-depth against kernel/elaborator bugs, external checkers such as `leanchecker` or `trepplein` are recommended (and run regularly against mathlib).

The linter remains registered, so it can still be invoked explicitly with `#lint+ checkType` or included via a custom linter set.

Discussion: https://github.com/leanprover-community/mathlib4/pull/36426 — based on review feedback that this should happen upstream rather than in mathlib alone.

🤖 Prepared with Claude Code