### PR TITLE
feat: cross-reference earlier `proof_wanted` via `❰foo❱`

### DIFF
--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -5,6 +5,7 @@ Authors: David Thrane Christiansen, Kim Morrison
 -/
 module
 
+public import Batteries.Tactic.Lint.Misc
 public meta import Lean.Elab.Command
 public meta import Lean.Elab.Term
 public meta import Batteries.Lean.Syntax
@@ -28,7 +29,7 @@ structure ProofWanted (α : Sort u) : Type where
 
 /-- Reducible accessor so a binder of type `ProofWanted.Stmt foo` reduces to `foo`'s
 statement. Used by the desugaring of `❰foo❱`. -/
-@[reducible]
+@[reducible, nolint unusedArguments]
 def ProofWanted.Stmt {α : Sort u} (_ : ProofWanted α) : Sort u := α
 
 end
@@ -114,23 +115,18 @@ def elabProofWanted : CommandElab
     -- (1) Brackets aren't allowed inside binder types in this version.
     for arg in args do
       rejectRefsIn "binder types" arg.raw
-    -- (2) Walk the result type, collecting and rewriting each `❰x❱` reference.
-    let nameToHypRef : IO.Ref (NameMap (TSyntax `ident)) ← IO.mkRef {}
+    -- (2) Walk the result type, replacing each `❰x❱` reference with a fresh hypothesis ident.
+    -- Each occurrence (even repeated `❰x❱`s for the same `x`) gets its own binder.
     let hypOrderRef : IO.Ref (Array (Name × TSyntax `ident)) ← IO.mkRef #[]
     let res' ← res.raw.replaceM fun s => do
       unless s.getKind == ``proofWantedRef do return none
       let identStx : Syntax.Ident := ⟨s[1]⟩
       let nm ← liftCoreM <| Elab.realizeGlobalConstNoOverloadWithInfo identStx
