### PR TITLE
chore: upstream `deprecated.module` linter

### DIFF
--- a/Batteries.lean
+++ b/Batteries.lean
@@ -79,6 +79,7 @@ public import Batteries.Lean.System.IO
 public import Batteries.Lean.TagAttribute
 public import Batteries.Lean.Util.EnvSearch
 public import Batteries.Linter
+public import Batteries.Linter.DeprecatedModule
 public import Batteries.Linter.UnnecessarySeqFocus
 public import Batteries.Linter.UnreachableTactic
 public import Batteries.Logic

--- a/Batteries/Linter.lean
+++ b/Batteries/Linter.lean
@@ -1,4 +1,5 @@
 module
 
+public meta import Batteries.Linter.DeprecatedModule
 public meta import Batteries.Linter.UnreachableTactic
 public meta import Batteries.Linter.UnnecessarySeqFocus

--- a/Batteries/Linter/DeprecatedModule.lean
+++ b/Batteries/Linter/DeprecatedModule.lean
@@ -36,10 +36,9 @@ open Lean Elab Command Linter
 namespace Batteries.Linter
 
 /--
-The `deprecated.module` linter emits a warning when a file that has been renamed or split
-is imported.
-The default value is `true`, since this linter is designed to warn projects downstream of `Mathlib`
-of refactors and deprecations in `Mathlib` itself.
+The `deprecated.module` linter emits a warning when a file that has been
+deprecated is imported. The default value is `true`, since this linter is
+designed to warn downstream projects.
 -/
 public register_option linter.deprecated.module : Bool := {
   defValue := true
@@ -51,8 +50,7 @@ Defines the `deprecatedModuleExt` extension for adding a `HashSet` of triples of
 * a module `Name` that has been deprecated and
 * an array of `Name`s of modules that should be imported instead
 * an optional `String` containing further messages to be displayed with the deprecation
-
-to the environment.
+  to the environment.
 -/
 public initialize deprecatedModuleExt :
     SimplePersistentEnvExtension
@@ -63,13 +61,13 @@ public initialize deprecatedModuleExt :
   }
 
 /--
-`addModuleDeprecation` adds to the `deprecatedModuleExt` extension the pair consisting of the
-current module name and the array of its direct imports.
+`addModuleDeprecation` adds to the `deprecatedModuleExt` extension the pair
+consisting of the current module name and the array of its direct imports.
 
-It ignores the `Init` import, since this is a special module that is expected to be imported
-by all files.
+It ignores the `Init` module, since this is a special module that is expected
+to be imported by all files.
 
-It also ignores the `Mathlib/Tactic/Linter/DeprecatedModule.lean` import (namely, the current file),
+It also ignores the `DeprecatedModule` import (namely, the current file),
 since there is no need to import this module.
 -/
 def addModuleDeprecation {m : Type → Type} [Monad m] [MonadEnv m]
@@ -81,14 +79,14 @@ def addModuleDeprecation {m : Type → Type} [Monad m] [MonadEnv m]
          i.module == `Batteries.Linter.DeprecatedModule then none else i.module, msg?))
 
 /--
-`deprecated_module "Optional string" (since := "yyyy-mm-dd")` deprecates the current module `A`
-in favour of its direct imports.
-This means that any file that directly imports `A` will get a notification on the `import A` line
+`deprecated_module "Optional string" (since := "yyyy-mm-dd")` deprecates the
+current module `A` in favor of its direct imports. This means that any file
+that directly imports `A` will get a notification on the `import A` line
 suggesting to instead import the *direct imports* of `A`.
 -/
-elab (name := deprecated_modules)
-    "deprecated_module " msg?:(str ppSpace)? "(" &"since " ":= " date:str ")" : command => do
-  if let .error _parsedDate := Std.Time.PlainDate.fromLeanDateString date.getString then
+elab (name := deprecatedModule)
+    "deprecated_module " msg?:(str ppSpace)? "(" &"since " ":= " when:str ")" : command => do
+  if let .error _parsedDate := Std.Time.PlainDate.fromLeanDateString when.getString then
     throwError "Invalid date: the expected format is \"{← Std.Time.PlainDate.now}\""
   addModuleDeprecation <| msg?.map (·.getString)
   -- Disable the linter, so that it does not complain in the file with the deprecation.
@@ -99,11 +97,9 @@ A utility command to show the current entries of the `deprecatedModuleExt` in th
 ```
 Deprecated modules
 
-'MathlibTest.DeprecatedModule' deprecates to
-#[Mathlib.Tactic.Linter.DocPrime, Mathlib.Tactic.Linter.DocString]
+'BatteriesTest.DeprecatedModule' deprecates to
+#[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
 with message 'We can also give more details about the deprecation'
