### PR TITLE
feat: allow a body on `proof_wanted` referencing other `proof_wanted`s

### DIFF
--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -161,12 +161,17 @@ private def validateProofWantedRef (nm : Name) (stx : Syntax) :
       let isCls : Bool := match αInst.getAppFn with
         | .const n _ => Lean.isClass env n
         | _ => false
-      -- Build syntax `∀ <foo's binders>, ProofWanted.Stmt (@foo.{us} arg1 ... argN)`. The `@`
-      -- keeps every implicit argument explicit so the syntax round-trips; the universe
-      -- annotations bind to `nm`'s own level params (auto-bound for the enclosing `proof_wanted`).
+      -- Build syntax `∀ <foo's binders>, ProofWanted.Stmt (@foo.{_, …} arg1 ... argN)`. The `@`
+      -- keeps every implicit argument explicit so the syntax round-trips. Each universe level is a
+      -- hole `_` rather than `nm`'s own level name: a named level would auto-bind to a fresh,
+      -- distinct param of the enclosing `proof_wanted`, leaving the hypothesis monomorphic at a
+      -- universe that can never match the use site (e.g. referencing `exists_ulift.{w}` at universe
+      -- `u`). A hole instead unifies with whatever universe the reference is used at. The single
+      -- remaining gap is using one reference at two different universes, which no single binder can
+      -- express; see the `ulift`/`TODO` tests in `BatteriesTest/proof_wanted.lean`.
       let fooIdent := mkIdent nm
       let levelStxs : Array (TSyntax `level) ←
-        info.levelParams.toArray.mapM fun u => `(level| $(mkIdent u):ident)
+        info.levelParams.toArray.mapM fun _ => `(level| _)
       let argIdents : Array (TSyntax `term) ← fvars.mapM fun fvar => do
         let decl ← fvar.fvarId!.getDecl
         return ⟨mkIdent decl.userName⟩

--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -11,8 +11,6 @@ public meta import Lean.Elab.Term
 public meta import Lean.Meta.Tactic.TryThis
 public meta import Batteries.Lean.Syntax
 
-@[expose] public section
-
 /-!
 # The `proof_wanted` command
 
@@ -34,16 +32,14 @@ Lean input method.
 -/
 
 /-- Wrapper recording that a `proof_wanted` of statement `α` has been declared. -/
-structure ProofWanted (α : Sort u) : Type where
+public structure ProofWanted (α : Sort u) : Type where
   /-- The trivial constructor; carries no information. -/
   mk ::
 
 /-- Reducible accessor so a binder of type `ProofWanted.Stmt foo` reduces to `foo`'s
 statement. Used by the desugaring of `❰foo❱`. -/
-@[reducible, nolint unusedArguments]
-def ProofWanted.Stmt {α : Sort u} (_ : ProofWanted α) : Sort u := α
-
-end
+@[reducible, nolint unusedArguments, expose]
+public def ProofWanted.Stmt {α : Sort u} (_ : ProofWanted α) : Sort u := α
 
 public meta section
 
@@ -81,13 +77,24 @@ a complete proof and the declaration should be a `theorem`.
 
 Typical usage:
 ```
-proof_wanted seventeen_eq_thirtyseven : 17 = 37
+-- A parameterless wanted fact:
+proof_wanted size_of_two_pushes_onto_empty :
+    ((#[] : Array Nat).push 1 |>.push 2).size = 2
 
-proof_wanted seventeen_in_fifty :
-    (⟨17, by rw [❰seventeen_eq_thirtyseven❱]; decide⟩ : Fin 50) = 0
+-- Referencing an earlier `proof_wanted` inside a statement (here in the `Fin`
+-- bound proof, which rewrites by the wanted fact):
+proof_wanted first_index_after_two_pushes :
+    (⟨0, by rw [❰size_of_two_pushes_onto_empty❱]; decide⟩
+      : Fin ((#[] : Array Nat).push 1 |>.push 2).size).val = 0
 
-proof_wanted seventeen_in_fifty' : (⟨17, by omega⟩ : Fin 50) = 0 := by
-  rw [show (17 : Nat) = 37 from ❰seventeen_eq_thirtyseven❱]; decide
+-- A parametrised wanted fact:
+proof_wanted size_after_two_pushes {α : Type _} (a : Array α) (x y : α) :
+    ((a.push x).push y).size = a.size + 2
+
+-- A partial proof may be supplied with `:= body`, deferring the harder step via `❰…❱`:
+proof_wanted size_after_three_pushes {α : Type _} (a : Array α) (x y z : α) :
+    (((a.push x).push y).push z).size = a.size + 3 := by
+  rw [Array.size_push, ❰size_after_two_pushes❱ a x y]
 ```
 -/
 @[command_parser]

