### PR TITLE
chore: remove the `simpVarHead` linter

### DIFF
--- a/Batteries/Tactic/Lint/Simp.lean
+++ b/Batteries/Tactic/Lint/Simp.lean
@@ -22,7 +22,6 @@ namespace Batteries.Tactic.Lint
 This files defines several linters that prevent common mistakes when declaring simp lemmas:
 
  * `simpNF` checks that the left-hand side of a simp lemma is not simplified by a different lemma.
- * `simpVarHead` checks that the head symbol of the left-hand side is not a variable.
  * `simpComm` checks that commutativity lemmas are not marked as simplification lemmas.
 -/
 
@@ -261,23 +260,6 @@ Here are some tips depending on the error raised by the linter:
      then apply `try_for 10000 { simp }` to the right-hand side.  You will
      see a periodic sequence of lemma applications in the trace message.
 -/
-
-/--
-A linter for simp lemmas whose lhs has a variable as head symbol,
-and which hence never fire.
--/
-@[env_linter] def simpVarHead : Linter where
-  noErrorsFound :=
-    "No left-hand sides of a simp lemma has a variable as head symbol."
-  errorsFound := "LEFT-HAND SIDE HAS VARIABLE AS HEAD SYMBOL.
-Some simp lemmas have a variable as head symbol of the left-hand side (after whnfR):"
-  test := fun declName => do
-    unless ← isSimpTheorem declName do return none
-    checkAllSimpTheoremInfos (← getConstInfo declName).type fun {lhs, ..} => do
-    let lhs ← whnfR lhs
-    let headSym := lhs.getAppFn
-    unless headSym.isFVar do return none
-    return m!"Left-hand side has variable as head symbol: {headSym}"
 
 private def Expr.eqOrIff? : Expr → Option (Expr × Expr)
   | .app (.app (.app (.const ``Eq _) _) lhs) rhs

--- a/BatteriesTest/lintsimp.lean
+++ b/BatteriesTest/lintsimp.lean
@@ -14,9 +14,6 @@ run_meta guard (← [``fg, ``fh].anyM fun n => return (← simpNF.test n).isSome
 @[simp] theorem test_and_comm : a ∧ b ↔ b ∧ a := And.comm
 run_meta guard (← simpComm.test ``test_and_comm).isSome
 
-@[simp] theorem Prod.mk_fst : (a, b).1 = id a := rfl
-run_meta guard (← simpVarHead.test ``Prod.mk_fst).isSome
-
 def SemiconjBy [Mul M] (a x y : M) : Prop :=
   a * x = y * a
 


### PR DESCRIPTION
It has been upstreamed to core in leanprover/lean4#13325, and enabled by default in leanprover/lean4#13403.