-
-...
 ```
 -/
 elab "#show_deprecated_modules" : command => do
@@ -112,8 +108,6 @@ elab "#show_deprecated_modules" : command => do
     directImports.fold (init := ["Deprecated modules\n"]) fun nms (i, deps, msg?) =>
       let msg := match msg? with | some str => s!"message '{str}'" | none => "no message"
       nms ++ [s!"'{i}' deprecates to\n{deps}\nwith {msg}\n"]
-
-namespace DeprecatedModule
 
 /--
 `IsLaterCommand` is an `IO.Ref` that starts out being `false`.
@@ -143,14 +137,10 @@ partial def getImportIds (s : Syntax) : Array Syntax :=
     rest
 
 @[inherit_doc Batteries.Linter.linter.deprecated.module]
-def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx => do
+def deprecatedModuleLinter : Linter where run := withSetOptionIn fun stx => do
   unless getLinterValue linter.deprecated.module (← getLinterOptions) do
     return
   if (← get).messages.hasErrors then
-    return
-  -- Exempt Mathlib.lean since it's auto-generated and imports all modules
-  -- for backwards compatibility
-  if (← getFileName).endsWith "Mathlib.lean" then
     return
   let laterCommand ← IsLaterCommand.get
   -- If `laterCommand` is `true`, then the linter already did what it was supposed to do.
@@ -162,7 +152,7 @@ def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx => do
   let deprecations := deprecatedModuleExt.getState (← getEnv)
   if deprecations.isEmpty then
     return
-  if stx.isOfKind ``Linter.deprecated_modules then return
+  if stx.isOfKind ``deprecatedModule then return
   let fm ← getFileMap
   let (importStx, _) ←
     Parser.parseHeader { inputString := fm.source, fileName := ← getFileName, fileMap := fm }
@@ -174,4 +164,4 @@ def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx => do
           '{nmStx}' has been deprecated: please replace this import by\n\n\
           {String.join (preferred.foldl (·.push s!"import {·}\n") #[]).toList}"
 
-initialize addLinter deprecated.moduleLinter
+initialize addLinter deprecatedModuleLinter

--- a/Batteries/Linter/DeprecatedModule.lean
+++ b/Batteries/Linter/DeprecatedModule.lean
@@ -13,20 +13,32 @@ public import Std.Time.Date
 /-!
 # The `deprecated.module` linter
 
-The `deprecated.module` linter emits a warning when a file that has been renamed or split
-is imported.
+This linter emits a warning when a deprecated imported. Reasons for module
+deprecation include renaming, splitting, obsolescence.
 
-The usage is as follows. Write
+The usage is as follows:
 ```lean
+import A
 import B
+import C
 ...
-import Z
 
