### PR TITLE
Added 15 `backward.simpa.using.reducibleClose`

### DIFF
--- a/Batteries/Data/RBMap/Lemmas.lean
+++ b/Batteries/Data/RBMap/Lemmas.lean
@@ -517,6 +517,7 @@ theorem Ordered.upperBound?_least_ub [Std.TransCmp (α := α) cmp] [IsCut cmp cu
     · cases h₁; cases hx.symm.trans hv
     · cases h₁; cases hx.symm.trans hv
 
+set_option backward.simpa.using.reducibleClose false in
 theorem Ordered.lowerBound?_greatest_lb [Std.TransCmp (α := α) cmp] [IsCut cmp cut]
     (h : Ordered cmp t) (hlb : ∀ {x}, lb = some x → t.All (cmpLT cmp x ·)) :
     t.lowerBound? cut lb = some x → y ∈ t → cut x = .gt → cmp x y = .lt → cut y = .lt := by
@@ -582,6 +583,7 @@ theorem Ordered.lowerBound?_lt [Std.TransCmp (α := α) cmp] [IsStrictCut cmp cu
     · exact ht.lowerBound?_greatest H hy h e
   · by_contra h'; exact lowerBound?_le H <| IsCut.le_lt_trans (cmp := cmp) (cut := cut) h' h
 
+set_option backward.simpa.using.reducibleClose false in
 /-- A stronger version of `upperBound?_least` that holds when the cut is strict. -/
 theorem Ordered.lt_upperBound? [Std.TransCmp (α := α) cmp] [IsStrictCut cmp cut]
     (ht : Ordered cmp t) (H : t.upperBound? cut = some x) (hy : y ∈ t) :
@@ -945,6 +947,7 @@ theorem mem_insert_of_mem [Std.TransCmp (α := α) cmp] (v) {t : RBSet α cmp}
   let ⟨_, h₁, h₂⟩ := mem_iff_mem_toList.1 h
   (mem_congr h₂).2 (mem_insert_of_mem_toList v h₁)
 
+set_option backward.simpa.using.reducibleClose false in
 theorem mem_toList_insert [Std.TransCmp (α := α) cmp] {t : RBSet α cmp} :
     v' ∈ toList (t.insert v) ↔ (v' ∈ toList t ∧ t.find? v ≠ some v') ∨ v' = v := by
   let ⟨ht₁, _, _, ht₂⟩ := t.2.out

--- a/Batteries/Data/RBMap/Lemmas.lean
+++ b/Batteries/Data/RBMap/Lemmas.lean
@@ -524,7 +524,7 @@ theorem Ordered.lowerBound?_greatest_lb [Std.TransCmp (α := α) cmp] [IsCut cmp
   rw [← reverse_reverse t, lowerBound?_reverse] at h1
   rw [← Ordering.swap_inj] at h3 ⊢
   revert h2 h3 h4
-  simpa! [-Ordering.swap_inj] using
+  simpa [-Ordering.swap_inj] using!
     h.reverse.upperBound?_least_ub (fun h => All.reverse.2 <| (hlb h).imp .flip) h1
 
 /--
@@ -588,7 +588,7 @@ theorem Ordered.lt_upperBound? [Std.TransCmp (α := α) cmp] [IsStrictCut cmp cu
     cmp y x = .lt ↔ cut y = .gt := by
   rw [← reverse_reverse t, upperBound?_reverse] at H
   rw [← Ordering.swap_inj (o₂ := .gt)]
-  revert hy; simpa! [-Ordering.swap_inj] using ht.reverse.lowerBound?_lt H
+  revert hy; simpa [-Ordering.swap_inj] using! ht.reverse.lowerBound?_lt H
 
 end «upperBound? and lowerBound?»
 
@@ -948,7 +948,7 @@ theorem mem_insert_of_mem [Std.TransCmp (α := α) cmp] (v) {t : RBSet α cmp}
 theorem mem_toList_insert [Std.TransCmp (α := α) cmp] {t : RBSet α cmp} :
     v' ∈ toList (t.insert v) ↔ (v' ∈ toList t ∧ t.find? v ≠ some v') ∨ v' = v := by
   let ⟨ht₁, _, _, ht₂⟩ := t.2.out
-  simpa! [mem_toList] using RBNode.mem_insert ht₂ ht₁
+  simpa [mem_toList] using! RBNode.mem_insert ht₂ ht₁
 
 theorem mem_insert [Std.TransCmp (α := α) cmp] {t : RBSet α cmp} :
     v' ∈ t.insert v ↔ v' ∈ t ∨ cmp v v' = .eq := by

--- a/Batteries/Data/RBMap/Lemmas.lean
+++ b/Batteries/Data/RBMap/Lemmas.lean
@@ -517,7 +517,6 @@ theorem Ordered.upperBound?_least_ub [Std.TransCmp (α := α) cmp] [IsCut cmp cu
     · cases h₁; cases hx.symm.trans hv
     · cases h₁; cases hx.symm.trans hv
 
-set_option backward.simpa.using.reducibleClose false in
 theorem Ordered.lowerBound?_greatest_lb [Std.TransCmp (α := α) cmp] [IsCut cmp cut]
     (h : Ordered cmp t) (hlb : ∀ {x}, lb = some x → t.All (cmpLT cmp x ·)) :
     t.lowerBound? cut lb = some x → y ∈ t → cut x = .gt → cmp x y = .lt → cut y = .lt := by
@@ -525,7 +524,7 @@ theorem Ordered.lowerBound?_greatest_lb [Std.TransCmp (α := α) cmp] [IsCut cmp
   rw [← reverse_reverse t, lowerBound?_reverse] at h1
   rw [← Ordering.swap_inj] at h3 ⊢
   revert h2 h3 h4
-  simpa [-Ordering.swap_inj] using
+  simpa! [-Ordering.swap_inj] using
     h.reverse.upperBound?_least_ub (fun h => All.reverse.2 <| (hlb h).imp .flip) h1
 
 /--
@@ -583,14 +582,13 @@ theorem Ordered.lowerBound?_lt [Std.TransCmp (α := α) cmp] [IsStrictCut cmp cu
     · exact ht.lowerBound?_greatest H hy h e
   · by_contra h'; exact lowerBound?_le H <| IsCut.le_lt_trans (cmp := cmp) (cut := cut) h' h
 
-set_option backward.simpa.using.reducibleClose false in
 /-- A stronger version of `upperBound?_least` that holds when the cut is strict. -/
 theorem Ordered.lt_upperBound? [Std.TransCmp (α := α) cmp] [IsStrictCut cmp cut]
     (ht : Ordered cmp t) (H : t.upperBound? cut = some x) (hy : y ∈ t) :
     cmp y x = .lt ↔ cut y = .gt := by
   rw [← reverse_reverse t, upperBound?_reverse] at H
   rw [← Ordering.swap_inj (o₂ := .gt)]
-  revert hy; simpa [-Ordering.swap_inj] using ht.reverse.lowerBound?_lt H
+  revert hy; simpa! [-Ordering.swap_inj] using ht.reverse.lowerBound?_lt H
 
 end «upperBound? and lowerBound?»
 
@@ -947,11 +945,10 @@ theorem mem_insert_of_mem [Std.TransCmp (α := α) cmp] (v) {t : RBSet α cmp}
   let ⟨_, h₁, h₂⟩ := mem_iff_mem_toList.1 h
   (mem_congr h₂).2 (mem_insert_of_mem_toList v h₁)
 
-set_option backward.simpa.using.reducibleClose false in
 theorem mem_toList_insert [Std.TransCmp (α := α) cmp] {t : RBSet α cmp} :
     v' ∈ toList (t.insert v) ↔ (v' ∈ toList t ∧ t.find? v ≠ some v') ∨ v' = v := by
   let ⟨ht₁, _, _, ht₂⟩ := t.2.out
-  simpa [mem_toList] using RBNode.mem_insert ht₂ ht₁
+  simpa! [mem_toList] using RBNode.mem_insert ht₂ ht₁
 
 theorem mem_insert [Std.TransCmp (α := α) cmp] {t : RBSet α cmp} :
     v' ∈ t.insert v ↔ v' ∈ t ∨ cmp v v' = .eq := by

--- a/Batteries/Data/String/Lemmas.lean
+++ b/Batteries/Data/String/Lemmas.lean
@@ -364,9 +364,8 @@ theorem findAux_of_valid (p) : ∀ l m r,
       rw [foo, Nat.add_right_comm, Nat.add_assoc]
     · simp
 
-set_option backward.simpa.using.reducibleClose false in
 theorem find_of_valid (p s) : Legacy.find s p = ⟨utf8Len (s.toList.takeWhile (!p ·))⟩ := by
-  simpa using findAux_of_valid p [] s.toList []
+  simpa! using findAux_of_valid p [] s.toList []
 
 @[nolint unusedHavesSuffices] -- false positive from unfolding String.revFindAux
 theorem revFindAux_of_valid (p) : ∀ l r,
@@ -384,10 +383,9 @@ theorem revFindAux_of_valid (p) : ∀ l r,
       List.tail?_cons, Option.map_some]
     exact revFindAux_of_valid p l (c::r)
 
-set_option backward.simpa.using.reducibleClose false in
 theorem revFind_of_valid (p s) :
     Legacy.revFind s p = (s.toList.reverse.dropWhile (!p ·)).tail?.map (⟨utf8Len ·⟩) := by
-  simpa using revFindAux_of_valid p s.toList.reverse []
+  simpa! using revFindAux_of_valid p s.toList.reverse []
 
 theorem firstDiffPos_loop_eq (l₁ l₂ r₁ r₂ stop p)
     (hl₁ : p = utf8Len l₁) (hl₂ : p = utf8Len l₂)
@@ -422,10 +420,9 @@ theorem firstDiffPos_loop_eq (l₁ l₂ r₁ r₂ stop p)
     obtain ⟨b, bs, e₂⟩ := List.exists_cons_of_ne_nil (this h₂)
     exact h _ _ _ _ e₁ e₂
 
-set_option backward.simpa.using.reducibleClose false in
 theorem firstDiffPos_eq (a b : String) :
     firstDiffPos a b = ⟨utf8Len (List.takeWhile₂ (· = ·) a.toList b.toList).1⟩ := by
-  simpa [firstDiffPos] using
+  simpa! [firstDiffPos] using
     firstDiffPos_loop_eq [] [] a.toList b.toList
       ((utf8Len a.toList).min (utf8Len b.toList)) 0 rfl rfl (by simp)
 
@@ -579,9 +576,8 @@ attribute [simp] toString pos
 
 namespace ValidFor
 
-set_option backward.simpa.using.reducibleClose false in
 theorem valid : ∀ {it}, ValidFor l r it → Valid it
-  | _, ⟨⟩ => by simpa [List.reverseAux_eq] using Pos.Raw.Valid.mk l.reverse r rfl
+  | _, ⟨⟩ => by simpa! [List.reverseAux_eq] using Pos.Raw.Valid.mk l.reverse r rfl
 
 theorem out : ∀ {it}, ValidFor l r it → it = ⟨String.ofList (l.reverseAux r), ⟨utf8Len l⟩⟩
   | _, ⟨⟩ => rfl
@@ -714,10 +710,9 @@ end ValidFor
 
 namespace Valid
 
-set_option backward.simpa.using.reducibleClose false in
 theorem validFor : ∀ {it}, Valid it → ∃ l r, ValidFor l r it
   | ⟨_, ⟨_⟩⟩, .mk l r rfl =>
-    ⟨l.reverse, r, by simpa [List.reverseAux_eq] using @ValidFor.mk l.reverse r⟩
+    ⟨l.reverse, r, by simpa! [List.reverseAux_eq] using @ValidFor.mk l.reverse r⟩
 
 theorem _root_.String.valid_mkIterator (s) : (mkIterator s).Valid := s.validFor_mkIterator.valid
 
@@ -771,10 +766,9 @@ theorem offsetOfPosAux_of_valid : ∀ l m r n,
     simpa [← Nat.add_assoc, Nat.add_right_comm] using
       offsetOfPosAux_of_valid (l++[c]) m r (n + 1)
 
-set_option backward.simpa.using.reducibleClose false in
 theorem offsetOfPos_of_valid (l r) :
     String.Pos.Raw.offsetOfPos (ofList (l ++ r)) ⟨utf8Len l⟩ = l.length := by
-  simpa using offsetOfPosAux_of_valid [] l r 0
+  simpa! using offsetOfPosAux_of_valid [] l r 0
 
 @[nolint unusedHavesSuffices] -- false positive from unfolding String.Legacy.foldlAux
 theorem foldlAux_of_valid (f : α → Char → α) : ∀ l m r a,
@@ -787,9 +781,8 @@ theorem foldlAux_of_valid (f : α → Char → α) : ∀ l m r a,
       get_of_valid l (c :: (m ++ r)), Char.reduceDefault, List.headD_cons, List.foldl_cons]
     simpa [← Nat.add_assoc, Nat.add_right_comm] using foldlAux_of_valid f (l++[c]) m r (f a c)
 
-set_option backward.simpa.using.reducibleClose false in
 theorem foldl_eq (f : α → Char → α) (s a) : Legacy.foldl f a s = s.toList.foldl f a := by
-  simpa using foldlAux_of_valid f [] s.toList [] a
+  simpa! using foldlAux_of_valid f [] s.toList [] a
 
 @[nolint unusedHavesSuffices] -- false positive from unfolding String.foldrAux
 theorem foldrAux_of_valid (f : Char → α → α) (l m r a) :
@@ -803,9 +796,8 @@ theorem foldrAux_of_valid (f : Char → α → α) (l m r a) :
     simp only [by simpa using get_of_valid (l ++ m.reverse) (c :: r)]
     simpa using IH (c::r) (f c a)
 
-set_option backward.simpa.using.reducibleClose false in
 theorem foldr_eq (f : Char → α → α) (s a) : Legacy.foldr f a s = s.toList.foldr f a := by
-  simpa using foldrAux_of_valid f [] s.toList [] a
+  simpa! using foldrAux_of_valid f [] s.toList [] a
 
 @[nolint unusedHavesSuffices] -- false positive from unfolding String.anyAux
 theorem anyAux_of_valid (p : Char → Bool) : ∀ l m r,
@@ -820,9 +812,8 @@ theorem anyAux_of_valid (p : Char → Bool) : ∀ l m r,
     cases p c <;> simp
     simpa [← Nat.add_assoc, Nat.add_right_comm] using anyAux_of_valid p (l++[c]) m r
 
-set_option backward.simpa.using.reducibleClose false in
 theorem any_eq (s : String) (p : Char → Bool) : Legacy.any s p = s.toList.any p := by
-  simpa using anyAux_of_valid p [] s.toList []
+  simpa! using anyAux_of_valid p [] s.toList []
 
 theorem any_iff (s : String) (p : Char → Bool) :
     Legacy.any s p ↔ ∃ c ∈ s.toList, p c := by simp [any_eq]
@@ -848,9 +839,8 @@ theorem mapAux_of_valid (f : Char → Char) :
       List.map_cons]
     simpa using mapAux_of_valid f (l++[f c]) r
 
-set_option backward.simpa.using.reducibleClose false in
 theorem map_eq (f : Char → Char) (s) : Legacy.map f s = ofList (s.toList.map f) := by
-  simpa using mapAux_of_valid f [] s.toList
+  simpa! using mapAux_of_valid f [] s.toList
 
 -- TODO: substrEq
 -- TODO: isPrefixOf
@@ -953,9 +943,8 @@ theorem toIterator : ∀ {s}, ValidFor l m r s → s.toLegacyIterator.ValidFor l
     simp only [Substring.Raw.toLegacyIterator]
     exact .of_eq _ (by simp [h.str, List.reverseAux_eq]) (by simp [h.startPos])
 
-set_option backward.simpa.using.reducibleClose false in
 theorem get : ∀ {s}, ValidFor l (m₁ ++ c :: m₂) r s → s.get ⟨utf8Len m₁⟩ = c
-  | _, ⟨⟩ => by simpa using get_of_valid (l ++ m₁) (c :: m₂ ++ r)
+  | _, ⟨⟩ => by simpa! using get_of_valid (l ++ m₁) (c :: m₂ ++ r)
 
 theorem next : ∀ {s}, ValidFor l (m₁ ++ c :: m₂) r s →
     s.next ⟨utf8Len m₁⟩ = ⟨utf8Len m₁ + c.utf8Size⟩
@@ -1107,12 +1096,11 @@ end ValidFor
 
 namespace Valid
 
-set_option backward.simpa.using.reducibleClose false in
 theorem validFor : ∀ {s}, Valid s → ∃ l m r, ValidFor l m r s
   | ⟨_, ⟨_⟩, ⟨_⟩⟩, ⟨.mk l mr rfl, t, h⟩ => by
     obtain ⟨lm, r, h₁, h₂⟩ := t.exists
     have e : lm ++ r = l ++ mr := by
-      simpa [← String.ofList_inj, ← String.toByteArray_inj] using h₁
+      simpa! [← String.ofList_inj, ← String.toByteArray_inj] using h₁
     obtain rfl := Pos.Raw.ext_iff.1 h₂
     simp only [Pos.Raw.mk_le_mk] at *
     have := (or_iff_right_iff_imp.2 fun h => ?x).1 (List.append_eq_append_iff.1 e)
@@ -1122,7 +1110,7 @@ theorem validFor : ∀ {s}, Valid s → ∃ l m r, ValidFor l m r s
       cases utf8Len_eq_zero.1 <| Nat.le_zero.1 (Nat.le_of_add_le_add_left (c := 0) h)
       exact ⟨[], by simp⟩
     match lm, mr, this with
-    | _, _, ⟨m, rfl, rfl⟩ => exact ⟨l, m, r, by simpa using ValidFor.mk⟩
+    | _, _, ⟨m, rfl, rfl⟩ => exact ⟨l, m, r, by simpa! using ValidFor.mk⟩
 
 theorem valid : ∀ {s}, ValidFor l m r s → Valid s
   | _, ⟨⟩ => ⟨.intro ⟨l, m ++ r, by simp, by simp⟩,

--- a/Batteries/Data/String/Lemmas.lean
+++ b/Batteries/Data/String/Lemmas.lean
@@ -365,7 +365,7 @@ theorem findAux_of_valid (p) : ∀ l m r,
     · simp
 
 theorem find_of_valid (p s) : Legacy.find s p = ⟨utf8Len (s.toList.takeWhile (!p ·))⟩ := by
-  simpa! using findAux_of_valid p [] s.toList []
+  simpa using! findAux_of_valid p [] s.toList []
 
 @[nolint unusedHavesSuffices] -- false positive from unfolding String.revFindAux
 theorem revFindAux_of_valid (p) : ∀ l r,
@@ -385,7 +385,7 @@ theorem revFindAux_of_valid (p) : ∀ l r,
 
 theorem revFind_of_valid (p s) :
     Legacy.revFind s p = (s.toList.reverse.dropWhile (!p ·)).tail?.map (⟨utf8Len ·⟩) := by
-  simpa! using revFindAux_of_valid p s.toList.reverse []
+  simpa using! revFindAux_of_valid p s.toList.reverse []
 
 theorem firstDiffPos_loop_eq (l₁ l₂ r₁ r₂ stop p)
     (hl₁ : p = utf8Len l₁) (hl₂ : p = utf8Len l₂)
@@ -422,7 +422,7 @@ theorem firstDiffPos_loop_eq (l₁ l₂ r₁ r₂ stop p)
 
 theorem firstDiffPos_eq (a b : String) :
     firstDiffPos a b = ⟨utf8Len (List.takeWhile₂ (· = ·) a.toList b.toList).1⟩ := by
-  simpa! [firstDiffPos] using
+  simpa [firstDiffPos] using!
     firstDiffPos_loop_eq [] [] a.toList b.toList
       ((utf8Len a.toList).min (utf8Len b.toList)) 0 rfl rfl (by simp)
 
@@ -577,7 +577,7 @@ attribute [simp] toString pos
 namespace ValidFor
 
 theorem valid : ∀ {it}, ValidFor l r it → Valid it
-  | _, ⟨⟩ => by simpa! [List.reverseAux_eq] using Pos.Raw.Valid.mk l.reverse r rfl
+  | _, ⟨⟩ => by simpa [List.reverseAux_eq] using! Pos.Raw.Valid.mk l.reverse r rfl
 
 theorem out : ∀ {it}, ValidFor l r it → it = ⟨String.ofList (l.reverseAux r), ⟨utf8Len l⟩⟩
   | _, ⟨⟩ => rfl
@@ -712,7 +712,7 @@ namespace Valid
 
 theorem validFor : ∀ {it}, Valid it → ∃ l r, ValidFor l r it
   | ⟨_, ⟨_⟩⟩, .mk l r rfl =>
-    ⟨l.reverse, r, by simpa! [List.reverseAux_eq] using @ValidFor.mk l.reverse r⟩
+    ⟨l.reverse, r, by simpa [List.reverseAux_eq] using! @ValidFor.mk l.reverse r⟩
 
 theorem _root_.String.valid_mkIterator (s) : (mkIterator s).Valid := s.validFor_mkIterator.valid
 
@@ -768,7 +768,7 @@ theorem offsetOfPosAux_of_valid : ∀ l m r n,
 
 theorem offsetOfPos_of_valid (l r) :
     String.Pos.Raw.offsetOfPos (ofList (l ++ r)) ⟨utf8Len l⟩ = l.length := by
-  simpa! using offsetOfPosAux_of_valid [] l r 0
+  simpa using! offsetOfPosAux_of_valid [] l r 0
 
 @[nolint unusedHavesSuffices] -- false positive from unfolding String.Legacy.foldlAux
 theorem foldlAux_of_valid (f : α → Char → α) : ∀ l m r a,
@@ -782,7 +782,7 @@ theorem foldlAux_of_valid (f : α → Char → α) : ∀ l m r a,
     simpa [← Nat.add_assoc, Nat.add_right_comm] using foldlAux_of_valid f (l++[c]) m r (f a c)
 
 theorem foldl_eq (f : α → Char → α) (s a) : Legacy.foldl f a s = s.toList.foldl f a := by
-  simpa! using foldlAux_of_valid f [] s.toList [] a
+  simpa using! foldlAux_of_valid f [] s.toList [] a
 
 @[nolint unusedHavesSuffices] -- false positive from unfolding String.foldrAux
 theorem foldrAux_of_valid (f : Char → α → α) (l m r a) :
@@ -797,7 +797,7 @@ theorem foldrAux_of_valid (f : Char → α → α) (l m r a) :
     simpa using IH (c::r) (f c a)
 
 theorem foldr_eq (f : Char → α → α) (s a) : Legacy.foldr f a s = s.toList.foldr f a := by
-  simpa! using foldrAux_of_valid f [] s.toList [] a
+  simpa using! foldrAux_of_valid f [] s.toList [] a
 
 @[nolint unusedHavesSuffices] -- false positive from unfolding String.anyAux
 theorem anyAux_of_valid (p : Char → Bool) : ∀ l m r,
@@ -813,7 +813,7 @@ theorem anyAux_of_valid (p : Char → Bool) : ∀ l m r,
     simpa [← Nat.add_assoc, Nat.add_right_comm] using anyAux_of_valid p (l++[c]) m r
 
 theorem any_eq (s : String) (p : Char → Bool) : Legacy.any s p = s.toList.any p := by
-  simpa! using anyAux_of_valid p [] s.toList []
+  simpa using! anyAux_of_valid p [] s.toList []
 
 theorem any_iff (s : String) (p : Char → Bool) :
     Legacy.any s p ↔ ∃ c ∈ s.toList, p c := by simp [any_eq]
@@ -840,7 +840,7 @@ theorem mapAux_of_valid (f : Char → Char) :
     simpa using mapAux_of_valid f (l++[f c]) r
 
 theorem map_eq (f : Char → Char) (s) : Legacy.map f s = ofList (s.toList.map f) := by
-  simpa! using mapAux_of_valid f [] s.toList
+  simpa using! mapAux_of_valid f [] s.toList
 
 -- TODO: substrEq
 -- TODO: isPrefixOf
@@ -944,7 +944,7 @@ theorem toIterator : ∀ {s}, ValidFor l m r s → s.toLegacyIterator.ValidFor l
     exact .of_eq _ (by simp [h.str, List.reverseAux_eq]) (by simp [h.startPos])
 
 theorem get : ∀ {s}, ValidFor l (m₁ ++ c :: m₂) r s → s.get ⟨utf8Len m₁⟩ = c
-  | _, ⟨⟩ => by simpa! using get_of_valid (l ++ m₁) (c :: m₂ ++ r)
+  | _, ⟨⟩ => by simpa using! get_of_valid (l ++ m₁) (c :: m₂ ++ r)
 
 theorem next : ∀ {s}, ValidFor l (m₁ ++ c :: m₂) r s →
     s.next ⟨utf8Len m₁⟩ = ⟨utf8Len m₁ + c.utf8Size⟩
@@ -1100,7 +1100,7 @@ theorem validFor : ∀ {s}, Valid s → ∃ l m r, ValidFor l m r s
   | ⟨_, ⟨_⟩, ⟨_⟩⟩, ⟨.mk l mr rfl, t, h⟩ => by
     obtain ⟨lm, r, h₁, h₂⟩ := t.exists
     have e : lm ++ r = l ++ mr := by
-      simpa! [← String.ofList_inj, ← String.toByteArray_inj] using h₁
+      simpa [← String.ofList_inj, ← String.toByteArray_inj] using! h₁
     obtain rfl := Pos.Raw.ext_iff.1 h₂
     simp only [Pos.Raw.mk_le_mk] at *
     have := (or_iff_right_iff_imp.2 fun h => ?x).1 (List.append_eq_append_iff.1 e)
@@ -1110,7 +1110,7 @@ theorem validFor : ∀ {s}, Valid s → ∃ l m r, ValidFor l m r s
       cases utf8Len_eq_zero.1 <| Nat.le_zero.1 (Nat.le_of_add_le_add_left (c := 0) h)
       exact ⟨[], by simp⟩
     match lm, mr, this with
-    | _, _, ⟨m, rfl, rfl⟩ => exact ⟨l, m, r, by simpa! using ValidFor.mk⟩
+    | _, _, ⟨m, rfl, rfl⟩ => exact ⟨l, m, r, by simpa using! ValidFor.mk⟩
 
 theorem valid : ∀ {s}, ValidFor l m r s → Valid s
   | _, ⟨⟩ => ⟨.intro ⟨l, m ++ r, by simp, by simp⟩,

--- a/Batteries/Data/String/Lemmas.lean
+++ b/Batteries/Data/String/Lemmas.lean
@@ -364,6 +364,7 @@ theorem findAux_of_valid (p) : ∀ l m r,
       rw [foo, Nat.add_right_comm, Nat.add_assoc]
     · simp
 
+set_option backward.simpa.using.reducibleClose false in
 theorem find_of_valid (p s) : Legacy.find s p = ⟨utf8Len (s.toList.takeWhile (!p ·))⟩ := by
   simpa using findAux_of_valid p [] s.toList []
 
@@ -383,6 +384,7 @@ theorem revFindAux_of_valid (p) : ∀ l r,
       List.tail?_cons, Option.map_some]
     exact revFindAux_of_valid p l (c::r)
 
+set_option backward.simpa.using.reducibleClose false in
 theorem revFind_of_valid (p s) :
     Legacy.revFind s p = (s.toList.reverse.dropWhile (!p ·)).tail?.map (⟨utf8Len ·⟩) := by
   simpa using revFindAux_of_valid p s.toList.reverse []
@@ -420,6 +422,7 @@ theorem firstDiffPos_loop_eq (l₁ l₂ r₁ r₂ stop p)
     obtain ⟨b, bs, e₂⟩ := List.exists_cons_of_ne_nil (this h₂)
     exact h _ _ _ _ e₁ e₂
 
+set_option backward.simpa.using.reducibleClose false in
 theorem firstDiffPos_eq (a b : String) :
     firstDiffPos a b = ⟨utf8Len (List.takeWhile₂ (· = ·) a.toList b.toList).1⟩ := by
   simpa [firstDiffPos] using
@@ -576,6 +579,7 @@ attribute [simp] toString pos
 
 namespace ValidFor
 
+set_option backward.simpa.using.reducibleClose false in
 theorem valid : ∀ {it}, ValidFor l r it → Valid it
   | _, ⟨⟩ => by simpa [List.reverseAux_eq] using Pos.Raw.Valid.mk l.reverse r rfl
 
@@ -710,6 +714,7 @@ end ValidFor
 
 namespace Valid
 
+set_option backward.simpa.using.reducibleClose false in
 theorem validFor : ∀ {it}, Valid it → ∃ l r, ValidFor l r it
   | ⟨_, ⟨_⟩⟩, .mk l r rfl =>
     ⟨l.reverse, r, by simpa [List.reverseAux_eq] using @ValidFor.mk l.reverse r⟩
@@ -766,6 +771,7 @@ theorem offsetOfPosAux_of_valid : ∀ l m r n,
     simpa [← Nat.add_assoc, Nat.add_right_comm] using
       offsetOfPosAux_of_valid (l++[c]) m r (n + 1)
 
+set_option backward.simpa.using.reducibleClose false in
 theorem offsetOfPos_of_valid (l r) :
     String.Pos.Raw.offsetOfPos (ofList (l ++ r)) ⟨utf8Len l⟩ = l.length := by
   simpa using offsetOfPosAux_of_valid [] l r 0
@@ -781,6 +787,7 @@ theorem foldlAux_of_valid (f : α → Char → α) : ∀ l m r a,
       get_of_valid l (c :: (m ++ r)), Char.reduceDefault, List.headD_cons, List.foldl_cons]
     simpa [← Nat.add_assoc, Nat.add_right_comm] using foldlAux_of_valid f (l++[c]) m r (f a c)
 
+set_option backward.simpa.using.reducibleClose false in
 theorem foldl_eq (f : α → Char → α) (s a) : Legacy.foldl f a s = s.toList.foldl f a := by
   simpa using foldlAux_of_valid f [] s.toList [] a
 
@@ -796,6 +803,7 @@ theorem foldrAux_of_valid (f : Char → α → α) (l m r a) :
     simp only [by simpa using get_of_valid (l ++ m.reverse) (c :: r)]
     simpa using IH (c::r) (f c a)
 
+set_option backward.simpa.using.reducibleClose false in
 theorem foldr_eq (f : Char → α → α) (s a) : Legacy.foldr f a s = s.toList.foldr f a := by
   simpa using foldrAux_of_valid f [] s.toList [] a
 
@@ -812,6 +820,7 @@ theorem anyAux_of_valid (p : Char → Bool) : ∀ l m r,
     cases p c <;> simp
     simpa [← Nat.add_assoc, Nat.add_right_comm] using anyAux_of_valid p (l++[c]) m r
 
+set_option backward.simpa.using.reducibleClose false in
 theorem any_eq (s : String) (p : Char → Bool) : Legacy.any s p = s.toList.any p := by
   simpa using anyAux_of_valid p [] s.toList []
 
@@ -839,6 +848,7 @@ theorem mapAux_of_valid (f : Char → Char) :
       List.map_cons]
     simpa using mapAux_of_valid f (l++[f c]) r
 
+set_option backward.simpa.using.reducibleClose false in
 theorem map_eq (f : Char → Char) (s) : Legacy.map f s = ofList (s.toList.map f) := by
   simpa using mapAux_of_valid f [] s.toList
 
@@ -943,6 +953,7 @@ theorem toIterator : ∀ {s}, ValidFor l m r s → s.toLegacyIterator.ValidFor l
     simp only [Substring.Raw.toLegacyIterator]
     exact .of_eq _ (by simp [h.str, List.reverseAux_eq]) (by simp [h.startPos])
 
+set_option backward.simpa.using.reducibleClose false in
 theorem get : ∀ {s}, ValidFor l (m₁ ++ c :: m₂) r s → s.get ⟨utf8Len m₁⟩ = c
   | _, ⟨⟩ => by simpa using get_of_valid (l ++ m₁) (c :: m₂ ++ r)
 
@@ -1096,6 +1107,7 @@ end ValidFor
 
 namespace Valid
 
+set_option backward.simpa.using.reducibleClose false in
 theorem validFor : ∀ {s}, Valid s → ∃ l m r, ValidFor l m r s
   | ⟨_, ⟨_⟩, ⟨_⟩⟩, ⟨.mk l mr rfl, t, h⟩ => by
     obtain ⟨lm, r, h₁, h₂⟩ := t.exists

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-13636-e62206c
+leanprover/lean4-pr-releases:pr-release-13636-11336d3

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-13636-8105849
+leanprover/lean4-pr-releases:pr-release-13636-2bcfa08

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-13636-11336d3
+leanprover/lean4-pr-releases:pr-release-13636-8105849


### PR DESCRIPTION
Created during a [Zulip thread to change the simpa tactic](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Mathlib.20code.20quality.3A.20simpa/with/594958924)

This PR wraps each affected declaration with `set_option backward.simpa.using.reducibleClose false in` to restore the old behavior.