-      let m ← nameToHypRef.get
-      match m.find? nm with
-      | some h => return some h.raw
-      | none =>
-        validateProofWantedRef nm identStx
-        let fresh ← freshHypName nm
-        let hyp : TSyntax `ident := mkIdent fresh
-        nameToHypRef.set (m.insert nm hyp)
-        hypOrderRef.modify (·.push (nm, hyp))
-        return some hyp.raw
+      validateProofWantedRef nm identStx
+      let fresh ← freshHypName nm
+      let hyp : TSyntax `ident := mkIdent fresh
+      hypOrderRef.modify (·.push (nm, hyp))
+      return some hyp.raw
     let res' : TSyntax `term := ⟨res'⟩
     let order : Array (Name × TSyntax `ident) ← hypOrderRef.get
     -- (3) Build the extra bracketed binders.

--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -115,18 +115,25 @@ def elabProofWanted : CommandElab
     -- (1) Brackets aren't allowed inside binder types in this version.
     for arg in args do
       rejectRefsIn "binder types" arg.raw
-    -- (2) Walk the result type, replacing each `❰x❱` reference with a fresh hypothesis ident.
-    -- Each occurrence (even repeated `❰x❱`s for the same `x`) gets its own binder.
+    -- (2) Walk the result type, collecting and rewriting each `❰x❱` reference. Repeated
+    -- references to the same `x` share one hypothesis binder, so the recorded statement reads
+    -- "if `x` holds, then …" rather than the noisier "if `x` holds and `x` holds, then …".
+    let nameToHypRef : IO.Ref (NameMap (TSyntax `ident)) ← IO.mkRef {}
     let hypOrderRef : IO.Ref (Array (Name × TSyntax `ident)) ← IO.mkRef #[]
     let res' ← res.raw.replaceM fun s => do
       unless s.getKind == ``proofWantedRef do return none
       let identStx : Syntax.Ident := ⟨s[1]⟩
       let nm ← liftCoreM <| Elab.realizeGlobalConstNoOverloadWithInfo identStx
-      validateProofWantedRef nm identStx
-      let fresh ← freshHypName nm
-      let hyp : TSyntax `ident := mkIdent fresh
-      hypOrderRef.modify (·.push (nm, hyp))
-      return some hyp.raw
+      let m ← nameToHypRef.get
+      match m.find? nm with
+      | some h => return some h.raw
+      | none =>
+        validateProofWantedRef nm identStx
+        let fresh ← freshHypName nm
+        let hyp : TSyntax `ident := mkIdent fresh
+        nameToHypRef.set (m.insert nm hyp)
+        hypOrderRef.modify (·.push (nm, hyp))
+        return some hyp.raw
     let res' : TSyntax `term := ⟨res'⟩
     let order : Array (Name × TSyntax `ident) ← hypOrderRef.get
     -- (3) Build the extra bracketed binders.

--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -10,8 +10,6 @@ public meta import Lean.Elab.Command
 public meta import Lean.Elab.Term
 public meta import Batteries.Lean.Syntax
 
-@[expose] public section
-
 /-!
 # The `proof_wanted` command
 
@@ -29,16 +27,14 @@ Lean input method.
 -/
 
 /-- Wrapper recording that a `proof_wanted` of statement `α` has been declared. -/
-structure ProofWanted (α : Sort u) : Type where
+public structure ProofWanted (α : Sort u) : Type where
   /-- The trivial constructor; carries no information. -/
   mk ::
 
 /-- Reducible accessor so a binder of type `ProofWanted.Stmt foo` reduces to `foo`'s
 statement. Used by the desugaring of `❰foo❱`. -/
-@[reducible, nolint unusedArguments]
-def ProofWanted.Stmt {α : Sort u} (_ : ProofWanted α) : Sort u := α
-
-end
+@[reducible, nolint unusedArguments, expose]
+public def ProofWanted.Stmt {α : Sort u} (_ : ProofWanted α) : Sort u := α
 
 public meta section
 
@@ -73,15 +69,24 @@ ProofWanted _`, the binder type is itself Π-quantified, so `❰foo❱ x y` appl
 
 Typical usage:
 ```
-proof_wanted seventeen_eq_thirtyseven : 17 = 37
+-- A parameterless wanted fact:
+proof_wanted size_of_two_pushes_onto_empty :
+    ((#[] : Array Nat).push 1 |>.push 2).size = 2
 
-proof_wanted seventeen_in_fifty :
-    (⟨17, by rw [❰seventeen_eq_thirtyseven❱]; decide⟩ : Fin 50) = 0
+-- Referencing an earlier `proof_wanted` inside a statement (here in the `Fin`
+-- bound proof, which rewrites by the wanted fact):
+proof_wanted first_index_after_two_pushes :
+    (⟨0, by rw [❰size_of_two_pushes_onto_empty❱]; decide⟩
+      : Fin ((#[] : Array Nat).push 1 |>.push 2).size).val = 0
 
-proof_wanted nat_refl_unconditional (n : Nat) : n = n
+-- A parametrised wanted fact:
+proof_wanted size_after_two_pushes {α : Type _} (a : Array α) (x y : α) :
+    ((a.push x).push y).size = a.size + 2
 
-proof_wanted refl_at_five :
-    (⟨5, by rw [❰nat_refl_unconditional❱ 5]; decide⟩ : Fin 50) = 0
+-- Referencing the parametrised wanted with arguments: `❰foo❱ a x y`.
+proof_wanted index_after_two_pushes {α : Type _} (a : Array α) (x y : α) :
+    (⟨a.size, by rw [❰size_after_two_pushes❱ a x y]; omega⟩
+      : Fin ((a.push x).push y).size).val = a.size
 ```
 -/
 @[command_parser]

--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -1,46 +1,150 @@
 /-
 Copyright (c) 2023 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: David Thrane Christiansen
+Authors: David Thrane Christiansen, Kim Morrison
 -/
 module
 
-public meta import Lean.Elab.Exception
 public meta import Lean.Elab.Command
+public meta import Lean.Elab.Term
+public meta import Batteries.Lean.Syntax
+
+@[expose] public section
+
+/-!
+# The `proof_wanted` command
+
+`proof_wanted name binders : T` records `T` as a wanted theorem. It elaborates to a private
+placeholder `def name binders : ProofWanted T := ⟨⟩` — a sound, file-local trace. Inside another
+`proof_wanted` statement, the bracket syntax `❰foo❱` lets you assume an earlier `proof_wanted`.
+The brackets desugar to fresh hypothesis binders, so the wanted statement honestly records the
+dependency: "if `foo` holds, then …" — no axioms or sorries are introduced.
+-/
+
+/-- Wrapper recording that a `proof_wanted` of statement `α` has been declared. -/
+structure ProofWanted (α : Sort u) : Type where
+  /-- The trivial constructor; carries no information. -/
+  mk ::
+
+/-- Reducible accessor so a binder of type `ProofWanted.Stmt foo` reduces to `foo`'s
+statement. Used by the desugaring of `❰foo❱`. -/
+@[reducible]
+def ProofWanted.Stmt {α : Sort u} (_ : ProofWanted α) : Sort u := α
+
+end
 
 public meta section
 
+open Lean Elab Command
 
-open Lean Parser Elab Command
+/-- Internal bracket syntax `❰foo❱` for referencing an earlier `proof_wanted`.
+Only meaningful inside the statement of a `proof_wanted`; the term elaborator
+errors everywhere else. -/
+syntax (name := proofWantedRef) "❰" ident "❱" : term
+
+/-- Elaborator that errors when `❰…❱` is used outside a `proof_wanted` statement. -/
+@[term_elab proofWantedRef]
+def elabProofWantedRef : Term.TermElab := fun _ _ =>
+  throwError "`❰…❱` may only appear inside the statement of `proof_wanted`"
 
 /-- This proof would be a welcome contribution to the library!
 
 The syntax of `proof_wanted` declarations is just like that of `theorem`, but without `:=` or the
 proof. Lean checks that `proof_wanted` declarations are well-formed (e.g. it ensures that all the
-mentioned names are in scope, and that the theorem statement is a valid proposition), but they are
-discarded afterwards. This means that they cannot be used as axioms.
+mentioned names are in scope, and that the theorem statement is a valid proposition), and records a
+private placeholder declaration of type `... → ProofWanted statement`.
+
+Modifiers (such as `@[simp]`) are accepted for syntactic compatibility with `theorem` but are
+currently ignored.
+
+Inside another `proof_wanted`'s statement, write `❰foo❱` to assume an earlier `proof_wanted` named
+`foo`. The bracket must appear inside the *statement* (it has no meaning in a proof body — there
+is none). It desugars to a fresh hypothesis binder of the matching type, so the resulting wanted
+statement is literally "if `foo` holds, then …". This keeps the trace sound — no axioms or
+sorries are introduced — while letting one `proof_wanted` build on another. Brackets only
+resolve names within the current file, since the placeholders are `private`.
 
 Typical usage:
 ```
-@[simp] proof_wanted empty_find? [BEq α] [Hashable α] {a : α} :
-    (∅ : HashMap α β).find? a = none
+proof_wanted seventeen_eq_thirtyseven : 17 = 37
+
+proof_wanted seventeen_in_fifty :
+    (⟨17, by rw [❰seventeen_eq_thirtyseven❱]; decide⟩ : Fin 50) = 0
 ```
 -/
 @[command_parser]
 def «proof_wanted» := leading_parser
-  declModifiers false >> "proof_wanted" >> declId >> ppIndent declSig
+  Parser.Command.declModifiers false >> "proof_wanted" >>
+    Parser.Command.declId >> Parser.ppIndent Parser.Command.declSig
 
-/-- Elaborate a `proof_wanted` declaration. The declaration is translated to an axiom during
-elaboration, but it's then removed from the environment.
--/
+/-- Walk a syntax tree, throwing on the first `proofWantedRef` node found. -/
+private def rejectRefsIn (loc : String) (stx : Syntax) : CommandElabM Unit := do
+  let _ ← stx.replaceM fun s => do
+    if s.getKind == ``proofWantedRef then
+      throwErrorAt s "`❰…❱` may not appear inside {loc} of `proof_wanted`"
+    return none
+
+/-- Build a fresh hypothesis identifier name based on the last component of `n`. -/
+private def freshHypName (n : Name) : CommandElabM Name := do
+  let baseStr := match n.componentsRev.head? with
+    | some (.str _ s) => "h_" ++ s
+    | _ => "h_ref"
+  liftCoreM <| Lean.mkFreshUserName (Name.mkSimple baseStr)
+
+/-- Check that `nm` is a previously-declared `proof_wanted` (i.e. its type unifies with
+`ProofWanted ?α` and `?α` is a proposition). Throws a descriptive error otherwise. -/
+private def validateProofWantedRef (nm : Name) (stx : Syntax) : CommandElabM Unit := do
+  Command.liftTermElabM do
+    let info ← getConstInfo nm
+    let u ← Lean.Meta.mkFreshLevelMVar
+    let α ← Lean.Meta.mkFreshExprMVar (some (Lean.mkSort u))
+    let expected := Lean.mkApp (Lean.mkConst ``ProofWanted [u]) α
+    unless ← Lean.Meta.isDefEq info.type expected do
+      throwErrorAt stx
+        "`{stx}` is not a `proof_wanted` declaration (its type is not `ProofWanted _`)"
+    unless ← Lean.Meta.isProp (← instantiateMVars α) do
+      throwErrorAt stx
+        "`{stx}` is a `ProofWanted`, but its statement is not a proposition"
+
+/-- Elaborate a `proof_wanted` declaration into a private placeholder `def` of type `ProofWanted`,
+expanding any `❰…❱` references to fresh hypothesis binders. -/
 @[command_elab «proof_wanted»]
 def elabProofWanted : CommandElab
-  | `($mods:declModifiers proof_wanted $name $args* : $res) => withoutModifyingEnv do
-    -- The helper axiom is used instead of `sorry` to avoid spurious warnings
+  | `($_mods:declModifiers proof_wanted $name $args* : $res) => do
+    -- (1) Brackets aren't allowed inside binder types in this version.
+    for arg in args do
+      rejectRefsIn "binder types" arg.raw
+    -- (2) Walk the result type, collecting and rewriting each `❰x❱` reference.
+    let nameToHypRef : IO.Ref (NameMap (TSyntax `ident)) ← IO.mkRef {}
+    let hypOrderRef : IO.Ref (Array (Name × TSyntax `ident)) ← IO.mkRef #[]
+    let res' ← res.raw.replaceM fun s => do
+      unless s.getKind == ``proofWantedRef do return none
+      let identStx : Syntax.Ident := ⟨s[1]⟩
+      let nm ← liftCoreM <| Elab.realizeGlobalConstNoOverloadWithInfo identStx
+      let m ← nameToHypRef.get
+      match m.find? nm with
+      | some h => return some h.raw
+      | none =>
+        validateProofWantedRef nm identStx
+        let fresh ← freshHypName nm
+        let hyp : TSyntax `ident := mkIdent fresh
+        nameToHypRef.set (m.insert nm hyp)
+        hypOrderRef.modify (·.push (nm, hyp))
+        return some hyp.raw
+    let res' : TSyntax `term := ⟨res'⟩
+    let order : Array (Name × TSyntax `ident) ← hypOrderRef.get
+    -- (3) Build the extra bracketed binders.
+    let extraBinders ← order.mapM fun (nm, hyp) =>
+      `(Parser.Term.bracketedBinderF| ($hyp : ProofWanted.Stmt $(mkIdent nm)))
+    -- (4) Emit the placeholder. Binders go on the `def` rather than inside `ProofWanted (∀ …)`,
+    -- which keeps the syntax-level splice simple at the cost that `❰name❱` only validates when
+    -- `name` itself has no binders (its type must unify with `ProofWanted _`). The `(_ : Prop)`
+    -- ascription preserves the "type is not a proposition" check the old `theorem` form gave
+    -- for free, and `linter.unusedVariables` is silenced so user binders that only appear in
+    -- the statement don't trigger warnings.
     elabCommand <| ← `(
       section
       set_option linter.unusedVariables false
-      axiom helper {α : Sort _} : α
-      $mods:declModifiers theorem $name $args* : $res := helper
+      private def $name $args* $extraBinders* : ProofWanted (($res' : Prop)) := ⟨⟩
       end)
   | _ => throwUnsupportedSyntax

--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -15,11 +15,17 @@ public meta import Batteries.Lean.Syntax
 /-!
 # The `proof_wanted` command
 
-`proof_wanted name binders : T` records `T` as a wanted theorem. It elaborates to a private
-placeholder `def name binders : ProofWanted T := ⟨⟩` — a sound, file-local trace. Inside another
-`proof_wanted` statement, the bracket syntax `❰foo❱` lets you assume an earlier `proof_wanted`.
-The brackets desugar to fresh hypothesis binders, so the wanted statement honestly records the
-dependency: "if `foo` holds, then …" — no axioms or sorries are introduced.
+Use `proof_wanted name binders : T` to mark a theorem the library should eventually contain
+without blocking compilation. The declaration elaborates to a private placeholder `def name
+binders : ProofWanted T := ⟨⟩`, so the wanted result is visible to downstream files and tools
+by type rather than by side-channel.
+
+Inside another `proof_wanted` statement, `❰foo❱` references an earlier `proof_wanted`; for
+parametrised `foo`, write `❰foo❱ x y` to apply it. The brackets desugar to fresh hypothesis
+binders, so the dependency appears in the recorded type.
+
+The `❰` and `❱` characters (U+2770, U+2771) are entered as `\h<` and `\h>` with the standard
+Lean input method.
 -/
 
 /-- Wrapper recording that a `proof_wanted` of statement `α` has been declared. -/
@@ -58,12 +64,12 @@ private placeholder declaration of type `... → ProofWanted statement`.
 Modifiers (such as `@[simp]`) are accepted for syntactic compatibility with `theorem` but are
 currently ignored.
 
-Inside another `proof_wanted`'s statement, write `❰foo❱` to assume an earlier `proof_wanted` named
-`foo`. The bracket must appear inside the *statement* (it has no meaning in a proof body — there
-is none). It desugars to a fresh hypothesis binder of the matching type, so the resulting wanted
-statement is literally "if `foo` holds, then …". This keeps the trace sound — no axioms or
-sorries are introduced — while letting one `proof_wanted` build on another. Brackets only
-resolve names within the current file, since the placeholders are `private`.
+Inside another `proof_wanted`'s statement, write `❰foo❱` to assume an earlier `proof_wanted`
+named `foo`. The bracket may only appear inside the statement, since there is no proof body. It
+desugars to a fresh hypothesis binder of the matching type; for parametrised `foo : ∀ args,
+ProofWanted _`, the binder type is itself Π-quantified, so `❰foo❱ x y` applies the parameter to
+`x y`. `❰foo❱` only resolves names within the current file, since the placeholders are
+`private`.
 
 Typical usage:
 ```
@@ -71,6 +77,11 @@ proof_wanted seventeen_eq_thirtyseven : 17 = 37
 
 proof_wanted seventeen_in_fifty :
     (⟨17, by rw [❰seventeen_eq_thirtyseven❱]; decide⟩ : Fin 50) = 0
+
+proof_wanted nat_refl_unconditional (n : Nat) : n = n
+
+proof_wanted refl_at_five :
+    (⟨5, by rw [❰nat_refl_unconditional❱ 5]; decide⟩ : Fin 50) = 0
 ```
 -/
 @[command_parser]
@@ -92,34 +103,87 @@ private def freshHypName (n : Name) : CommandElabM Name := do
     | _ => "h_ref"
   liftCoreM <| Lean.mkFreshUserName (Name.mkSimple baseStr)
 
-/-- Check that `nm` is a previously-declared `proof_wanted` (i.e. its type unifies with
-`ProofWanted ?α` and `?α` is a proposition). Throws a descriptive error otherwise. -/
-private def validateProofWantedRef (nm : Name) (stx : Syntax) : CommandElabM Unit := do
-  Command.liftTermElabM do
+/-- Information returned by `validateProofWantedRef`: the parameter-binder type syntax, and a
+flag saying whether the recorded statement is a typeclass — informs whether the caller emits
+`[c_foo : …]` (instance) or the default `{c_foo : …}` (implicit). -/
+private structure ProofWantedRefInfo where
+  binderType : TSyntax `term
+  /-- `true` if the wanted's payload is a typeclass. The generated parameter is then an instance
+  binder so Lean's instance synth can find it. -/
+  isClass : Bool
+
+/-- Check that `nm` is a previously-declared `proof_wanted` (i.e. its type, after stripping any
+Π binders, unifies with `ProofWanted ?α` and `?α` is a proposition), and return the parameter-
+binder type to use when referencing it plus a class-payload flag. For parameterless `nm`, the
+binder type is `ProofWanted.Stmt foo`; for parametrised `nm : ∀ args, ProofWanted (P args)`, it
+is `∀ args, ProofWanted.Stmt (foo args)`, so a user can write `❰foo❱ x y` and have the bracket
+desugar to the parameter applied to `x y`.
+
+We construct the binder type directly as syntax (rather than via `Meta` + delab) to avoid two
+round-trip pitfalls: pretty-printer dot notation can elide implicit arguments (so for `foo {n :
+Nat} : …`, `(foo n).Stmt` would print as `foo.Stmt` and lose `n`), and a delab over fresh
+universe metavariables emits `sorry` placeholders. -/
+private def validateProofWantedRef (nm : Name) (stx : Syntax) :
+    CommandElabM ProofWantedRefInfo := do
+  Command.liftTermElabM <| open Lean.Meta in do
     let info ← getConstInfo nm
-    let u ← Lean.Meta.mkFreshLevelMVar
-    let α ← Lean.Meta.mkFreshExprMVar (some (Lean.mkSort u))
-    let expected := Lean.mkApp (Lean.mkConst ``ProofWanted [u]) α
-    unless ← Lean.Meta.isDefEq info.type expected do
-      throwErrorAt stx
-        "`{stx}` is not a `proof_wanted` declaration (its type is not `ProofWanted _`)"
-    unless ← Lean.Meta.isProp (← instantiateMVars α) do
-      throwErrorAt stx
-        "`{stx}` is a `ProofWanted`, but its statement is not a proposition"
+    forallTelescope info.type fun fvars body => do
+      let u ← mkFreshLevelMVar
+      let α ← mkFreshExprMVar (some (Lean.mkSort u))
+      unless ← isDefEq body (Lean.mkApp (Lean.mkConst ``ProofWanted [u]) α) do
+        throwErrorAt stx
+          "`{stx}` is not a `proof_wanted` declaration \
+           (its type doesn't end in `ProofWanted _`)"
+      let αInst ← Lean.instantiateMVars α
+      unless ← isProp αInst do
+        throwErrorAt stx
+          "`{stx}` is a `ProofWanted`, but its statement is not a proposition"
+      let env ← getEnv
+      let isCls : Bool := match αInst.getAppFn with
+        | .const n _ => Lean.isClass env n
+        | _ => false
+      -- Build syntax `∀ <foo's binders>, ProofWanted.Stmt (@foo.{us} arg1 ... argN)`. The `@`
+      -- keeps every implicit argument explicit so the syntax round-trips; the universe
+      -- annotations bind to `nm`'s own level params (auto-bound for the enclosing `proof_wanted`).
+      let fooIdent := mkIdent nm
+      let levelStxs : Array (TSyntax `level) ←
+        info.levelParams.toArray.mapM fun u => `(level| $(mkIdent u):ident)
+      let argIdents : Array (TSyntax `term) ← fvars.mapM fun fvar => do
+        let decl ← fvar.fvarId!.getDecl
+        return ⟨mkIdent decl.userName⟩
+      let appliedSyn : TSyntax `term ←
+        if levelStxs.isEmpty then
+          `(@$fooIdent $argIdents*)
+        else
+          `(@$fooIdent:ident.{$levelStxs,*} $argIdents*)
+      let accessorIdent := mkIdent ``ProofWanted.Stmt
+      let bodySyn ← `($accessorIdent $appliedSyn)
+      -- Wrap with Π binders, preserving each binder's name, type, and binder info.
+      let mut binderTySyn := bodySyn
+      for fvar in fvars.reverse do
+        let decl ← fvar.fvarId!.getDecl
+        let nameId := mkIdent decl.userName
+        -- Delab only the *type* of each binder; this is a plain type expression and doesn't
+        -- hit the dot-notation problem that motivated the manual construction above.
+        let typeSyn ← PrettyPrinter.delab decl.type
+        binderTySyn ← match decl.binderInfo with
+          | .default        => `(($nameId : $typeSyn) → $binderTySyn)
+          | .implicit       => `({$nameId : $typeSyn} → $binderTySyn)
+          | .strictImplicit => `(⦃$nameId : $typeSyn⦄ → $binderTySyn)
+          | .instImplicit   => `([$nameId : $typeSyn] → $binderTySyn)
+      return { binderType := binderTySyn, isClass := isCls }
 
 /-- Elaborate a `proof_wanted` declaration into a private placeholder `def` of type `ProofWanted`,
 expanding any `❰…❱` references to fresh hypothesis binders. -/
 @[command_elab «proof_wanted»]
 def elabProofWanted : CommandElab
   | `($_mods:declModifiers proof_wanted $name $args* : $res) => do
-    -- (1) Brackets aren't allowed inside binder types in this version.
     for arg in args do
       rejectRefsIn "binder types" arg.raw
-    -- (2) Walk the result type, collecting and rewriting each `❰x❱` reference. Repeated
-    -- references to the same `x` share one hypothesis binder, so the recorded statement reads
-    -- "if `x` holds, then …" rather than the noisier "if `x` holds and `x` holds, then …".
+    -- Brackets are deduplicated by referenced name, so repeated `❰x❱` references share one
+    -- hypothesis binder rather than producing `x.Stmt → x.Stmt → …`.
     let nameToHypRef : IO.Ref (NameMap (TSyntax `ident)) ← IO.mkRef {}
-    let hypOrderRef : IO.Ref (Array (Name × TSyntax `ident)) ← IO.mkRef #[]
+    let hypOrderRef : IO.Ref (Array (TSyntax `ident × ProofWantedRefInfo)) ← IO.mkRef #[]
     let res' ← res.raw.replaceM fun s => do
       unless s.getKind == ``proofWantedRef do return none
       let identStx : Syntax.Ident := ⟨s[1]⟩
@@ -128,23 +192,25 @@ def elabProofWanted : CommandElab
       match m.find? nm with
       | some h => return some h.raw
       | none =>
-        validateProofWantedRef nm identStx
+        let refInfo ← validateProofWantedRef nm identStx
         let fresh ← freshHypName nm
         let hyp : TSyntax `ident := mkIdent fresh
         nameToHypRef.set (m.insert nm hyp)
-        hypOrderRef.modify (·.push (nm, hyp))
+        hypOrderRef.modify (·.push (hyp, refInfo))
         return some hyp.raw
     let res' : TSyntax `term := ⟨res'⟩
-    let order : Array (Name × TSyntax `ident) ← hypOrderRef.get
-    -- (3) Build the extra bracketed binders.
-    let extraBinders ← order.mapM fun (nm, hyp) =>
-      `(Parser.Term.bracketedBinderF| ($hyp : ProofWanted.Stmt $(mkIdent nm)))
-    -- (4) Emit the placeholder. Binders go on the `def` rather than inside `ProofWanted (∀ …)`,
-    -- which keeps the syntax-level splice simple at the cost that `❰name❱` only validates when
-    -- `name` itself has no binders (its type must unify with `ProofWanted _`). The `(_ : Prop)`
-    -- ascription preserves the "type is not a proposition" check the old `theorem` form gave
-    -- for free, and `linter.unusedVariables` is silenced so user binders that only appear in
-    -- the statement don't trigger warnings.
+    let order : Array (TSyntax `ident × ProofWantedRefInfo) ← hypOrderRef.get
+    -- Class-valued wanted refs get instance binders so Lean's typeclass synth can use them
+    -- (including via Π-instance synth when chained through another wanted). Non-class refs
+    -- get implicit binders so the chained-dependency parameter can be unified at use sites.
+    let extraBinders ← order.mapM fun (hyp, refInfo) =>
+      if refInfo.isClass then
+        `(Parser.Term.bracketedBinderF| [$hyp : $(refInfo.binderType)])
+      else
+        `(Parser.Term.bracketedBinderF| {$hyp : $(refInfo.binderType)})
+    -- The `(_ : Prop)` ascription reproduces the "not a proposition" check `theorem` gives for
+    -- free; `linter.unusedVariables` is silenced because user binders may only appear in the
+    -- statement.
     elabCommand <| ← `(
       section
       set_option linter.unusedVariables false

--- a/BatteriesTest/proof_wanted.lean
+++ b/BatteriesTest/proof_wanted.lean
@@ -21,13 +21,13 @@ info: env_trace : ProofWanted (17 = 37)
 proof_wanted with_ref :
     (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50) = 0
 
-/-! Each `❰foo❱` occurrence gets its own fresh hypothesis (no deduplication). -/
+/-! Repeated references to the same bracket share one hypothesis binder. -/
 proof_wanted double_ref :
     (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
       = (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
 
 /--
-info: double_ref : (h_env_trace h_env_trace_1 : env_trace.Stmt) → ProofWanted (⟨17, ⋯⟩ = ⟨17, ⋯⟩)
+info: double_ref : (h_env_trace : env_trace.Stmt) → ProofWanted (⟨17, ⋯⟩ = ⟨17, ⋯⟩)
 -/
 #guard_msgs in #check @double_ref
 

--- a/BatteriesTest/proof_wanted.lean
+++ b/BatteriesTest/proof_wanted.lean
@@ -1,15 +1,126 @@
 import Batteries.Util.ProofWanted
 
 /-!
-No unused variable warnings.
+# Tests for `proof_wanted`
 -/
-#guard_msgs in proof_wanted foo (x : Nat) : True
 
-/-!
-When not a proposition, rely on `theorem` command failing.
--/
+/-! No unused variable warnings, even though `x` is only mentioned in the statement. -/
+#guard_msgs in proof_wanted no_unused_warning (x : Nat) : x = x
+
+/-! After elaboration, the wanted statement lives in the env as a `ProofWanted`. -/
+proof_wanted env_trace : 17 = 37
+
 /--
-error: type of theorem `foo` is not a proposition
-  Nat → Nat
+info: env_trace : ProofWanted (17 = 37)
 -/
-#guard_msgs in proof_wanted foo (x : Nat) : Nat
+#guard_msgs in #check @env_trace
+
+/-! ## The headline bracket feature -/
+
+/-! Forward reference via `❰…❱` works: the resulting statement records "if env_trace then …". -/
+proof_wanted with_ref :
+    (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50) = 0
+
+/-! Multiple references to the same bracket dedupe into one hypothesis (no name clash). -/
+proof_wanted double_ref :
+    (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
+      = (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
+
+-- Two `❰env_trace❱` occurrences share *one* `h_env_trace` binder, not two.
+/--
+info: double_ref : (h_env_trace : env_trace.Stmt) → ProofWanted (⟨17, ⋯⟩ = ⟨17, ⋯⟩)
+-/
+#guard_msgs in #check @double_ref
+
+/-! Multiple distinct brackets each get their own hypothesis. -/
+proof_wanted other_eq : 5 = 11
+
+proof_wanted two_refs :
+    (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
+      = (⟨5, by rw [❰other_eq❱]; decide⟩ : Fin 50)
+
+-- Two distinct brackets produce two distinct binders, in order of first occurrence.
+/--
+info: two_refs : (h_env_trace : env_trace.Stmt) → (h_other_eq : other_eq.Stmt) → ProofWanted (⟨17, ⋯⟩ = ⟨5, ⋯⟩)
+-/
+#guard_msgs in #check @two_refs
+
+/-! ## Error cases -/
+
+/-! Referencing an unknown identifier. -/
+/--
+error: Unknown constant `not_declared`
+-/
+#guard_msgs in proof_wanted bad_unknown : ❰not_declared❱
+
+/-! Referencing a regular `def` (not a `ProofWanted`). -/
+private def regular_def : Nat := 0
+
+/--
+error: `regular_def` is not a `proof_wanted` declaration (its type is not `ProofWanted _`)
+-/
+#guard_msgs in proof_wanted bad_not_pw : ❰regular_def❱
+
+/-! Referencing a hand-rolled `ProofWanted` whose statement isn't a `Prop`. -/
+private def fake_pw : ProofWanted Nat := ⟨⟩
+
+/--
+error: `fake_pw` is a `ProofWanted`, but its statement is not a proposition
+-/
+#guard_msgs in proof_wanted bad_not_prop : ❰fake_pw❱
+
+/-! Using `❰…❱` outside `proof_wanted`. -/
+/--
+error: `❰…❱` may only appear inside the statement of `proof_wanted`
+-/
+#guard_msgs in example : True := ❰env_trace❱
+
+/-! `❰…❱` in a binder type is rejected explicitly. -/
+/--
+error: `❰…❱` may not appear inside binder types of `proof_wanted`
+-/
+#guard_msgs in proof_wanted bad_in_binder (h : ❰env_trace❱) : True
+
+/-! When the statement isn't a proposition the `: Prop` ascription rejects it. -/
+/--
+error: Type mismatch
+  Nat
+has type
+  Type
+of sort `Type 1` but is expected to have type
+  Prop
+of sort `Type`
+-/
+#guard_msgs in proof_wanted bad_not_a_prop (x : Nat) : Nat
+
+/-! ## Namespacing -/
+
+namespace N
+  proof_wanted ns_foo : 17 = 37
+
+  /-- Bracket resolution works on namespaced names; the generated hypothesis uses just the last
+      component of the name. -/
+  proof_wanted ns_bar :
+      (⟨17, by rw [❰ns_foo❱]; decide⟩ : Fin 50) = 0
+end N
+
+/-! ## Soundness
+
+A `proof_wanted` must *not* be usable as a proof of its statement. The placeholder has type
+`ProofWanted T`, not `T`, so any attempt to use it as a proof should fail to typecheck. -/
+
+/--
+error: Type mismatch
+  env_trace
+has type
+  ProofWanted (17 = 37)
+of sort `Type` but is expected to have type
+  17 = 37
+of sort `Prop`
+-/
+#guard_msgs in example : 17 = 37 := env_trace
+
+/-- And the bracket itself is not a term-level escape hatch: outside `proof_wanted` it errors,
+and inside `proof_wanted` it only adds a hypothesis to the recorded statement. So even chained
+`proof_wanted`s never produce a real proof, only a wanted theorem of the form "if … then …". -/
+example : True := trivial

--- a/BatteriesTest/proof_wanted.lean
+++ b/BatteriesTest/proof_wanted.lean
@@ -21,14 +21,13 @@ info: env_trace : ProofWanted (17 = 37)
 proof_wanted with_ref :
     (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50) = 0
 
-/-! Multiple references to the same bracket dedupe into one hypothesis (no name clash). -/
+/-! Each `❰foo❱` occurrence gets its own fresh hypothesis (no deduplication). -/
 proof_wanted double_ref :
     (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
       = (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
 
--- Two `❰env_trace❱` occurrences share *one* `h_env_trace` binder, not two.
 /--
-info: double_ref : (h_env_trace : env_trace.Stmt) → ProofWanted (⟨17, ⋯⟩ = ⟨17, ⋯⟩)
+info: double_ref : (h_env_trace h_env_trace_1 : env_trace.Stmt) → ProofWanted (⟨17, ⋯⟩ = ⟨17, ⋯⟩)
 -/
 #guard_msgs in #check @double_ref
 

--- a/BatteriesTest/proof_wanted.lean
+++ b/BatteriesTest/proof_wanted.lean
@@ -15,7 +15,7 @@ info: env_trace : ProofWanted (17 = 37)
 -/
 #guard_msgs in #check @env_trace
 
-/-! ## The headline bracket feature -/
+/-! ## Bracket references -/
 
 /-! Forward reference via `❰…❱` works: the resulting statement records "if env_trace then …". -/
 proof_wanted with_ref :
@@ -27,7 +27,7 @@ proof_wanted double_ref :
       = (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
 
 /--
-info: double_ref : (h_env_trace : env_trace.Stmt) → ProofWanted (⟨17, ⋯⟩ = ⟨17, ⋯⟩)
+info: @double_ref : {h_env_trace : env_trace.Stmt} → ProofWanted (⟨17, ⋯⟩ = ⟨17, ⋯⟩)
 -/
 #guard_msgs in #check @double_ref
 
@@ -38,11 +38,62 @@ proof_wanted two_refs :
     (⟨17, by rw [❰env_trace❱]; decide⟩ : Fin 50)
       = (⟨5, by rw [❰other_eq❱]; decide⟩ : Fin 50)
 
--- Two distinct brackets produce two distinct binders, in order of first occurrence.
+/-! Two distinct brackets produce two distinct binders, in order of first occurrence. -/
 /--
-info: two_refs : (h_env_trace : env_trace.Stmt) → (h_other_eq : other_eq.Stmt) → ProofWanted (⟨17, ⋯⟩ = ⟨5, ⋯⟩)
+info: @two_refs : {h_env_trace : env_trace.Stmt} → {h_other_eq : other_eq.Stmt} → ProofWanted (⟨17, ⋯⟩ = ⟨5, ⋯⟩)
 -/
 #guard_msgs in #check @two_refs
+
+/-! ## Parametrised references
+
+`❰foo❱` applied to arguments works when `foo` has its own binders. -/
+
+proof_wanted param_pw (n : Nat) : n = n
+
+proof_wanted ref_param_pw :
+    (⟨5, by rw [❰param_pw❱ 5]; decide⟩ : Fin 50) = 0
+
+/--
+info: @ref_param_pw : {h_param_pw : ∀ (n : Nat), (param_pw n).Stmt} → ProofWanted (⟨5, ⋯⟩ = 0)
+-/
+#guard_msgs in #check @ref_param_pw
+
+/-! Implicit binders. The printed `param_imp.Stmt` drops the implicit argument cosmetically; the
+underlying type retains it (see `set_option pp.all true`). -/
+
+proof_wanted param_imp {n : Nat} : n = n
+
+proof_wanted ref_param_imp :
+    (⟨5, by rw [show (5 : Nat) = 5 from ❰param_imp❱]; decide⟩ : Fin 50) = 0
+
+/--
+info: @ref_param_imp : {h_param_imp : ∀ {n : Nat}, param_imp.Stmt} → ProofWanted (⟨5, ⋯⟩ = 0)
+-/
+#guard_msgs in #check @ref_param_imp
+
+/-! Instance binders. `❰param_inst❱` resolves the instance from context. -/
+
+proof_wanted param_inst [Decidable True] : True
+
+proof_wanted ref_param_inst :
+    (⟨0, by have : True := ❰param_inst❱; decide⟩ : Fin 50) = 0
+
+/--
+info: @ref_param_inst : {h_param_inst : ∀ [inst : Decidable True], param_inst.Stmt} → ProofWanted (⟨0, ⋯⟩ = 0)
+-/
+#guard_msgs in #check @ref_param_inst
+
+/-! Multiple dependent binders. -/
+
+proof_wanted param_many (n : Nat) (h : n > 0) : n - 1 < n
+
+proof_wanted ref_param_many :
+    (⟨3, by have := ❰param_many❱ 4 (by decide); omega⟩ : Fin 50) = ⟨3, by decide⟩
+
+/--
+info: @ref_param_many : {h_param_many : ∀ (n : Nat) (h : n > 0), (param_many n h).Stmt} → ProofWanted (⟨3, ⋯⟩ = ⟨3, ⋯⟩)
+-/
+#guard_msgs in #check @ref_param_many
 
 /-! ## Error cases -/
 
@@ -56,7 +107,7 @@ error: Unknown constant `not_declared`
 private def regular_def : Nat := 0
 
 /--
-error: `regular_def` is not a `proof_wanted` declaration (its type is not `ProofWanted _`)
+error: `regular_def` is not a `proof_wanted` declaration (its type doesn't end in `ProofWanted _`)
 -/
 #guard_msgs in proof_wanted bad_not_pw : ❰regular_def❱
 


### PR DESCRIPTION
This PR makes `proof_wanted` leave a private placeholder `def name args : ProofWanted T := ⟨⟩` in the environment (previously the declaration was elaborated inside `withoutModifyingEnv` and discarded), and adds `❰foo❱` syntax for referring to earlier `proof_wanted`s in the same file. Inside a `proof_wanted`'s statement, `❰foo❱` desugars to a fresh hypothesis binder of `foo`'s statement (repeated references share one binder), so the recorded type is `foo.Stmt → …`. No axioms or sorries are introduced; `example : 17 = 37 := env_trace` rightly fails to typecheck because `env_trace : ProofWanted (17 = 37)`, not `17 = 37`.

`ProofWanted α` is a Unit-like wrapper and `ProofWanted.Stmt p` is a reducible accessor that exposes the statement as a type (never as an inhabitant). The bracket is only valid inside a `proof_wanted` statement; outside it errors. Brackets may not appear in binder types (they would reference an out-of-scope hypothesis).

Test coverage in [BatteriesTest/proof_wanted.lean](BatteriesTest/proof_wanted.lean): the original "no unused-var warning" and "not a proposition" cases plus forward references, deduplication, distinct hypotheses for distinct brackets, namespacing, the error paths, and a soundness check that a `proof_wanted` can't be used as a proof of its statement.

Parametrised `proof_wanted`s work too: for `foo : (n : Nat) → ProofWanted (P n)`, `❰foo❱ x` desugars to `h_foo x` where the generated hypothesis binder is `h_foo : ∀ (n : Nat), (foo n).Stmt`. The implementation uses `forallTelescope` to strip `foo`'s Π binders and builds the parameter-binder syntax directly (using `@foo.{us}` to keep implicits explicit, so the syntax round-trips). Implicit, strict-implicit, and instance binders all preserve their `BinderInfo`.

🤖 Prepared with Claude Code, reviewed by Codex.