-deprecated_module "Optional string here with further details" (since := "yyyy-mm-dd")
+deprecated_module "Optional string with further details" (since := "yyyy-mm-dd")
 ```
-in module `A` with the expectation that `A` contains nothing else.
-This triggers the `deprecated.module` linter to notify every file with `import A`
-to instead import the *direct imports* of `A`, that is `B, ..., Z`.
+in module `X` with the expectation that `X` contains nothing else.
+
+This triggers the `deprecated.module` linter to notify every file with
+`import X` to instead import the *direct imports* of `X`, that is modules
+`A`, `B`, `C`,...
+
+The deprecated module linter is enabled by default. To disable it set option
+`linter.deprecated.module` to `false`.
+
+Some projects (like Mathlib) are designed so that the root module imports
+everything, regardless of deprecation status. In such cases, there is an
+additional linter option `linter.deprecated.module.exclude_root` that
+prevents the deprecated module linter on the root module when set to `true`.
+This option has no effect if the deprecated module linter is disabled.
 -/
 
 meta section
@@ -36,9 +48,9 @@ open Lean Elab Command Linter
 namespace Batteries.Linter
 
 /--
-The `deprecated.module` linter emits a warning when a file that has been
-deprecated is imported. The default value is `true`, since this linter is
-designed to warn downstream projects.
+The deprecated module linter emits a warning when a module that has been
+deprecated is imported. This linter is enabled by default, since this linter
+is designed to warn downstream projects of changes in their dependencies.
 -/
 public register_option linter.deprecated.module : Bool := {
   defValue := true
@@ -59,11 +71,11 @@ public register_option linter.deprecated.module.exclude_root : Bool := {
 }
 
 /--
-Defines the `deprecatedModuleExt` extension for adding a `HashSet` of triples of
-* a module `Name` that has been deprecated and
-* an array of `Name`s of modules that should be imported instead
-* an optional `String` containing further messages to be displayed with the deprecation
-  to the environment.
+The deprecated module extension is a `HashMap` where keys are module names and
+values are pairs consisting of:
+* an array of `Name`s of modules that should be imported instead,
+* an optional `String` containing further messages to be displayed with the
+  deprecation to the environment.
 -/
 public initialize deprecatedModuleExt :
     SimplePersistentEnvExtension
@@ -79,22 +91,21 @@ def isDeprecatedModule (env : Environment) (modName : Name) : Bool :=
   deprecatedModuleExt.getState env |>.contains modName
 
 /--
-`addModuleDeprecation` adds to the `deprecatedModuleExt` extension the pair
-consisting of the current module name and the array of its direct imports.
-
-It ignores the `Init` module, since this is a special module that is expected
-to be imported by all files.
-
-It also ignores the `DeprecatedModule` import (namely, the current file),
-since there is no need to import this module.
+`addModuleDeprecation` adds the current module to the deprecated module
+extension. The value consists of the module's direct imports excluding two:
+* The `Init` module since it is always imported.
+* The `Batteries.Linter.DeprecatedModule` which is imported to access the
+  deprecated module command.
 -/
-def addModuleDeprecation {m : Type → Type} [Monad m] [MonadEnv m]
-    (msg? : Option String) : m Unit := do
+def addModuleDeprecation {m : Type → Type} [Monad m] [MonadEnv m] (msg? : Option String) :
+    m Unit := do
   let modName ← getMainModule
-  modifyEnv (deprecatedModuleExt.addEntry ·
-    (modName, (← getEnv).imports.filterMap fun i =>
-      if i.module == `Init ||
-         i.module == `Batteries.Linter.DeprecatedModule then none else i.module, msg?))
+  let replNames := (← getEnv).imports |>.filterMap fun i =>
+    if i.module == `Init || i.module == `Batteries.Linter.DeprecatedModule then
+      none
+    else
+      some i.module
+  modifyEnv (deprecatedModuleExt.addEntry · (modName, replNames, msg?))
 
 /--
 `deprecated_module "Optional string" (since := "yyyy-mm-dd")` deprecates the
@@ -102,10 +113,10 @@ current module `A` in favor of its direct imports. This means that any file
 that directly imports `A` will get a notification on the `import A` line
 suggesting to instead import the *direct imports* of `A`.
 -/
-elab (name := deprecatedModule)
-    "deprecated_module " msg?:(str ppSpace)? "(" &"since " ":= " when:str ")" : command => do
+elab (name := deprecatedModule) "deprecated_module " msg?:(str ppSpace)?
+    "(" &"since " ":= " when:str ")" : command => do
   if let .error _parsedDate := Std.Time.PlainDate.fromLeanDateString when.getString then
-    throwError "Invalid date: the expected format is \"{← Std.Time.PlainDate.now}\""
+    throwError "Invalid date: the expected format is \"yyyy-mm-dd\""
   addModuleDeprecation <| msg?.map (·.getString)
   -- Disable the linter, so that it does not complain in the file with the deprecation.
   elabCommand <| mkNullNode #[← `(set_option linter.deprecated.module false)]

--- a/Batteries/Linter/DeprecatedModule.lean
+++ b/Batteries/Linter/DeprecatedModule.lean
@@ -76,7 +76,7 @@ def addModuleDeprecation {m : Type → Type} [Monad m] [MonadEnv m]
     (msg? : Option String) : m Unit := do
   let modName ← getMainModule
   modifyEnv (deprecatedModuleExt.addEntry ·
-    (modName, (← getEnv).imports.filterMap fun i ↦
+    (modName, (← getEnv).imports.filterMap fun i =>
       if i.module == `Init ||
          i.module == `Batteries.Linter.DeprecatedModule then none else i.module, msg?))
 
@@ -109,7 +109,7 @@ with message 'We can also give more details about the deprecation'
 elab "#show_deprecated_modules" : command => do
   let directImports := deprecatedModuleExt.getState (← getEnv)
   logInfo <| "\n".intercalate <|
-    directImports.fold (init := ["Deprecated modules\n"]) fun nms (i, deps, msg?) ↦
+    directImports.fold (init := ["Deprecated modules\n"]) fun nms (i, deps, msg?) =>
       let msg := match msg? with | some str => s!"message '{str}'" | none => "no message"
       nms ++ [s!"'{i}' deprecates to\n{deps}\nwith {msg}\n"]
 
@@ -143,7 +143,7 @@ partial def getImportIds (s : Syntax) : Array Syntax :=
     rest
 
 @[inherit_doc Batteries.Linter.linter.deprecated.module]
-def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx ↦ do
+def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx => do
   unless getLinterValue linter.deprecated.module (← getLinterOptions) do
     return
   if (← get).messages.hasErrors then
@@ -166,7 +166,7 @@ def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx ↦ do
   let fm ← getFileMap
   let (importStx, _) ←
     Parser.parseHeader { inputString := fm.source, fileName := ← getFileName, fileMap := fm }
-  let modulesWithNames := (getImportIds importStx).map fun i ↦ (i, i.getId)
+  let modulesWithNames := (getImportIds importStx).map fun i => (i, i.getId)
   for (i, preferred, msg?) in deprecations do
     for (nmStx, _) in modulesWithNames.filter (·.2 == i) do
       Linter.logLint linter.deprecated.module nmStx

--- a/Batteries/Linter/DeprecatedModule.lean
+++ b/Batteries/Linter/DeprecatedModule.lean
@@ -78,7 +78,7 @@ def addModuleDeprecation {m : Type → Type} [Monad m] [MonadEnv m]
   modifyEnv (deprecatedModuleExt.addEntry ·
     (modName, (← getEnv).imports.filterMap fun i ↦
       if i.module == `Init ||
-         i.module == `Mathlib.Tactic.Linter.DeprecatedModule then none else i.module, msg?))
+         i.module == `Batteries.Linter.DeprecatedModule then none else i.module, msg?))
 
 /--
 `deprecated_module "Optional string" (since := "yyyy-mm-dd")` deprecates the current module `A`
@@ -92,8 +92,7 @@ elab (name := deprecated_modules)
     throwError "Invalid date: the expected format is \"{← Std.Time.PlainDate.now}\""
   addModuleDeprecation <| msg?.map (·.getString)
   -- Disable the linter, so that it does not complain in the file with the deprecation.
-  elabCommand <| mkNullNode #[← `(set_option linter.style.header false),
-                              ← `(set_option linter.deprecated.module false)]
+  elabCommand <| mkNullNode #[← `(set_option linter.deprecated.module false)]
 
 /--
 A utility command to show the current entries of the `deprecatedModuleExt` in the format:

