### PR TITLE
refactor: consolidate linters

### DIFF
--- a/Batteries.lean
+++ b/Batteries.lean
@@ -108,7 +108,12 @@ public import Batteries.Tactic.HelpCmd
 public import Batteries.Tactic.Init
 public import Batteries.Tactic.Instances
 public import Batteries.Tactic.Lemma
-public import Batteries.Linter
+public import Batteries.Tactic.Lint
+public import Batteries.Tactic.Lint.Basic
+public import Batteries.Tactic.Lint.Frontend
+public import Batteries.Tactic.Lint.Misc
+public import Batteries.Tactic.Lint.Simp
+public import Batteries.Tactic.Lint.TypeClass
 public import Batteries.Tactic.NoMatch
 public import Batteries.Tactic.OpenPrivate
 public import Batteries.Tactic.PermuteGoals

--- a/Batteries.lean
+++ b/Batteries.lean
@@ -79,6 +79,7 @@ public import Batteries.Lean.TagAttribute
 public import Batteries.Lean.Util.EnvSearch
 public import Batteries.Linter
 public import Batteries.Linter.Frontend
+public import Batteries.Linter.Misc
 public import Batteries.Linter.Simp
 public import Batteries.Linter.TypeClass
 public import Batteries.Linter.UnnecessarySeqFocus
@@ -108,7 +109,6 @@ public import Batteries.Tactic.Instances
 public import Batteries.Tactic.Lemma
 public import Batteries.Tactic.Lint
 public import Batteries.Tactic.Lint.Basic
-public import Batteries.Tactic.Lint.Misc
 public import Batteries.Tactic.NoMatch
 public import Batteries.Tactic.OpenPrivate
 public import Batteries.Tactic.PermuteGoals

--- a/Batteries.lean
+++ b/Batteries.lean
@@ -79,6 +79,7 @@ public import Batteries.Lean.TagAttribute
 public import Batteries.Lean.Util.EnvSearch
 public import Batteries.Linter
 public import Batteries.Linter.Frontend
+public import Batteries.Linter.Simp
 public import Batteries.Linter.TypeClass
 public import Batteries.Linter.UnnecessarySeqFocus
 public import Batteries.Linter.UnreachableTactic
@@ -108,7 +109,6 @@ public import Batteries.Tactic.Lemma
 public import Batteries.Tactic.Lint
 public import Batteries.Tactic.Lint.Basic
 public import Batteries.Tactic.Lint.Misc
-public import Batteries.Tactic.Lint.Simp
 public import Batteries.Tactic.NoMatch
 public import Batteries.Tactic.OpenPrivate
 public import Batteries.Tactic.PermuteGoals

--- a/Batteries.lean
+++ b/Batteries.lean
@@ -78,6 +78,7 @@ public import Batteries.Lean.System.IO
 public import Batteries.Lean.TagAttribute
 public import Batteries.Lean.Util.EnvSearch
 public import Batteries.Linter
+public import Batteries.Linter.TypeClass
 public import Batteries.Linter.UnnecessarySeqFocus
 public import Batteries.Linter.UnreachableTactic
 public import Batteries.Logic
@@ -108,7 +109,6 @@ public import Batteries.Tactic.Lint.Basic
 public import Batteries.Tactic.Lint.Frontend
 public import Batteries.Tactic.Lint.Misc
 public import Batteries.Tactic.Lint.Simp
-public import Batteries.Tactic.Lint.TypeClass
 public import Batteries.Tactic.NoMatch
 public import Batteries.Tactic.OpenPrivate
 public import Batteries.Tactic.PermuteGoals

--- a/Batteries.lean
+++ b/Batteries.lean
@@ -78,6 +78,7 @@ public import Batteries.Lean.System.IO
 public import Batteries.Lean.TagAttribute
 public import Batteries.Lean.Util.EnvSearch
 public import Batteries.Linter
+public import Batteries.Linter.Basic
 public import Batteries.Linter.Frontend
 public import Batteries.Linter.Misc
 public import Batteries.Linter.Simp
@@ -108,7 +109,6 @@ public import Batteries.Tactic.Init
 public import Batteries.Tactic.Instances
 public import Batteries.Tactic.Lemma
 public import Batteries.Tactic.Lint
