### PR TITLE
Lean pr testing 14177

### DIFF
--- a/Batteries/Data/List/Perm.lean
+++ b/Batteries/Data/List/Perm.lean
@@ -383,7 +383,7 @@ theorem Perm.getElem_idxBij_symm_eq_getElem [BEq α] [LawfulBEq α] {xs ys : Lis
   getElem_idxOfNth_eq
 
 theorem Perm.idxBij_leftInverse_idxBij_symm [BEq α] [LawfulBEq α] {xs ys : List α} (h : xs ~ ys) :
-    h.idxBij.LeftInverse h.symm.idxBij := by grind
+    h.idxBij.LeftInverse h.symm.idxBij := by grind (ematch := 6)
 
 theorem Perm.idxBij_rightInverse_idxBij_symm [BEq α] [LawfulBEq α] {xs ys : List α} (h : xs ~ ys) :
     h.idxBij.RightInverse h.symm.idxBij := by grind

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-14177-a0e54ad
+leanprover/lean4-pr-releases:pr-release-14177-7de24c9

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-14177-8b74f07
+leanprover/lean4-pr-releases:pr-release-14177-47876f3

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2026-06-24
+leanprover/lean4-pr-releases:pr-release-14177-a0e54ad


### PR DESCRIPTION
The changes upstream do not change the proof grind finds but they make grind take one step longer to identify it. Looking at the previous grind trace, this proof was already 76 instances long so it should probably be refactored by introducing better API to begin with.