### PR TITLE
fix: `❰…❱` references resolve at concrete universes

### DIFF
--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -207,10 +207,18 @@ private def classifyWantedRef (nm : Name) (stx : Syntax) : CommandElabM WantedRe
           Lean.mkFreshUserName (Name.mkSimple baseStr)
         let renameMap : Std.HashMap Name Name :=
           oldNames.zip freshNames |>.foldl (fun m (o, n) => m.insert o n) {}
+        -- `nm`'s universe parameters appear inside the delaborated binder types as named level
+        -- idents (e.g. `Type u_1`). Left as-is, each auto-binds to a fresh *rigid* universe
+        -- parameter of the enclosing wanted declaration, pinning the reference to a single
+        -- universe that can never match a concrete use site (`❰foo❱ ℚ` wants `ℚ : Type u_1`).
+        -- Rewrite them to level holes `_` so they unify at the use site, mirroring the hole
+        -- treatment already applied to `nm`'s application levels (`@nm.{_}`).
+        let holeLevel : Syntax := (← `(level| _)).raw
         let renameInTy (ty : TSyntax `term) : MetaM (TSyntax `term) := do
           return ⟨← ty.raw.replaceM fun s => do
             if s.isIdent then
               if let some n := renameMap[s.getId]? then return some (mkIdent n).raw
+              if info.levelParams.contains s.getId.eraseMacroScopes then return some holeLevel
             return none⟩
         let argIdents : Array (TSyntax `term) ← freshNames.mapM fun n => do
           let id := mkIdent n

--- a/BatteriesTest/def_wanted.lean
+++ b/BatteriesTest/def_wanted.lean
@@ -167,7 +167,7 @@ info: use_poly_dw : Type u_1 → {d_poly_dw : (α : Type u_1) → (poly_dw α).V
 -/
 #guard_msgs in #check @use_poly_dw
 
-/-! A universe-polymorphic wanted may equally be referenced at a *concrete* universe: the generated
+/-! A universe-polymorphic `def_wanted` may equally be referenced at a *concrete* universe: the generated
 binder spells `poly_dw`'s universe as a hole, so `❰poly_dw❱ Nat` resolves at `Type` rather than
 pinning the reference to a rigid universe parameter that no concrete type could match. -/
 def_wanted use_poly_concrete : Type := ❰poly_dw❱ Nat

--- a/BatteriesTest/def_wanted.lean
+++ b/BatteriesTest/def_wanted.lean
@@ -167,6 +167,16 @@ info: use_poly_dw : Type u_1 → {d_poly_dw : (α : Type u_1) → (poly_dw α).V
 -/
 #guard_msgs in #check @use_poly_dw
 
+/-! A universe-polymorphic wanted may equally be referenced at a *concrete* universe: the generated
+binder spells `poly_dw`'s universe as a hole, so `❰poly_dw❱ Nat` resolves at `Type` rather than
+pinning the reference to a rigid universe parameter that no concrete type could match. -/
+def_wanted use_poly_concrete : Type := ❰poly_dw❱ Nat
+
+/--
+info: @use_poly_concrete : {d_poly_dw : (α : Type) → (poly_dw α).Val} → DefWanted Type
+-/
+#guard_msgs in #check @use_poly_concrete
+
 /-! ## Namespacing -/
 
 namespace M

--- a/BatteriesTest/theorem_wanted.lean
+++ b/BatteriesTest/theorem_wanted.lean
@@ -225,6 +225,25 @@ info: @exists_ulift_down : {h_exists_ulift : exists_ulift.Stmt} → ProofWanted 
 -/
 #guard_msgs in #check @exists_ulift_down
 
+/-! When the referenced declaration carries a binder whose *type* mentions its universe parameter
+(`{α : Type _}`), that universe is also spelled as a hole in the generated hypothesis, so the
+reference may be used at a concrete universe — here `Array Nat` at `Type` — not just at a shared
+universe variable. -/
+
+theorem_wanted size_poly {α : Type _} (a : Array α) (x y : α) :
+    ((a.push x).push y).size = a.size + 2
+
+theorem_wanted ref_size_concrete (a : Array Nat) (x y : Nat) :
+    ((a.push x).push y).size = a.size + 2 := ❰size_poly❱ a x y
+
+/--
+info: ref_size_concrete : (a : Array Nat) →
+  (x y : Nat) →
+    {h_size_poly : ∀ {α : Type} (a : Array α) (x y : α), (size_poly a x y).Stmt} →
+      ProofWanted (((a.push x).push y).size = a.size + 2)
+-/
+#guard_msgs in #check @ref_size_concrete
+
 /-! TODO: a single `❰…❱` reference desugars to one hypothesis binder, which is monomorphic in
 universes. Using that one reference at two *different* universes therefore fails: the binder unifies
 with the first use's universe (`u` below) and the second use (`v`) then mismatches. Lifting this


### PR DESCRIPTION
This PR makes a `❰foo❱` reference to a universe-polymorphic `theorem_wanted` or `def_wanted` usable at a concrete universe, not only at a use site that shares `foo`'s universe variable.

The generated hypothesis binder spelled `foo`'s universe parameters as named levels inside the binder types (e.g. `(R : Type u_1)`), because they came straight out of `PrettyPrinter.delab`. Those named levels then auto-bound as fresh rigid universe parameters of the enclosing wanted declaration, pinning the reference to a single universe; `❰foo❱ ℚ` for `foo (R : Type _)` therefore failed with "ℚ should be of higher level". The fix rewrites them to level holes `_`, mirroring the treatment already applied to the application levels (`@foo.{_}`), so they unify with whatever universe the reference is used at. The existing `use_poly_dw` test still prints `Type u_1`, because the hole correctly solves to the shared universe when the use site genuinely shares it.

🤖 Prepared with Claude Code