-public import Batteries.Tactic.Lint.Basic
 public import Batteries.Tactic.NoMatch
 public import Batteries.Tactic.OpenPrivate
 public import Batteries.Tactic.PermuteGoals

--- a/Batteries.lean
+++ b/Batteries.lean
@@ -108,7 +108,7 @@ public import Batteries.Tactic.HelpCmd
 public import Batteries.Tactic.Init
 public import Batteries.Tactic.Instances
 public import Batteries.Tactic.Lemma
-public import Batteries.Tactic.Lint
+public import Batteries.Linter
 public import Batteries.Tactic.NoMatch
 public import Batteries.Tactic.OpenPrivate
 public import Batteries.Tactic.PermuteGoals

--- a/Batteries.lean
+++ b/Batteries.lean
@@ -78,6 +78,7 @@ public import Batteries.Lean.System.IO
 public import Batteries.Lean.TagAttribute
 public import Batteries.Lean.Util.EnvSearch
 public import Batteries.Linter
+public import Batteries.Linter.Frontend
 public import Batteries.Linter.TypeClass
 public import Batteries.Linter.UnnecessarySeqFocus
 public import Batteries.Linter.UnreachableTactic
@@ -106,7 +107,6 @@ public import Batteries.Tactic.Instances
 public import Batteries.Tactic.Lemma
 public import Batteries.Tactic.Lint
 public import Batteries.Tactic.Lint.Basic
-public import Batteries.Tactic.Lint.Frontend
 public import Batteries.Tactic.Lint.Misc
 public import Batteries.Tactic.Lint.Simp
 public import Batteries.Tactic.NoMatch

--- a/Batteries/Control/Nondet/Basic.lean
+++ b/Batteries/Control/Nondet/Basic.lean
@@ -5,7 +5,7 @@ Authors: Kim Morrison
 -/
 module
 
-public import Batteries.Tactic.Lint.Misc
+public import Batteries.Linter.Misc
 public import Batteries.Data.MLList.Basic
 import Lean.Util.MonadBacktrack
 

--- a/Batteries/Data/DList/Basic.lean
+++ b/Batteries/Data/DList/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 module
-import Batteries.Tactic.Lint
+import Batteries.Linter
 public import Batteries.Linter.Simp
 
 @[expose] public section

--- a/Batteries/Data/DList/Basic.lean
+++ b/Batteries/Data/DList/Basic.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura
 -/
 module
 import Batteries.Tactic.Lint
-public import Batteries.Tactic.Lint.Simp
+public import Batteries.Linter.Simp
 
 @[expose] public section
 

--- a/Batteries/Data/Fin/Coding.lean
+++ b/Batteries/Data/Fin/Coding.lean
@@ -9,7 +9,7 @@ public import Batteries.Data.Char
 public import Batteries.Data.Fin.Lemmas
 public import Batteries.Tactic.Basic
 public import Batteries.Tactic.Trans
-public import Batteries.Tactic.Lint
+public import Batteries.Linter
 
 @[expose] public section
 

--- a/Batteries/Data/String/Lemmas.lean
+++ b/Batteries/Data/String/Lemmas.lean
@@ -6,7 +6,7 @@ Authors: Bulhwi Cha, Mario Carneiro
 module
 
 public import Batteries.Data.String.Basic
-public import Batteries.Tactic.Lint.Misc
+public import Batteries.Linter.Misc
 public import Batteries.Tactic.SeqFocus
 public import Batteries.Classes.Order
 public import Batteries.Data.List.Basic

--- a/Batteries/Data/UnionFind/Basic.lean
+++ b/Batteries/Data/UnionFind/Basic.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 -/
 module
 
-public import Batteries.Tactic.Lint.Misc
+public import Batteries.Linter.Misc
 public import Batteries.Tactic.SeqFocus
 public import Batteries.Util.Panic
 

--- a/Batteries/Lean/Util/EnvSearch.lean
+++ b/Batteries/Lean/Util/EnvSearch.lean
@@ -5,7 +5,7 @@ Authors: Shing Tak Lam, Daniel Selsam, Mario Carneiro
 -/
 module
 
-public import Batteries.Tactic.Lint.Misc
+public import Batteries.Linter.Misc
 
 namespace Lean
 