--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -8,6 +8,7 @@ module
 public import Batteries.Tactic.Lint.Misc
 public meta import Lean.Elab.Command
 public meta import Lean.Elab.Term
+public meta import Lean.Meta.Tactic.TryThis
 public meta import Batteries.Lean.Syntax
 
 @[expose] public section
@@ -20,9 +21,13 @@ without blocking compilation. The declaration elaborates to a private placeholde
 binders : ProofWanted T := ⟨⟩`, so the wanted result is visible to downstream files and tools
 by type rather than by side-channel.
 
-Inside another `proof_wanted` statement, `❰foo❱` references an earlier `proof_wanted`; for
-parametrised `foo`, write `❰foo❱ x y` to apply it. The brackets desugar to fresh hypothesis
-binders, so the dependency appears in the recorded type.
+Inside another `proof_wanted`, `❰foo❱` references an earlier `proof_wanted`; for parametrised
+`foo`, write `❰foo❱ x y` to apply it. The brackets desugar to fresh hypothesis binders, so the
+dependency appears in the recorded type.
+
+A partial proof may be supplied with `proof_wanted name binders : T := body`. The body must
+reference at least one `❰…❱` (in the statement or the body); a complete proof should be a
+`theorem` instead, and the error includes a `Try this:` suggestion to that effect.
 
 The `❰` and `❱` characters (U+2770, U+2771) are entered as `\h<` and `\h>` with the standard
 Lean input method.
@@ -45,31 +50,34 @@ public meta section
 open Lean Elab Command
 
 /-- Internal bracket syntax `❰foo❱` for referencing an earlier `proof_wanted`.
-Only meaningful inside the statement of a `proof_wanted`; the term elaborator
+Only meaningful inside the statement or body of a `proof_wanted`; the term elaborator
 errors everywhere else. -/
 syntax (name := proofWantedRef) "❰" ident "❱" : term
 
-/-- Elaborator that errors when `❰…❱` is used outside a `proof_wanted` statement. -/
+/-- Elaborator that errors when `❰…❱` is used outside a `proof_wanted`. -/
 @[term_elab proofWantedRef]
 def elabProofWantedRef : Term.TermElab := fun _ _ =>
-  throwError "`❰…❱` may only appear inside the statement of `proof_wanted`"
+  throwError "`❰…❱` may only appear inside the statement or body of `proof_wanted`"
 
 /-- This proof would be a welcome contribution to the library!
 
-The syntax of `proof_wanted` declarations is just like that of `theorem`, but without `:=` or the
-proof. Lean checks that `proof_wanted` declarations are well-formed (e.g. it ensures that all the
-mentioned names are in scope, and that the theorem statement is a valid proposition), and records a
-private placeholder declaration of type `... → ProofWanted statement`.
+The syntax of `proof_wanted` declarations is just like that of `theorem`. Without `:=` and a
+proof body it records a wanted theorem; with one it records a partial proof that still depends on
+other wanted lemmas. Lean checks that `proof_wanted` declarations are well-formed (e.g. it ensures
+that all the mentioned names are in scope, and that the theorem statement is a valid proposition),
+and records a private placeholder declaration of type `... → ProofWanted statement`.
 
 Modifiers (such as `@[simp]`) are accepted for syntactic compatibility with `theorem` but are
 currently ignored.
 
-Inside another `proof_wanted`'s statement, write `❰foo❱` to assume an earlier `proof_wanted`
-named `foo`. The bracket may only appear inside the statement, since there is no proof body. It
-desugars to a fresh hypothesis binder of the matching type; for parametrised `foo : ∀ args,
-ProofWanted _`, the binder type is itself Π-quantified, so `❰foo❱ x y` applies the parameter to
-`x y`. `❰foo❱` only resolves names within the current file, since the placeholders are
-`private`.
+Inside another `proof_wanted`, write `❰foo❱` to reference an earlier `proof_wanted` named `foo`.
+The bracket may appear in the statement or the body, and each distinct reference becomes a fresh
+hypothesis binder of the matching type. For parametrised `foo : ∀ args, ProofWanted _`, the
+binder type is itself Π-quantified, so `❰foo❱ x y` applies the parameter to `x y`. `❰foo❱` only
+resolves names within the current file, since the placeholders are `private`.
+
+A body must reference at least one `❰…❱` (in the statement or the body); otherwise the body is
+a complete proof and the declaration should be a `theorem`.
 
 Typical usage:
 ```
