### PR TITLE
feat: make unused_argument work again

### DIFF
--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -47,7 +47,7 @@ their value, and allow arguments starting with `_` to be unused. -/
     if ← isProjectionFn declName then return none
     let info ← getConstInfo declName
     let ty := info.type
-    let some val := info.value? | return none
+    let some val := info.value? (allowOpaque := true) | return none
     if val.hasSorry || ty.hasSorry then return none
     forallTelescope ty fun args ty => do
       let mut e := (mkAppN val args).headBeta
@@ -58,7 +58,12 @@ their value, and allow arguments starting with `_` to be unused. -/
         if let some val := ldecl.value? then
           e := mkApp e val
       let unused := ldecls.zipIdx.filter fun (ldecl, _) =>
-        !ldecl.userName.isInternal && !e.containsFVar ldecl.fvarId
+        -- We allow unused names that start with `_`, similar to the syntax linter, *unless* the
+        -- name starts with `inst` and has macro scopes, because then it is an
+        -- automatically generated instance name, and we do want to check those.
+        (!ldecl.userName.isInternal ||
+          (ldecl.userName.hasMacroScopes && ldecl.userName.getRoot == `inst)) &&
+          !e.containsFVar ldecl.fvarId
       if unused.isEmpty then return none
       addMessageContextFull <| .joinSep (← unused.toList.mapM fun (ldecl, i) =>
           return m!"argument {i+1}: {ldecl.toExpr} : {ldecl.type}") m!", "

--- a/BatteriesTest/lintunused.lean
+++ b/BatteriesTest/lintunused.lean
@@ -12,11 +12,28 @@ def foo' (_h : 1 = 1) : Bool := true
 set_option linter.unusedVariables false in
 def fooBad (h : 1 = 1) : Bool := true
 
+theorem foo1_ok (_h : 1 = 2) : True := trivial
+
+set_option linter.unusedVariables false in
+theorem foo2_bad (h : 1 = 1) : True := trivial
+
+theorem foo3_bad [Mul Nat] : True := trivial
+
+set_option linter.unusedVariables false in
+theorem foo4_bad [h : Mul Nat] : True := trivial
+
+theorem foo5_ok [_h : Mul Nat] : True := trivial
+
+theorem foo6_ok (_ : Nat) : True := trivial
+
 /--
 error: /- The `unusedArguments` linter reports:
 UNUSED ARGUMENTS.
 This linter can be disabled with `@[nolint unusedArguments]`. -/
 #check fooBad /- argument 1: h : 1 = 1 -/
+#check foo2_bad /- argument 1: h : 1 = 1 -/
+#check @foo3_bad /- argument 1: inst✝ : Mul Nat -/
+#check @foo4_bad /- argument 1: h : Mul Nat -/
 -/
 #guard_msgs in
 #lint- only unusedArguments


### PR DESCRIPTION
* enable the `unusedArguments` linter for theorems.
* enable the linter for unnamed type-class arguments.
* the linter remained disabled for names starting with `_`.
* add tests for all of these cases.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/348111-batteries/topic/unused.20anonymous.20argument/with/606308593