--- a/Batteries/Linter.lean
+++ b/Batteries/Linter.lean
@@ -1,6 +1,7 @@
 module -- shake: keep-all
 
 public meta import Batteries.Linter.Frontend
+public meta import Batteries.Linter.Misc
 public meta import Batteries.Linter.Simp
 public meta import Batteries.Linter.TypeClass
 public meta import Batteries.Linter.UnreachableTactic

--- a/Batteries/Linter.lean
+++ b/Batteries/Linter.lean
@@ -1,4 +1,5 @@
 module
 
+public meta import Batteries.Linter.TypeClass
 public meta import Batteries.Linter.UnreachableTactic
 public meta import Batteries.Linter.UnnecessarySeqFocus

--- a/Batteries/Linter.lean
+++ b/Batteries/Linter.lean
@@ -1,5 +1,6 @@
 module -- shake: keep-all
 
+public meta import Batteries.Linter.Basic
 public meta import Batteries.Linter.Frontend
 public meta import Batteries.Linter.Misc
 public meta import Batteries.Linter.Simp

--- a/Batteries/Linter.lean
+++ b/Batteries/Linter.lean
@@ -1,5 +1,6 @@
-module
+module -- shake: keep-all
 
+public meta import Batteries.Linter.Frontend
 public meta import Batteries.Linter.TypeClass
 public meta import Batteries.Linter.UnreachableTactic
 public meta import Batteries.Linter.UnnecessarySeqFocus

--- a/Batteries/Linter.lean
+++ b/Batteries/Linter.lean
@@ -1,6 +1,7 @@
 module -- shake: keep-all
 
 public meta import Batteries.Linter.Frontend
+public meta import Batteries.Linter.Simp
 public meta import Batteries.Linter.TypeClass
 public meta import Batteries.Linter.UnreachableTactic
 public meta import Batteries.Linter.UnnecessarySeqFocus

--- a/Batteries/Linter/Basic.lean
+++ b/Batteries/Linter/Basic.lean
@@ -14,8 +14,7 @@ public meta section
 
 open Lean Meta
 
-namespace Batteries.Tactic.Lint
-
+namespace Batteries.Linter
 /-!
 # Basic linter types and attributes
 
@@ -76,7 +75,7 @@ See `Lean.Environment.isAutoDecl` for an identical pure version of this function
   return (← getEnv).isAutoDecl decl
 
 /-- A linting test for the `#lint` command. -/
-structure Linter where
+structure _root_.Batteries.Linter where
   /-- `test` defines a test to perform on every declaration. It should never fail. Returning `none`
   signifies a passing test. Returning `some msg` reports a failing test with error `msg`. -/
   test : Name → MetaM (Option MessageData)

--- a/Batteries/Linter/Frontend.lean
+++ b/Batteries/Linter/Frontend.lean
@@ -54,8 +54,8 @@ omits it from only the specified linter checks.
 sanity check, lint, cleanup, command, tactic
 -/
 
-namespace Batteries.Tactic.Lint
-open Lean Elab Command
+namespace Batteries.Linter
+open Lean Elab Command Tactic Lint
 
 /-- Verbosity for the linter output. -/
 inductive LintVerbosity

--- a/Batteries/Linter/Frontend.lean
+++ b/Batteries/Linter/Frontend.lean
@@ -6,7 +6,7 @@ Authors: Floris van Doorn, Robert Y. Lewis, Gabriel Ebner
 module
 
 public meta import Lean.Elab.Command
-public meta import Batteries.Tactic.Lint.Basic
+public meta import Batteries.Linter.Basic
 
 public meta section
 
@@ -55,7 +55,7 @@ sanity check, lint, cleanup, command, tactic
 -/
 
 namespace Batteries.Linter
-open Lean Elab Command Tactic Lint
+open Lean Elab Command Tactic
 
 /-- Verbosity for the linter output. -/
 inductive LintVerbosity

--- a/Batteries/Linter/Frontend.lean
+++ b/Batteries/Linter/Frontend.lean
@@ -41,7 +41,7 @@ You can append `only name1 name2 ...` to any command to run a subset of linters,
 
 You can add custom linters by defining a term of type `Linter` with the
 `@[env_linter]` attribute.
