### PR TITLE
fix: correctly handle `globs` in `runLinter`

### DIFF
--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -28,13 +28,13 @@ def resolveDefaultRootModules : IO (Array Name) := do
     | throw <| IO.userError "failed to load Lake workspace"
 
   -- build an array of all root modules of `lean_exe` and `lean_lib` default targets
-  let defaultTargetModules := workspace.root.defaultTargets.flatMap fun target =>
+  let defaultTargetModules ← workspace.root.defaultTargets.flatMapM fun target => do
     if let some lib := workspace.root.findLeanLib? target then
-      lib.roots
+      pure <| (← lib.getModuleArray).map Lake.Module.name
     else if let some exe := workspace.root.findLeanExe? target then
-      #[exe.config.root]
+      pure #[exe.config.root]
     else
-      #[]
+      pure #[]
   return defaultTargetModules
 
 /-- Arguments for `runLinter`. -/
@@ -68,7 +68,7 @@ where
       if let some parsed := parseArg parsed arg then
         go parsed mods rest
       else
-        match arg.toName with 
+        match arg.toName with
         | .anonymous => Except.error [s!"could not parse argument '{arg}'"]
         | mod => go parsed (mod :: mods) rest
     | [] => Except.ok (parsed, mods.reverse)


### PR DESCRIPTION
Previously this would ignore `globs = ["Foo.+"]` and crash due to `Foo.lean` not existing.