### PR TITLE
feat: allow arguments starting with `_` to be unused in `unusedArguments` linter

### DIFF
--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -61,7 +61,7 @@ their value, and allow arguments starting with `_` to be unused. -/
         !ldecl.userName.isInternal && !e.containsFVar ldecl.fvarId
       if unused.isEmpty then return none
       addMessageContextFull <| .joinSep (← unused.toList.mapM fun (ldecl, i) =>
-          return m!"argument {i+1} {ldecl.toExpr} : {ldecl.type}") m!", "
+          return m!"argument {i+1}: {ldecl.toExpr} : {ldecl.type}") m!", "
 
 /-- A linter for checking definition doc strings. -/
 @[env_linter] def docBlame : Linter where

--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -37,8 +37,8 @@ This file defines several small linters.
       | return none
     return m!"The namespace {dup} is duplicated in the name"
 
-/-- A linter for checking for unused arguments.
-We skip all declarations that contain `sorry` in their value. -/
+/-- A linter for checking for unused arguments. We skip all declarations that contain `sorry` in
+their value, and allow arguments starting with `_` to be unused. -/
 @[env_linter] def unusedArguments : Linter where
   noErrorsFound := "No unused arguments."
   errorsFound := "UNUSED ARGUMENTS."
@@ -51,17 +51,17 @@ We skip all declarations that contain `sorry` in their value. -/
     if val.hasSorry || ty.hasSorry then return none
     forallTelescope ty fun args ty => do
       let mut e := (mkAppN val args).headBeta
+      let ldecls ← args.mapM getFVarLocalDecl
       e := mkApp e ty
-      for arg in args do
-        let ldecl ← getFVarLocalDecl arg
+      for ldecl in ldecls do
         e := mkApp e ldecl.type
         if let some val := ldecl.value? then
           e := mkApp e val
-      let unused := args.zip (.range args.size) |>.filter fun (arg, _) =>
-        !e.containsFVar arg.fvarId!
+      let unused := ldecls.zipIdx.filter fun (ldecl, _) =>
+        !ldecl.userName.isInternal && !e.containsFVar ldecl.fvarId
       if unused.isEmpty then return none
-      addMessageContextFull <| .joinSep (← unused.toList.mapM fun (arg, i) =>
-          return m!"argument {i+1} {arg} : {← inferType arg}") m!", "
+      addMessageContextFull <| .joinSep (← unused.toList.mapM fun (ldecl, i) =>
+          return m!"argument {i+1} {ldecl.toExpr} : {ldecl.type}") m!", "
 
 /-- A linter for checking definition doc strings. -/
 @[env_linter] def docBlame : Linter where

--- a/BatteriesTest/lintunused.lean
+++ b/BatteriesTest/lintunused.lean
@@ -8,4 +8,14 @@ def foo (h : 1 = 1) : Bool := sorry
 -- should be ignored since it uses `_h`
 def foo' (_h : 1 = 1) : Bool := true
 
+-- should not be ignored
+def fooBad (h : 1 = 1) : Bool := true
+
+/--
+error: /- The `unusedArguments` linter reports:
+UNUSED ARGUMENTS.
+This linter can be disabled with `@[nolint unusedArguments]`. -/
+#check fooBad /- argument 1: h : 1 = 1 -/
+-/
+#guard_msgs in
 #lint- only unusedArguments

--- a/BatteriesTest/lintunused.lean
+++ b/BatteriesTest/lintunused.lean
@@ -3,7 +3,9 @@ import Batteries.Tactic.Lint
 -- should be ignored as the proof contains sorry
 /-- warning: declaration uses `sorry` -/
 #guard_msgs in
-theorem Foo (h : 1 = 1) : True :=
-  sorry
+def foo (h : 1 = 1) : Bool := sorry
+
+-- should be ignored since it uses `_h`
+def foo' (_h : 1 = 1) : Bool := true
 
 #lint- only unusedArguments

--- a/BatteriesTest/lintunused.lean
+++ b/BatteriesTest/lintunused.lean
@@ -9,6 +9,7 @@ def foo (h : 1 = 1) : Bool := sorry
 def foo' (_h : 1 = 1) : Bool := true
 
 -- should not be ignored
+set_option linter.unusedVariables false in
 def fooBad (h : 1 = 1) : Bool := true
 
 /--


### PR DESCRIPTION
This PR makes the `unusedArguments` environment linter consistent with the unused variables syntax linter, and does not lint against arguments starting with `_`.

---

Note: the `unusedArguments` linter does not lint theorems. I've updated the tests to be meaningful, but I'm not sure if this is intentional.

Mentioned on zulip [here](https://leanprover.zulipchat.com/#narrow/channel/348111-batteries/topic/unused.20anonymous.20argument/near/599546336), but no response.