--- a/Batteries/Linter/DeprecatedModule.lean
+++ b/Batteries/Linter/DeprecatedModule.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2025 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+module
+
+public meta import Lean.Elab.Command
+public meta import Lean.Linter
+public meta import Std.Time.Format
+--public import Mathlib.Init
+public import Std.Time.Date
+
+/-!
+# The `deprecated.module` linter
+
+The `deprecated.module` linter emits a warning when a file that has been renamed or split
+is imported.
+
+The usage is as follows. Write
+```lean
+import B
+...
+import Z
+
+deprecated_module "Optional string here with further details" (since := "yyyy-mm-dd")
+```
+in module `A` with the expectation that `A` contains nothing else.
+This triggers the `deprecated.module` linter to notify every file with `import A`
+to instead import the *direct imports* of `A`, that is `B, ..., Z`.
+-/
+
+meta section
+
+open Lean Elab Command Linter
+
+namespace Mathlib.Linter
+
+/--
+The `deprecated.module` linter emits a warning when a file that has been renamed or split
+is imported.
+The default value is `true`, since this linter is designed to warn projects downstream of `Mathlib`
+of refactors and deprecations in `Mathlib` itself.
+-/
+public register_option linter.deprecated.module : Bool := {
+  defValue := true
+  descr := "enable the `deprecated.module` linter"
+}
+
+/--
+Defines the `deprecatedModuleExt` extension for adding a `HashSet` of triples of
+* a module `Name` that has been deprecated and
+* an array of `Name`s of modules that should be imported instead
+* an optional `String` containing further messages to be displayed with the deprecation
+
+to the environment.
+-/
+public initialize deprecatedModuleExt :
+    SimplePersistentEnvExtension
+      (Name × Array Name × Option String) (Std.HashSet (Name × Array Name × Option String)) ←
+  registerSimplePersistentEnvExtension {
+    addImportedFn := (·.foldl Std.HashSet.insertMany {})
+    addEntryFn := .insert
+  }
+
+/--
+`addModuleDeprecation` adds to the `deprecatedModuleExt` extension the pair consisting of the
+current module name and the array of its direct imports.
+
+It ignores the `Init` import, since this is a special module that is expected to be imported
+by all files.
+
+It also ignores the `Mathlib/Tactic/Linter/DeprecatedModule.lean` import (namely, the current file),
+since there is no need to import this module.
+-/
+def addModuleDeprecation {m : Type → Type} [Monad m] [MonadEnv m]
+    (msg? : Option String) : m Unit := do
+  let modName ← getMainModule
+  modifyEnv (deprecatedModuleExt.addEntry ·
+    (modName, (← getEnv).imports.filterMap fun i ↦
+      if i.module == `Init ||
+         i.module == `Mathlib.Tactic.Linter.DeprecatedModule then none else i.module, msg?))
+
+/--
+`deprecated_module "Optional string" (since := "yyyy-mm-dd")` deprecates the current module `A`
+in favour of its direct imports.
+This means that any file that directly imports `A` will get a notification on the `import A` line
+suggesting to instead import the *direct imports* of `A`.
+-/
+elab (name := deprecated_modules)
+    "deprecated_module " msg?:(str ppSpace)? "(" &"since " ":= " date:str ")" : command => do
+  if let .error _parsedDate := Std.Time.PlainDate.fromLeanDateString date.getString then
+    throwError "Invalid date: the expected format is \"{← Std.Time.PlainDate.now}\""
+  addModuleDeprecation <| msg?.map (·.getString)
+  -- Disable the linter, so that it does not complain in the file with the deprecation.
+  elabCommand <| mkNullNode #[← `(set_option linter.style.header false),
+                              ← `(set_option linter.deprecated.module false)]
+
+/--
+A utility command to show the current entries of the `deprecatedModuleExt` in the format:
+```
+Deprecated modules
+
+'MathlibTest.DeprecatedModule' deprecates to
+#[Mathlib.Tactic.Linter.DocPrime, Mathlib.Tactic.Linter.DocString]
+with message 'We can also give more details about the deprecation'
+
+...
+```
+-/
+elab "#show_deprecated_modules" : command => do
+  let directImports := deprecatedModuleExt.getState (← getEnv)
+  logInfo <| "\n".intercalate <|
+    directImports.fold (init := ["Deprecated modules\n"]) fun nms (i, deps, msg?) ↦
+      let msg := match msg? with | some str => s!"message '{str}'" | none => "no message"
+      nms ++ [s!"'{i}' deprecates to\n{deps}\nwith {msg}\n"]
+
+namespace DeprecatedModule
+
+/--
+`IsLaterCommand` is an `IO.Ref` that starts out being `false`.
+As soon as a (non-import) command in a file is processed, the `deprecated.module` linter
+sets it to `true`.
+If it is `false`, then the `deprecated.module` linter will check for deprecated modules.
+
+This is used to ensure that the linter performs the deprecation checks only once per file.
+There are possible concurrency issues, but they should not be particularly worrying:
+* the linter check should be relatively quick;
+* the only way in which the linter could change what it reports is if the imports are changed
+  and a change in imports triggers a rebuild of the whole file anyway, resetting the `IO.Ref`.
+-/
+initialize IsLaterCommand : IO.Ref Bool ← IO.mkRef false
+
+-- Note: from Mathlib.Tactic.Linter.Header
+partial def getImportIds (s : Syntax) : Array Syntax :=
+  let rest : Array Syntax := (s.getArgs.map getImportIds).flatten
+  -- Check if this is an import node by kind, rather than pattern matching all optional modifiers.
+  -- This is more robust if the import syntax changes.
+  if s.isOfKind `Lean.Parser.Module.import then
+    -- The module name is the last identifier in the import node arguments
+    match s.getArgs.filter (·.isIdent) |>.back? with
+    | some n => rest.push n
+    | none => rest
+  else
+    rest
+
+@[inherit_doc Mathlib.Linter.linter.deprecated.module]
+def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx ↦ do
+  unless getLinterValue linter.deprecated.module (← getLinterOptions) do
+    return
+  if (← get).messages.hasErrors then
+    return
+  -- Exempt Mathlib.lean since it's auto-generated and imports all modules
+  -- for backwards compatibility
+  if (← getFileName).endsWith "Mathlib.lean" then
+    return
+  let laterCommand ← IsLaterCommand.get
+  -- If `laterCommand` is `true`, then the linter already did what it was supposed to do.
+  -- If `laterCommand` is `false` at the end of file, the file is an import-only file and
+  -- the linter should not do anything.
+  if laterCommand || (Parser.isTerminalCommand stx && !laterCommand) then
+    return
+  IsLaterCommand.set true
+  let deprecations := deprecatedModuleExt.getState (← getEnv)
+  if deprecations.isEmpty then
+    return
+  if stx.isOfKind ``Linter.deprecated_modules then return
+  let fm ← getFileMap
+  let (importStx, _) ←
+    Parser.parseHeader { inputString := fm.source, fileName := ← getFileName, fileMap := fm }
+  let modulesWithNames := (getImportIds importStx).map fun i ↦ (i, i.getId)
+  for (i, preferred, msg?) in deprecations do
+    for (nmStx, _) in modulesWithNames.filter (·.2 == i) do
+      Linter.logLint linter.deprecated.module nmStx
+        m!"{msg?.getD ""}\n\
+          '{nmStx}' has been deprecated: please replace this import by\n\n\
+          {String.join (preferred.foldl (·.push s!"import {·}\n") #[]).toList}"
+
+initialize addLinter deprecated.moduleLinter
+
+end DeprecatedModule
+
+end Mathlib.Linter