-A linter defined with the name `Batteries.Tactic.Lint.myNewCheck` can be run with `#lint myNewCheck`
+A linter defined with the name `Batteries.Linter.myNewCheck` can be run with `#lint myNewCheck`
 or `#lint only myNewCheck`.
 If you add the attribute `@[env_linter disabled]` to `linter.myNewCheck` it will be
 registered, but not run by default.

--- a/Batteries/Linter/Misc.lean
+++ b/Batteries/Linter/Misc.lean
@@ -11,11 +11,11 @@ public meta import Lean.Meta.Check
 public meta import Lean.Meta.Instances
 public meta import Lean.Util.Recognizers
 public meta import Lean.DocString
-public meta import Batteries.Tactic.Lint.Basic
+public meta import Batteries.Linter.Basic
 
 public meta section
 
-open Lean Meta Std Batteries.Tactic.Lint
+open Lean Meta Std
 
 namespace Batteries.Linter
 

--- a/Batteries/Linter/Misc.lean
+++ b/Batteries/Linter/Misc.lean
@@ -15,9 +15,9 @@ public meta import Batteries.Tactic.Lint.Basic
 
 public meta section
 
-open Lean Meta Std
+open Lean Meta Std Batteries.Tactic.Lint
 
-namespace Batteries.Tactic.Lint
+namespace Batteries.Linter
 
 /-!
 # Various linters

--- a/Batteries/Linter/Simp.lean
+++ b/Batteries/Linter/Simp.lean
@@ -12,9 +12,9 @@ public meta import Batteries.Util.LibraryNote
 import all Lean.Meta.Tactic.Simp.SimpTheorems
 
 public meta section
-open Lean Meta
+open Lean Meta Batteries.Tactic.Lint
 
-namespace Batteries.Tactic.Lint
+namespace Batteries.Linter
 
 /-!
 # Linter for simplification lemmas
