### PR TITLE
fix: ensure that CI actually runs `BatteriesRecycling`

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,7 +1,7 @@
 name = "batteries"
 testDriver = "BatteriesTest"
 lintDriver = "runLinter"
-defaultTargets = ["Batteries", "runLinter"]
+defaultTargets = ["Batteries", "BatteriesRecycling", "runLinter"]
 
 [leanOptions]
 linter.missingDocs = true


### PR DESCRIPTION
Maybe this was already tested somewhere else, but I didn't see it.