### PR TITLE
chore: route Zulip notifications to nightly-testing-batteries

### DIFF
--- a/.github/workflows/nightly_bump_and_merge.yml
+++ b/.github/workflows/nightly_bump_and_merge.yml
@@ -334,7 +334,7 @@ jobs:
         api-key: ${{ secrets.ZULIP_API_KEY }}
         email: 'github-mathlib4-bot@leanprover.zulipchat.com'
         organization-url: 'https://leanprover.zulipchat.com'
-        to: 'nightly-testing'
+        to: 'nightly-testing-batteries'
         type: 'stream'
         topic: 'Mergeable lean testing PRs (Batteries)'
         content: |

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -18,7 +18,7 @@ jobs:
         api-key: ${{ secrets.ZULIP_API_KEY }}
         email: 'github-mathlib4-bot@leanprover.zulipchat.com'
         organization-url: 'https://leanprover.zulipchat.com'
-        to: 'nightly-testing'
+        to: 'nightly-testing-batteries'
         type: 'stream'
         topic: 'Batteries status updates'
         content: |
@@ -90,7 +90,7 @@ jobs:
           'num_before': 1,
           'num_after': 0,
           'narrow': [
-            {'operator': 'stream', 'operand': 'nightly-testing'},
+            {'operator': 'stream', 'operand': 'nightly-testing-batteries'},
             {'operator': 'topic', 'operand': 'Batteries status updates'},
             {'operator': 'sender', 'operand': bot_email}
           ],
@@ -102,7 +102,7 @@ jobs:
             # Post the success message
             request = {
                 'type': 'stream',
-                'to': 'nightly-testing',
+                'to': 'nightly-testing-batteries',
                 'topic': 'Batteries status updates',
                 'content': f"✅ The latest CI for Batteries' [nightly-testing branch](https://github.com/${{ github.repository }}/tree/nightly-testing) has succeeded! ([{os.getenv('SHA')}](https://github.com/${{ github.repository }}/commit/{os.getenv('SHA')}))"
             }
@@ -194,7 +194,7 @@ jobs:
         api-key: ${{ secrets.ZULIP_API_KEY }}
         email: 'github-mathlib4-bot@leanprover.zulipchat.com'
         organization-url: 'https://leanprover.zulipchat.com'
-        to: 'nightly-testing'
+        to: 'nightly-testing-batteries'
         type: 'stream'
         topic: 'Batteries status updates'
         content: |
@@ -299,7 +299,7 @@ jobs:
               'num_before': 1,
               'num_after': 0,
               'narrow': [
-                {'operator': 'stream', 'operand': 'nightly-testing'},
+                {'operator': 'stream', 'operand': 'nightly-testing-batteries'},
                 {'operator': 'topic', 'operand': 'Batteries bump branch reminders'},
                 {'operator': 'sender', 'operand': bot_email}
               ],
@@ -337,7 +337,7 @@ jobs:
                 # Post the reminder message
                 request = {
                     'type': 'stream',
-                    'to': 'nightly-testing',
+                    'to': 'nightly-testing-batteries',
                     'topic': 'Batteries bump branch reminders',
                     'content': payload
                 }

--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -206,7 +206,7 @@ if git diff --name-only "bump/$BUMPVERSION" "bump/nightly-$NIGHTLYDATE" | grep -
   echo " Body: $zulip_body"
 
   if command -v zulip-send >/dev/null 2>&1; then
-    zulip_command="zulip-send --stream nightly-testing --subject \"$zulip_title\" --message \"$zulip_body\""
+    zulip_command="zulip-send --stream nightly-testing-batteries --subject \"$zulip_title\" --message \"$zulip_body\""
     echo "Running the following 'zulip-send' command to do this:"
     echo "> $zulip_command"
     eval "$zulip_command"

--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -200,7 +200,7 @@ if git diff --name-only "bump/$BUMPVERSION" "bump/nightly-$NIGHTLYDATE" | grep -
   zulip_title="batteries#$pr_number adaptations for nightly-$NIGHTLYDATE"
   zulip_body=$(printf "> %s\n\nPlease review this PR. At the end of the month this diff will land in 'main'." "$pr_title batteries#$pr_number")
 
-  echo "Posting the link to the PR in a new thread on the #nightly-testing channel on Zulip"
+  echo "Posting the link to the PR in a new thread on the #nightly-testing-batteries channel on Zulip"
   echo "Here is the message:"
   echo "Title: $zulip_title"
   echo " Body: $zulip_body"


### PR DESCRIPTION
This PR retargets the nightly-testing detection and bump-and-merge workflows, and the adaptation-PR helper script, from the shared `nightly-testing` channel to the new `#nightly-testing-batteries` channel, in line with the [proposal to split `#nightly-testing`](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/proposal.20to.20split.20the.20channel/near/592721807) into per-project channels for Mathlib, Batteries, and Cslib.

Topic names are unchanged so existing bookmarks and topic links continue to resolve to the same conversations (which were also moved over).

The `#nightly-testing-batteries` channel mirrors the original (web-public, history visible to subscribers, anyone can post).

Companion PRs: https://github.com/leanprover-community/mathlib4/pull/38946 and https://github.com/leanprover-community/mathlib-ci/pull/33.

🤖 Prepared with Claude Code