--- a/Batteries/Linter/DeprecatedModule.lean
+++ b/Batteries/Linter/DeprecatedModule.lean
@@ -8,7 +8,6 @@ module
 public meta import Lean.Elab.Command
 public meta import Lean.Linter
 public meta import Std.Time.Format
---public import Mathlib.Init
 public import Std.Time.Date
 
 /-!
@@ -34,7 +33,7 @@ meta section
 
 open Lean Elab Command Linter
 
-namespace Mathlib.Linter
+namespace Batteries.Linter
 
 /--
 The `deprecated.module` linter emits a warning when a file that has been renamed or split
@@ -144,7 +143,7 @@ partial def getImportIds (s : Syntax) : Array Syntax :=
   else
     rest
 
-@[inherit_doc Mathlib.Linter.linter.deprecated.module]
+@[inherit_doc Batteries.Linter.linter.deprecated.module]
 def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx ↦ do
   unless getLinterValue linter.deprecated.module (← getLinterOptions) do
     return
@@ -180,4 +179,4 @@ initialize addLinter deprecated.moduleLinter
 
 end DeprecatedModule
 
-end Mathlib.Linter
+end Batteries.Linter

--- a/Batteries/Linter/DeprecatedModule.lean
+++ b/Batteries/Linter/DeprecatedModule.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Damiano Testa
+Authors: Damiano Testa, François G. Dorais
 -/
 module
 