@@ -78,16 +86,15 @@ proof_wanted seventeen_eq_thirtyseven : 17 = 37
 proof_wanted seventeen_in_fifty :
     (⟨17, by rw [❰seventeen_eq_thirtyseven❱]; decide⟩ : Fin 50) = 0
 
-proof_wanted nat_refl_unconditional (n : Nat) : n = n
-
-proof_wanted refl_at_five :
-    (⟨5, by rw [❰nat_refl_unconditional❱ 5]; decide⟩ : Fin 50) = 0
+proof_wanted seventeen_in_fifty' : (⟨17, by omega⟩ : Fin 50) = 0 := by
+  rw [show (17 : Nat) = 37 from ❰seventeen_eq_thirtyseven❱]; decide
 ```
 -/
 @[command_parser]
 def «proof_wanted» := leading_parser
   Parser.Command.declModifiers false >> "proof_wanted" >>
-    Parser.Command.declId >> Parser.ppIndent Parser.Command.declSig
+    Parser.Command.declId >> Parser.ppIndent Parser.Command.declSig >>
+    Parser.optional (" := " >> Parser.termParser)
 
 /-- Walk a syntax tree, throwing on the first `proofWantedRef` node found. -/
 private def rejectRefsIn (loc : String) (stx : Syntax) : CommandElabM Unit := do
@@ -174,19 +181,21 @@ private def validateProofWantedRef (nm : Name) (stx : Syntax) :
       return { binderType := binderTySyn, isClass := isCls }
 
 /-- Elaborate a `proof_wanted` declaration into a private placeholder `def` of type `ProofWanted`,
-expanding any `❰…❱` references to fresh hypothesis binders. -/
+expanding any `❰…❱` references to fresh hypothesis binders. If a body is supplied, it is
+type-checked against the statement; the placeholder still carries no proof. -/
 @[command_elab «proof_wanted»]
-def elabProofWanted : CommandElab
-  | `($_mods:declModifiers proof_wanted $name $args* : $res) => do
+def elabProofWanted : CommandElab := fun stx => do
+  match stx with
+  | `($mods:declModifiers proof_wanted $name $args* : $res $[:= $body?]?) => do
     for arg in args do
       rejectRefsIn "binder types" arg.raw
-    -- Brackets are deduplicated by referenced name, so repeated `❰x❱` references share one
-    -- hypothesis binder rather than producing `x.Stmt → x.Stmt → …`.
+    -- Brackets are deduplicated by referenced name across both the statement and the body, so
+    -- repeated `❰x❱` references share one hypothesis binder.
     let nameToHypRef : IO.Ref (NameMap (TSyntax `ident)) ← IO.mkRef {}
     let hypOrderRef : IO.Ref (Array (TSyntax `ident × ProofWantedRefInfo)) ← IO.mkRef #[]
-    let res' ← res.raw.replaceM fun s => do
-      unless s.getKind == ``proofWantedRef do return none
-      let identStx : Syntax.Ident := ⟨s[1]⟩
+    let rewriteRefs (s : Syntax) : CommandElabM Syntax := s.replaceM fun node => do
+      unless node.getKind == ``proofWantedRef do return none
+      let identStx : Syntax.Ident := ⟨node[1]⟩
       let nm ← liftCoreM <| Elab.realizeGlobalConstNoOverloadWithInfo identStx
       let m ← nameToHypRef.get
       match m.find? nm with
@@ -198,8 +207,20 @@ def elabProofWanted : CommandElab
         nameToHypRef.set (m.insert nm hyp)
         hypOrderRef.modify (·.push (hyp, refInfo))
         return some hyp.raw
-    let res' : TSyntax `term := ⟨res'⟩
-    let order : Array (TSyntax `ident × ProofWantedRefInfo) ← hypOrderRef.get
+    let res' : TSyntax `term := ⟨← rewriteRefs res.raw⟩
+    let body'? : Option (TSyntax `term) ← body?.mapM fun b => return ⟨← rewriteRefs b.raw⟩
+    let order ← hypOrderRef.get
+    -- A body with no brackets anywhere is a complete proof; suggest `theorem` instead.
+    if let some body := body? then
+      if order.isEmpty then
+        let thmStx ← `(command|
+          $mods:declModifiers theorem $name $args* : $res := $body)
+        liftCoreM <| Lean.Meta.Tactic.TryThis.addSuggestion stx
+          { suggestion := .tsyntax thmStx }
+        throwError
+          "`proof_wanted` with a body but no `❰…❱` reference is just a `theorem`; \
+           either replace `proof_wanted` with `theorem`, or reference another `proof_wanted` \
+           via `❰…❱` in the statement or body"
     -- Class-valued wanted refs get instance binders so Lean's typeclass synth can use them
     -- (including via Π-instance synth when chained through another wanted). Non-class refs
     -- get implicit binders so the chained-dependency parameter can be unified at use sites.
@@ -210,10 +231,21 @@ def elabProofWanted : CommandElab
         `(Parser.Term.bracketedBinderF| {$hyp : $(refInfo.binderType)})
     -- The `(_ : Prop)` ascription reproduces the "not a proposition" check `theorem` gives for
     -- free; `linter.unusedVariables` is silenced because user binders may only appear in the
-    -- statement.
-    elabCommand <| ← `(
-      section
-      set_option linter.unusedVariables false
-      private def $name $args* $extraBinders* : ProofWanted (($res' : Prop)) := ⟨⟩
-      end)
+    -- statement. The body, if present, is discharged via `have` so it is type-checked but
+    -- discarded.
+    match body'? with
+    | none =>
+      elabCommand <| ← `(
+        section
+        set_option linter.unusedVariables false
+        private def $name $args* $extraBinders* : ProofWanted (($res' : Prop)) := ⟨⟩
+        end)
+    | some body' =>
+      elabCommand <| ← `(
+        section
+        set_option linter.unusedVariables false
+        private def $name $args* $extraBinders* : ProofWanted (($res' : Prop)) :=
+          have : ($res' : Prop) := $body'
+          ⟨⟩
+        end)
   | _ => throwUnsupportedSyntax

--- a/BatteriesTest/proof_wanted.lean
+++ b/BatteriesTest/proof_wanted.lean
@@ -205,6 +205,46 @@ error: `proof_wanted` with a body but no `❰…❱` reference is just a `theore
 -/
 #guard_msgs in proof_wanted trivially_true : True := trivial
 
+/-! ## Universe-polymorphic references
+
+A reference to a universe-polymorphic `proof_wanted` is usable at a single use-site universe: the
+generated hypothesis binder spells the reference's universe levels as holes, so they unify with
+whatever universe the reference is used at (here `u`, distinct from the referenced `w`). -/
+
+proof_wanted exists_ulift.{w} : ∃ x : ULift.{w} Nat, x.down = 1
+
+proof_wanted exists_ulift_down.{u} : ∃ x : ULift.{u} Nat, x.down = 1 := by
+  obtain ⟨x : ULift.{u} Nat, hx⟩ := ❰exists_ulift❱
+  exact ⟨x, hx⟩
+
+/--
+info: @exists_ulift_down : {h_exists_ulift : exists_ulift.Stmt} → ProofWanted (∃ x, x.down = 1)
+-/
+#guard_msgs in #check @exists_ulift_down
+
+/-! TODO: a single `❰…❱` reference desugars to one hypothesis binder, which is monomorphic in
+universes. Using that one reference at two *different* universes therefore fails: the binder unifies
+with the first use's universe (`u` below) and the second use (`v`) then mismatches. Lifting this
+would need a universe-polymorphic hypothesis, which the term language can't express; the alternative
+is a separate `proof_wanted` per universe. Flagged for future contributors. -/
+/--
+error: Type mismatch
+  h_exists_ulift✝
+has type
+  ProofWanted.Stmt.{0} exists_ulift.{u}
+but is expected to have type
+  Exists.{v + 1} fun y => Eq.{1} (ULift.down.{v, 0} y) 1
+-/
+#guard_msgs in
+set_option pp.universes true in
+proof_wanted exists_ulift_two.{u, v} :
+    ∃ x : ULift.{u} Nat, ∃ y : ULift.{v} Nat, x.down = y.down := by
+  have hu : ∃ x : ULift.{u} Nat, x.down = 1 := ❰exists_ulift❱
+  have hv : ∃ y : ULift.{v} Nat, y.down = 1 := ❰exists_ulift❱
+  obtain ⟨x, hx⟩ := hu
+  obtain ⟨y, hy⟩ := hv
+  exact ⟨x, y, hx.trans hy.symm⟩
+
 /-! ## Namespacing -/
 
 namespace N

--- a/BatteriesTest/proof_wanted.lean
+++ b/BatteriesTest/proof_wanted.lean
@@ -121,7 +121,7 @@ error: `fake_pw` is a `ProofWanted`, but its statement is not a proposition
 
 /-! Using `❰…❱` outside `proof_wanted`. -/
 /--
-error: `❰…❱` may only appear inside the statement of `proof_wanted`
+error: `❰…❱` may only appear inside the statement or body of `proof_wanted`
 -/
 #guard_msgs in example : True := ❰env_trace❱
 
@@ -142,6 +142,68 @@ of sort `Type 1` but is expected to have type
 of sort `Type`
 -/
 #guard_msgs in proof_wanted bad_not_a_prop (x : Nat) : Nat
+
+/-! ## Bodies -/
+
+private def foo : Nat := 17
+proof_wanted foo_eq_37 : foo = 37
+proof_wanted thirtyseven_eq_41 : (37 : Nat) = 41
+
+/-! Body-only references still become binders on the recorded placeholder. -/
+proof_wanted foo_eq_41 : foo = 41 := by
+  rw [❰foo_eq_37❱]; exact ❰thirtyseven_eq_41❱
+
+/--
+info: @foo_eq_41 : {h_foo_eq_37 : foo_eq_37.Stmt} → {h_thirtyseven_eq_41 : thirtyseven_eq_41.Stmt} → ProofWanted (foo = 41)
+-/
+#guard_msgs in #check @foo_eq_41
+
+/-! A reference shared between statement and body is deduplicated. -/
+proof_wanted foo_eq_41_fin :
+    (⟨foo, by rw [❰foo_eq_37❱]; decide⟩ : Fin 50) = ⟨41, by decide⟩ := by
+  apply Fin.ext
+  show foo = 41
+  rw [❰foo_eq_37❱]; exact ❰thirtyseven_eq_41❱
+
+/--
+info: @foo_eq_41_fin : {h_foo_eq_37 : foo_eq_37.Stmt} →
+  {h_thirtyseven_eq_41 : thirtyseven_eq_41.Stmt} → ProofWanted (⟨foo, ⋯⟩ = ⟨41, ⋯⟩)
+-/
+#guard_msgs in #check @foo_eq_41_fin
+
+/-! A body that doesn't type-check is rejected; the bracket has already been substituted for the
+hypothesis binder by the time the error is reported. -/
+/--
+error: Type mismatch
+  h_foo_eq_37✝
+has type
+  foo_eq_37.Stmt
+but is expected to have type
+  foo + 1 = 38
+-/
+#guard_msgs in proof_wanted bad_body : foo + 1 = 38 := ❰foo_eq_37❱
+
+/-! A body may reference a parametrised `proof_wanted`. -/
+
+proof_wanted foo_param (m : Nat) : foo = m
+
+proof_wanted foo_eq_99 : foo = 99 := ❰foo_param❱ 99
+
+/--
+info: @foo_eq_99 : {h_foo_param : ∀ (m : Nat), (foo_param m).Stmt} → ProofWanted (foo = 99)
+-/
+#guard_msgs in #check @foo_eq_99
+
+/-! A body with no `❰…❱` reference anywhere is rejected with a `Try this:` pointing at
+`theorem`. -/
+/--
+info: Try this:
+  [apply] theorem trivially_true : True :=
+    trivial
+---
+error: `proof_wanted` with a body but no `❰…❱` reference is just a `theorem`; either replace `proof_wanted` with `theorem`, or reference another `proof_wanted` via `❰…❱` in the statement or body
+-/
+#guard_msgs in proof_wanted trivially_true : True := trivial
 
 /-! ## Namespacing -/
 


### PR DESCRIPTION
This PR (stacked on https://github.com/leanprover-community/batteries/pull/1814) extends `proof_wanted` to optionally take a body: `proof_wanted name binders : T := body`. Bracket references `❰foo❱` in the body are collected alongside those in the statement, deduplicated, and become extra hypothesis binders on the recorded `ProofWanted`. The body is type-checked against the statement via a `have`; the placeholder still carries no proof.

Diff against #1814's tip: https://github.com/leanprover-community/batteries/compare/proof_wanted...proof_wanted_body

A declaration that supplies a body but uses no `❰…❱` reference is rejected; such a body is a complete proof, and the declaration should be a `theorem`. The error includes a `Try this:` suggestion replacing it with a `theorem`.

Test coverage in [BatteriesTest/proof_wanted.lean](BatteriesTest/proof_wanted.lean) under "Bodies": body-only references that become binders; a reference shared between statement and body that is deduplicated; a body whose type check fails; a body using a parametrised `proof_wanted`; and the no-reference case showing the rendered `Try this:`.

🤖 Prepared with Claude Code, reviewed by Codex.