@@ -126,7 +126,7 @@ def formatLemmas (usedSimps : Simp.UsedSimps) (simpName : String) (higherOrder :
   return m!"{simpName}{contextual?} only {args.toList}"
 
 /-- A linter for simp lemmas whose lhs is not in simp-normal form, and which hence never fire. -/
-@[env_linter] def simpNF : Linter where
+@[env_linter] def simpNF : Tactic.Lint.Linter where
   noErrorsFound := "All left-hand sides of simp lemmas are in simp-normal form."
   errorsFound := "SOME SIMP LEMMAS ARE NOT IN SIMP-NORMAL FORM.
 Please change the lemma to make sure their left-hand sides are in simp normal form.
@@ -268,7 +268,7 @@ private def Expr.eqOrIff? : Expr → Option (Expr × Expr)
   | _ => none
 
 /-- A linter for commutativity lemmas that are marked simp. -/
-@[env_linter] def simpComm : Linter where
+@[env_linter] def simpComm : Tactic.Lint.Linter where
   noErrorsFound := "No commutativity lemma is marked simp."
   errorsFound := "COMMUTATIVITY LEMMA IS SIMP.
 Some commutativity lemmas are simp lemmas:"

--- a/Batteries/Linter/Simp.lean
+++ b/Batteries/Linter/Simp.lean
@@ -6,13 +6,13 @@ Authors: Gabriel Ebner
 module
 
 public meta import Lean.Meta.Tactic.Simp.Main
-public meta import Batteries.Tactic.Lint.Basic
+public meta import Batteries.Linter.Basic
 public meta import Batteries.Tactic.OpenPrivate
 public meta import Batteries.Util.LibraryNote
 import all Lean.Meta.Tactic.Simp.SimpTheorems
 
 public meta section
-open Lean Meta Batteries.Tactic.Lint
+open Lean Meta
 
 namespace Batteries.Linter
 
@@ -126,7 +126,7 @@ def formatLemmas (usedSimps : Simp.UsedSimps) (simpName : String) (higherOrder :
   return m!"{simpName}{contextual?} only {args.toList}"
 
 /-- A linter for simp lemmas whose lhs is not in simp-normal form, and which hence never fire. -/
-@[env_linter] def simpNF : Tactic.Lint.Linter where
+@[env_linter] def simpNF : Linter where
   noErrorsFound := "All left-hand sides of simp lemmas are in simp-normal form."
   errorsFound := "SOME SIMP LEMMAS ARE NOT IN SIMP-NORMAL FORM.
 Please change the lemma to make sure their left-hand sides are in simp normal form.
@@ -268,7 +268,7 @@ private def Expr.eqOrIff? : Expr → Option (Expr × Expr)
   | _ => none
 
 /-- A linter for commutativity lemmas that are marked simp. -/
-@[env_linter] def simpComm : Tactic.Lint.Linter where
+@[env_linter] def simpComm : Linter where
   noErrorsFound := "No commutativity lemma is marked simp."
   errorsFound := "COMMUTATIVITY LEMMA IS SIMP.
 Some commutativity lemmas are simp lemmas:"

--- a/Batteries/Linter/TypeClass.lean
+++ b/Batteries/Linter/TypeClass.lean
@@ -10,8 +10,8 @@ public meta import Batteries.Tactic.Lint.Basic
 
 public meta section
 
-namespace Batteries.Tactic.Lint
-open Lean Meta
+namespace Batteries.Linter
+open Lean Meta Tactic Lint
 
 /--
 Lints for instances with arguments that cannot be filled in, like

--- a/Batteries/Linter/TypeClass.lean
+++ b/Batteries/Linter/TypeClass.lean
@@ -6,12 +6,12 @@ Authors: Gabriel Ebner
 module
 
 public meta import Lean.Meta.Instances
-public meta import Batteries.Tactic.Lint.Basic
+public meta import Batteries.Linter.Basic
 
 public meta section
 
 namespace Batteries.Linter
-open Lean Meta Tactic Lint
+open Lean Meta
 
 /--
 Lints for instances with arguments that cannot be filled in, like

--- a/Batteries/Recycling/RBTree/Basic.lean
+++ b/Batteries/Recycling/RBTree/Basic.lean
@@ -7,7 +7,7 @@ module
 
 public import Batteries.Classes.Order
 public import Batteries.Control.ForInStep.Basic
-public import Batteries.Tactic.Lint.Misc
+public import Batteries.Linter.Misc
 
 @[expose] public section
 

--- a/Batteries/Tactic/Lint.lean
+++ b/Batteries/Tactic/Lint.lean
@@ -3,5 +3,4 @@ module
 public import Batteries.Tactic.Lint.Basic
 public import Batteries.Tactic.Lint.Misc
 public import Batteries.Tactic.Lint.Simp
-public import Batteries.Tactic.Lint.TypeClass
 public import Batteries.Tactic.Lint.Frontend

--- a/Batteries/Tactic/Lint.lean
+++ b/Batteries/Tactic/Lint.lean
@@ -2,4 +2,3 @@ module
 
 public import Batteries.Tactic.Lint.Basic
 public import Batteries.Tactic.Lint.Misc
-public import Batteries.Tactic.Lint.Simp

--- a/Batteries/Tactic/Lint.lean
+++ b/Batteries/Tactic/Lint.lean
@@ -3,4 +3,3 @@ module
 public import Batteries.Tactic.Lint.Basic
 public import Batteries.Tactic.Lint.Misc
 public import Batteries.Tactic.Lint.Simp
-public import Batteries.Tactic.Lint.Frontend

--- a/Batteries/Tactic/Lint.lean
+++ b/Batteries/Tactic/Lint.lean
@@ -1,6 +1,6 @@
 module
 
-public import Batteries.Tactic.Lint.Basic
+-- public import Batteries.Linter.Basic
 -- public import Batteries.Linter.Misc
 -- public import Batteries.Tactic.Lint.Simp
 -- public import Batteries.Tactic.Lint.TypeClass

--- a/Batteries/Tactic/Lint.lean
+++ b/Batteries/Tactic/Lint.lean
@@ -1,4 +1,7 @@
 module
 
 public import Batteries.Tactic.Lint.Basic
-public import Batteries.Tactic.Lint.Misc
+-- public import Batteries.Linter.Misc
+-- public import Batteries.Tactic.Lint.Simp
+-- public import Batteries.Tactic.Lint.TypeClass
+-- public import Batteries.Tactic.Lint.Frontend

--- a/Batteries/Tactic/Lint/Basic.lean
+++ b/Batteries/Tactic/Lint/Basic.lean
@@ -1,5 +1,5 @@
 module -- shake: keep-all
 
-public import Batteries.Linter
+public import Batteries.Linter.Basic
 
 deprecated_module (since := "2026-06-24")

--- a/Batteries/Tactic/Lint/Frontend.lean
+++ b/Batteries/Tactic/Lint/Frontend.lean
@@ -1,5 +1,5 @@
 module -- shake: keep-all
 
-public import Batteries.Linter
+public import Batteries.Linter.Frontend
 
 deprecated_module (since := "2026-06-24")

--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -1,5 +1,5 @@
 module -- shake: keep-all
 
-public import Batteries.Linter
+public import Batteries.Linter.Misc
 
 deprecated_module (since := "2026-06-24")

--- a/Batteries/Tactic/Lint/Simp.lean
+++ b/Batteries/Tactic/Lint/Simp.lean
@@ -1,5 +1,5 @@
 module -- shake: keep-all
 
-public import Batteries.Linter
+public import Batteries.Linter.Simp
 
 deprecated_module (since := "2026-06-24")

--- a/Batteries/Tactic/Lint/TypeClass.lean
+++ b/Batteries/Tactic/Lint/TypeClass.lean
@@ -1,5 +1,5 @@
 module -- shake: keep-all
 
-public import Batteries.Linter
+public import Batteries.Linter.TypeClass
 
 deprecated_module (since := "2026-06-24")

--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -5,7 +5,7 @@ Authors: David Thrane Christiansen, Kim Morrison
 -/
 module
 
-public import Batteries.Tactic.Lint.Misc
+public import Batteries.Linter.Misc
 public meta import Lean.Elab.Command
 public meta import Lean.Elab.Term
 public meta import Lean.Meta.Tactic.TryThis

--- a/BatteriesTest/by_contra.lean
+++ b/BatteriesTest/by_contra.lean
@@ -1,5 +1,7 @@
 import Batteries.Tactic.Basic
 
+set_option linter.defProp false
+
 private def nonDecid (P : Prop) (x : P) : P := by
   by_contra h
   guard_hyp h : ¬P

--- a/BatteriesTest/lintTC.lean
+++ b/BatteriesTest/lintTC.lean
@@ -1,7 +1,5 @@
-import Batteries.Tactic.Lint.TypeClass
+import Batteries.Linter.TypeClass
 import Lean.Elab.Command
-
-open Batteries.Tactic.Lint
 
 namespace A
 

--- a/BatteriesTest/lintTrace.lean
+++ b/BatteriesTest/lintTrace.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 /-!

--- a/BatteriesTest/lintTrace.lean
+++ b/BatteriesTest/lintTrace.lean
@@ -1,4 +1,5 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
 /-!
 Tests tracing in `#lint`.

--- a/BatteriesTest/lint_coinductive.lean
+++ b/BatteriesTest/lint_coinductive.lean
@@ -1,4 +1,5 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
 /-! Tests that linters skip auto-generated declarations from coinductive predicates. -/
 

--- a/BatteriesTest/lint_coinductive.lean
+++ b/BatteriesTest/lint_coinductive.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 /-! Tests that linters skip auto-generated declarations from coinductive predicates. -/

--- a/BatteriesTest/lint_docBlame.lean
+++ b/BatteriesTest/lint_docBlame.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 set_option linter.missingDocs false

--- a/BatteriesTest/lint_docBlame.lean
+++ b/BatteriesTest/lint_docBlame.lean
@@ -1,4 +1,5 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
 set_option linter.missingDocs false
 

--- a/BatteriesTest/lint_docBlameThm.lean
+++ b/BatteriesTest/lint_docBlameThm.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 set_option linter.missingDocs false

--- a/BatteriesTest/lint_docBlameThm.lean
+++ b/BatteriesTest/lint_docBlameThm.lean
@@ -1,4 +1,5 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
 set_option linter.missingDocs false
 

--- a/BatteriesTest/lint_dupNamespace.lean
+++ b/BatteriesTest/lint_dupNamespace.lean
@@ -1,4 +1,5 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
 -- internal names should be ignored
 theorem Foo.Foo._bar : True := trivial

--- a/BatteriesTest/lint_dupNamespace.lean
+++ b/BatteriesTest/lint_dupNamespace.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 -- internal names should be ignored

--- a/BatteriesTest/lint_lean.lean
+++ b/BatteriesTest/lint_lean.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 
 /-!
 This test file runs the environment linters set up in Batteries on the core Lean4 repository.

--- a/BatteriesTest/lint_simpNF.lean
+++ b/BatteriesTest/lint_simpNF.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 set_option linter.missingDocs false

--- a/BatteriesTest/lint_simpNF.lean
+++ b/BatteriesTest/lint_simpNF.lean
@@ -1,4 +1,5 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
 set_option linter.missingDocs false
 

--- a/BatteriesTest/lint_simpNF_respectTransparency.lean
+++ b/BatteriesTest/lint_simpNF_respectTransparency.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
 set_option linter.missingDocs false
 

--- a/BatteriesTest/lint_simpNF_respectTransparency.lean
+++ b/BatteriesTest/lint_simpNF_respectTransparency.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 set_option linter.missingDocs false

--- a/BatteriesTest/linterVisibility.lean
+++ b/BatteriesTest/linterVisibility.lean
@@ -1,10 +1,8 @@
 module
 
 -- import `Linter` into both private and public scopes for testing
-import Batteries.Tactic.Lint.Basic
-public import Batteries.Tactic.Lint.Basic
-
-open Batteries.Tactic.Lint
+import Batteries.Linter.Basic
+public import Batteries.Linter.Basic
 
 /--
 error: Cannot add attribute `[env_linter]`: Declaration `foo` must be marked as `meta`

--- a/BatteriesTest/lintsimp.lean
+++ b/BatteriesTest/lintsimp.lean
@@ -1,6 +1,7 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
-open Batteries.Tactic.Lint
+open Batteries.Tactic.Lint Batteries.Linter
 set_option linter.missingDocs false
 
 def f : Nat := 0

--- a/BatteriesTest/lintsimp.lean
+++ b/BatteriesTest/lintsimp.lean
@@ -1,7 +1,7 @@
 import Batteries.Tactic.Lint
 import Batteries.Linter
 
-open Batteries.Tactic.Lint Batteries.Linter
+open Batteries.Linter
 set_option linter.missingDocs false
 
 def f : Nat := 0

--- a/BatteriesTest/lintsimp.lean
+++ b/BatteriesTest/lintsimp.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 open Batteries.Linter

--- a/BatteriesTest/lintunused.lean
+++ b/BatteriesTest/lintunused.lean
@@ -1,4 +1,5 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 
 -- should be ignored as the proof contains sorry
 /-- warning: declaration uses `sorry` -/

--- a/BatteriesTest/lintunused.lean
+++ b/BatteriesTest/lintunused.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 
 -- should be ignored as the proof contains sorry

--- a/BatteriesTest/rfl.lean
+++ b/BatteriesTest/rfl.lean
@@ -2,6 +2,7 @@ import Lean.Elab.Tactic.Rfl
 -- Adaptation note: we should be able to remove this import after nightly-2024-03-19
 
 set_option linter.missingDocs false
+set_option linter.defProp false
 
 example (a : Nat) : a = a := rfl
 

--- a/BatteriesTest/trans.lean
+++ b/BatteriesTest/trans.lean
@@ -1,5 +1,7 @@
 import Batteries.Tactic.Trans
 
+set_option linter.defProp false
+
 -- testing that the attribute is recognized and used
 def nleq (a b : Nat) : Prop := a ≤ b
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -1,6 +1,6 @@
 {"ignoreImport": ["Init", "Lean"],
  "ignore":
- {"Batteries.Tactic.Lint.Simp":
+ {"Batteries.Linter.Simp":
   ["Batteries.Tactic.OpenPrivate", "Batteries.Util.LibraryNote"],
   "Batteries.Tactic.Exact": ["Batteries.Tactic.Alias"],
   "Batteries.Logic": ["Batteries.Tactic.Alias"],

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -6,20 +6,20 @@
   "Batteries.Logic": ["Batteries.Tactic.Alias"],
   "Batteries.Linter.UnreachableTactic":
   ["Batteries.Tactic.Unreachable", "Lean.Parser.Syntax"],
-  "Batteries.Lean.Util.EnvSearch": ["Batteries.Tactic.Lint.Misc"],
+  "Batteries.Lean.Util.EnvSearch": ["Batteries.Linter.Misc"],
   "Batteries.Lean.Meta.Simp": ["Batteries.Tactic.OpenPrivate"],
   "Batteries.Data.UnionFind.Basic":
-  ["Batteries.Tactic.Lint.Misc", "Batteries.Tactic.SeqFocus"],
+  ["Batteries.Linter.Misc", "Batteries.Tactic.SeqFocus"],
   "Batteries.Data.String.Matcher": ["Batteries.Data.String.Basic"],
   "Batteries.Data.String.Lemmas":
   ["Batteries.Data.String.Basic",
-   "Batteries.Tactic.Lint.Misc",
+   "Batteries.Linter.Misc",
    "Std.Classes.Ord.String"],
   "Batteries.Data.Rat.Lemmas": ["Batteries.Tactic.SeqFocus"],
   "Batteries.Data.Range.Lemmas":
   ["Batteries.Tactic.Alias", "Batteries.Tactic.SeqFocus"],
   "Batteries.Data.RBMap.Lemmas": ["Batteries.Tactic.Basic"],
-  "Batteries.Data.RBMap.Basic": ["Batteries.Tactic.Lint.Misc"],
+  "Batteries.Data.RBMap.Basic": ["Batteries.Linter.Misc"],
   "Batteries.Data.Nat.Lemmas": ["Batteries.Tactic.Alias"],
   "Batteries.Data.Nat.Bisect": ["Batteries.Tactic.Basic"],
   "Batteries.Data.List.Lemmas": ["Batteries.Tactic.Alias"],
@@ -32,7 +32,7 @@
   "Batteries.Data.Array.Pairwise": ["Batteries.Tactic.Alias"],
   "Batteries.Data.Array.Monadic": ["Batteries.Util.ProofWanted"],
   "Batteries.Data.Array.Lemmas": ["Batteries.Data.List.Lemmas"],
-  "Batteries.Control.Nondet.Basic": ["Batteries.Tactic.Lint.Misc"],
+  "Batteries.Control.Nondet.Basic": ["Batteries.Linter.Misc"],
   "Batteries.Control.Monad": ["Batteries.Tactic.Alias"],
   "Batteries.Control.AlternativeMonad": ["Batteries.Control.Lemmas"],
   "Batteries.CodeAction.Misc": ["Lean.Server.CodeActions.Provider"],

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -3,7 +3,7 @@ import Batteries.Linter
 import Batteries.Data.Array.Basic
 import Lake.CLI.Main
 
-open Lean Core Elab Command Batteries.Tactic.Lint Batteries.Linter
+open Lean Core Elab Command Batteries.Linter
 open System (FilePath)
 
 /-- The list of `nolints` pulled from the `nolints.json` file -/

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -1,4 +1,4 @@
-import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Linter
 import Batteries.Data.Array.Basic
 import Lake.CLI.Main
@@ -129,7 +129,7 @@ unsafe def runLinterOnModule (cfg : LinterConfig) (module : Name) : IO Unit := d
   buildIfNeeded module
   -- If the linter is being run on a target that doesn't import `Batteries.Tactic.List`,
   -- the linters are ineffective. So we import it here.
-  let lintModule := `Batteries.Tactic.Lint
+  let lintModule := `Batteries.Linter
   buildIfNeeded lintModule
   let nolintsFile : FilePath := "scripts/nolints.json"
   let nolints ← if ← nolintsFile.pathExists then

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -1,8 +1,9 @@
 import Batteries.Tactic.Lint
+import Batteries.Linter
 import Batteries.Data.Array.Basic
 import Lake.CLI.Main
 
-open Lean Core Elab Command Batteries.Tactic.Lint
+open Lean Core Elab Command Batteries.Tactic.Lint Batteries.Linter
 open System (FilePath)
 
 /-- The list of `nolints` pulled from the `nolints.json` file -/


### PR DESCRIPTION
This PR proposes to consolidate all linters in `Batteries.Linters`.

Previously, environment linters were in `Batteries.Tactic.Lint` and only syntax linters were in `Batteries.Linters`. The distinction is based on implementation instead of function.