@@ -46,6 +46,19 @@ public register_option linter.deprecated.module : Bool := {
 }
 
 /--
+The option `deprecated.module.exclude_root` controls whether the `deprecated.module` linter will
+run on root modules. The default value is `false`; this option has no effect if the
+`deprecated.module` linter is disabled.
+
+Some root modules (e.g. `Mathlib`) are designed to import every module regardless of deprecation
+status. This option allows to exclude deprecated import checking in such cases.
+-/
+public register_option linter.deprecated.module.exclude_root : Bool := {
+  defValue := false
+  descr := "disable the `deprecated.module` linter on project root"
+}
+
+/--
 Defines the `deprecatedModuleExt` extension for adding a `HashSet` of triples of
 * a module `Name` that has been deprecated and
 * an array of `Name`s of modules that should be imported instead
@@ -54,11 +67,16 @@ Defines the `deprecatedModuleExt` extension for adding a `HashSet` of triples of
 -/
 public initialize deprecatedModuleExt :
     SimplePersistentEnvExtension
-      (Name × Array Name × Option String) (Std.HashSet (Name × Array Name × Option String)) ←
+      (Name × Array Name × Option String) (Std.HashMap Name (Array Name × Option String)) ←
   registerSimplePersistentEnvExtension {
-    addImportedFn := (·.foldl Std.HashSet.insertMany {})
-    addEntryFn := .insert
+    addImportedFn := (·.foldl Std.HashMap.insertMany {})
+    addEntryFn := (Function.uncurry ·.insert)
   }
+
+/-- Check whether a module is deprecated. -/
+@[inline]
+def isDeprecatedModule (env : Environment) (modName : Name) : Bool :=
+  deprecatedModuleExt.getState env |>.contains modName
 
 /--
 `addModuleDeprecation` adds to the `deprecatedModuleExt` extension the pair
@@ -103,9 +121,9 @@ with message 'We can also give more details about the deprecation'
 ```
 -/
 elab "#show_deprecated_modules" : command => do
-  let directImports := deprecatedModuleExt.getState (← getEnv)
+  let deprecated := deprecatedModuleExt.getState (← getEnv)
   logInfo <| "\n".intercalate <|
-    directImports.fold (init := ["Deprecated modules\n"]) fun nms (i, deps, msg?) =>
+    deprecated.fold (init := ["Deprecated modules\n"]) fun nms i (deps, msg?) =>
       let msg := match msg? with | some str => s!"message '{str}'" | none => "no message"
       nms ++ [s!"'{i}' deprecates to\n{deps}\nwith {msg}\n"]
 
@@ -141,6 +159,10 @@ def deprecatedModuleLinter : Linter where run := withSetOptionIn fun stx => do
   unless getLinterValue linter.deprecated.module (← getLinterOptions) do
     return
   if (← get).messages.hasErrors then
+    return
+  -- Exclude root module?
+  if getLinterValue linter.deprecated.module.exclude_root (← getLinterOptions)
+      && (← getMainModule).getNumParts == 1 then
     return
   let laterCommand ← IsLaterCommand.get
   -- If `laterCommand` is `true`, then the linter already did what it was supposed to do.

--- a/Batteries/Linter/DeprecatedModule.lean
+++ b/Batteries/Linter/DeprecatedModule.lean
@@ -176,7 +176,3 @@ def deprecated.moduleLinter : Linter where run := withSetOptionIn fun stx ↦ do
           {String.join (preferred.foldl (·.push s!"import {·}\n") #[]).toList}"
 
 initialize addLinter deprecated.moduleLinter
-
-end DeprecatedModule
-
-end Batteries.Linter

--- a/BatteriesRecycling/README.md
+++ b/BatteriesRecycling/README.md
@@ -1,0 +1,5 @@
+# Batteries Recycling
+
+This is a collection of modules that have been deprecated due to obsolescence.
+
+These modules are no longer actively maintained but you can still import them if you need to.

--- a/BatteriesTest/DeprecatedModule.lean
+++ b/BatteriesTest/DeprecatedModule.lean
@@ -1,0 +1,54 @@
+import Batteries.Linter.DeprecatedModule
+import Batteries.Tactic.Alias
+import Batteries.Tactic.Basic
+
+deprecated_module (since := "2025-04-10")
+
+/--
+info: Deprecated modules
+
+'BatteriesTest.DeprecatedModule' deprecates to
+#[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
+with no message
+-/
+#guard_msgs in
+#show_deprecated_modules
+
+-- Deprecating the current module is possible and allows to add more deprecation information.
+deprecated_module "We can also give more details about the deprecation" (since := "2025-04-10")
+
+/--
+info: Deprecated modules
+
+'BatteriesTest.DeprecatedModule' deprecates to
+#[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
+with message 'We can also give more details about the deprecation'
+
+'BatteriesTest.DeprecatedModule' deprecates to
+#[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
+with no message
+-/
+#guard_msgs in
+#show_deprecated_modules
+
+/- Commenting out the following test, since it does not work in CI
+besides, it suggests the current date, so it should *not* be uncommented
+until that is also fixed!
+/-- error: Invalid date: the expected format is "2025-04-14" -/
+#guard_msgs in
+deprecated_module "Text" (since := "2025-02-31")
+-/
+
+/--
+info: Deprecated modules
+
+'BatteriesTest.DeprecatedModule' deprecates to
+#[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
+with message 'We can also give more details about the deprecation'
+
+'BatteriesTest.DeprecatedModule' deprecates to
+#[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
+with no message
+-/
+#guard_msgs in
+#show_deprecated_modules

--- a/BatteriesTest/DeprecatedModule.lean
+++ b/BatteriesTest/DeprecatedModule.lean
@@ -23,10 +23,6 @@ info: Deprecated modules
 'BatteriesTest.DeprecatedModule' deprecates to
 #[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
 with message 'We can also give more details about the deprecation'
-
-'BatteriesTest.DeprecatedModule' deprecates to
-#[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
-with no message
 -/
 #guard_msgs in
 #show_deprecated_modules
@@ -45,10 +41,6 @@ info: Deprecated modules
 'BatteriesTest.DeprecatedModule' deprecates to
 #[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
 with message 'We can also give more details about the deprecation'
-
-'BatteriesTest.DeprecatedModule' deprecates to
-#[Batteries.Tactic.Alias, Batteries.Tactic.Basic]
-with no message
 -/
 #guard_msgs in
 #show_deprecated_modules

--- a/BatteriesTest/DeprecatedModuleAllTest.lean
+++ b/BatteriesTest/DeprecatedModuleAllTest.lean
@@ -1,0 +1,18 @@
+module
+
+import all BatteriesTest.DeprecatedModuleNew
+
+/--
+warning: Testing public import deprecation
+'BatteriesTest.DeprecatedModuleNew' has been deprecated: please replace this import by
+
+import Batteries.Tactic.Alias
+import Batteries.Tactic.Basic
+
+
+Note: This linter can be disabled with `set_option linter.deprecated.module false`
+-/
+#guard_msgs in
+/-!
+This file imports a deprecated module with `import all`.
+-/

--- a/BatteriesTest/DeprecatedModuleMetaTest.lean
+++ b/BatteriesTest/DeprecatedModuleMetaTest.lean
@@ -4,10 +4,10 @@ meta import BatteriesTest.DeprecatedModuleNew
 
 /--
 warning: Testing public import deprecation
-'MathlibTest.DeprecatedModuleNew' has been deprecated: please replace this import by
+'BatteriesTest.DeprecatedModuleNew' has been deprecated: please replace this import by
 
-import Mathlib.Tactic.Linter.DocPrime
-import Mathlib.Tactic.Linter.DocString
+import Batteries.Tactic.Alias
+import Batteries.Tactic.Basic
 
 
 Note: This linter can be disabled with `set_option linter.deprecated.module false`

--- a/BatteriesTest/DeprecatedModuleMetaTest.lean
+++ b/BatteriesTest/DeprecatedModuleMetaTest.lean
@@ -1,0 +1,18 @@
+module
+
+meta import BatteriesTest.DeprecatedModuleNew
+
+/--
+warning: Testing public import deprecation
+'MathlibTest.DeprecatedModuleNew' has been deprecated: please replace this import by
+
+import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.DocString
+
+
+Note: This linter can be disabled with `set_option linter.deprecated.module false`
+-/
+#guard_msgs in
+/-!
+This file imports a deprecated module with `meta import`.
+-/

--- a/BatteriesTest/DeprecatedModuleNew.lean
+++ b/BatteriesTest/DeprecatedModuleNew.lean
@@ -1,0 +1,7 @@
+module
+
+public import Batteries.Linter.DeprecatedModule
+public import Batteries.Tactic.Alias
+public import Batteries.Tactic.Basic
+
+deprecated_module "Testing public import deprecation" (since := "2025-04-10")

--- a/BatteriesTest/DeprecatedModulePublicMetaTest.lean
+++ b/BatteriesTest/DeprecatedModulePublicMetaTest.lean
@@ -1,0 +1,18 @@
+module
+
+public meta import BatteriesTest.DeprecatedModuleNew
+
+/--
+warning: Testing public import deprecation
+'BatteriesTest.DeprecatedModuleNew' has been deprecated: please replace this import by
+
+import Batteries.Tactic.Alias
+import Batteries.Tactic.Basic
+
+
+Note: This linter can be disabled with `set_option linter.deprecated.module false`
+-/
+#guard_msgs in
+/-!
+This file imports a deprecated module with `public meta import`.
+-/

--- a/BatteriesTest/DeprecatedModulePublicTest.lean
+++ b/BatteriesTest/DeprecatedModulePublicTest.lean
@@ -1,0 +1,18 @@
+module
+
+public import BatteriesTest.DeprecatedModuleNew
+
+/--
+warning: Testing public import deprecation
+'MathlibTest.DeprecatedModuleNew' has been deprecated: please replace this import by
+
+import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.DocString
+
+
+Note: This linter can be disabled with `set_option linter.deprecated.module false`
+-/
+#guard_msgs in
+/-!
+This file imports a deprecated module with `public import`.
+-/

--- a/BatteriesTest/DeprecatedModulePublicTest.lean
+++ b/BatteriesTest/DeprecatedModulePublicTest.lean
@@ -4,10 +4,10 @@ public import BatteriesTest.DeprecatedModuleNew
 
 /--
 warning: Testing public import deprecation
-'MathlibTest.DeprecatedModuleNew' has been deprecated: please replace this import by
+'BatteriesTest.DeprecatedModuleNew' has been deprecated: please replace this import by
 
-import Mathlib.Tactic.Linter.DocPrime
-import Mathlib.Tactic.Linter.DocString
+import Batteries.Tactic.Alias
+import Batteries.Tactic.Basic
 
 
 Note: This linter can be disabled with `set_option linter.deprecated.module false`

--- a/BatteriesTest/DeprecatedModuleTest.lean
+++ b/BatteriesTest/DeprecatedModuleTest.lean
@@ -1,0 +1,25 @@
+import MathlibTest.DeprecatedModule
+
+/--
+warning: We can also give more details about the deprecation
+'MathlibTest.DeprecatedModule' has been deprecated: please replace this import by
+
+import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.DocString
+
+
+Note: This linter can be disabled with `set_option linter.deprecated.module false`
+---
+warning:
+'MathlibTest.DeprecatedModule' has been deprecated: please replace this import by
+
+import Mathlib.Tactic.Linter.DocPrime
+import Mathlib.Tactic.Linter.DocString
+
+
+Note: This linter can be disabled with `set_option linter.deprecated.module false`
+-/
+#guard_msgs in
+/-!
+This file imports a deprecated module.
+-/

--- a/BatteriesTest/DeprecatedModuleTest.lean
+++ b/BatteriesTest/DeprecatedModuleTest.lean
@@ -9,15 +9,6 @@ import Batteries.Tactic.Basic
 
 
 Note: This linter can be disabled with `set_option linter.deprecated.module false`
----
-warning:
-'BatteriesTest.DeprecatedModule' has been deprecated: please replace this import by
-
-import Batteries.Tactic.Alias
-import Batteries.Tactic.Basic
-
-
-Note: This linter can be disabled with `set_option linter.deprecated.module false`
 -/
 #guard_msgs in
 /-!

--- a/BatteriesTest/DeprecatedModuleTest.lean
+++ b/BatteriesTest/DeprecatedModuleTest.lean
@@ -1,20 +1,20 @@
-import MathlibTest.DeprecatedModule
+import BatteriesTest.DeprecatedModule
 
 /--
 warning: We can also give more details about the deprecation
-'MathlibTest.DeprecatedModule' has been deprecated: please replace this import by
+'BatteriesTest.DeprecatedModule' has been deprecated: please replace this import by
 
-import Mathlib.Tactic.Linter.DocPrime
-import Mathlib.Tactic.Linter.DocString
+import Batteries.Tactic.Alias
+import Batteries.Tactic.Basic
 
 
 Note: This linter can be disabled with `set_option linter.deprecated.module false`
 ---
 warning:
-'MathlibTest.DeprecatedModule' has been deprecated: please replace this import by
+'BatteriesTest.DeprecatedModule' has been deprecated: please replace this import by
 
-import Mathlib.Tactic.Linter.DocPrime
-import Mathlib.Tactic.Linter.DocString
+import Batteries.Tactic.Alias
+import Batteries.Tactic.Basic
 
 
 Note: This linter can be disabled with `set_option linter.deprecated.module false`

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -10,6 +10,10 @@ linter.missingDocs = true
 name = "Batteries"
 
 [[lean_lib]]
+name = "BatteriesRecycling"
+globs = ["BatteriesRecycling.+"]
+
+[[lean_lib]]
 name = "BatteriesTest"
 globs = ["BatteriesTest.+"]
 leanOptions = {linter.missingDocs = false}


### PR DESCRIPTION
After [mathlib4#39408](https://github.com/leanprover-community/mathlib4/pull/39408), this upstreaming has no behavior changes from the original linter. The implementation has changed a bit but remains compatible.