### PR TITLE
chore: deprecate `MLList` in favour of `Std.IterM`

### DIFF
--- a/Batteries/Data/MLList.lean
+++ b/Batteries/Data/MLList.lean
@@ -1,5 +1,7 @@
-module
+module -- deprecated_module: ignore
 
 public import Batteries.Data.MLList.Basic
 public import Batteries.Data.MLList.Heartbeats
 public import Batteries.Data.MLList.IO
+
+deprecated_module "It is recommended to use `Std.IterM` instead." (since := "2026-07-06")

--- a/Batteries/Data/MLList/Basic.lean
+++ b/Batteries/Data/MLList/Basic.lean
@@ -7,6 +7,8 @@ module
 
 public import Batteries.Control.AlternativeMonad
 
+deprecated_module "It is recommended to use `Std.IterM` instead." (since := "2026-07-06")
+
 public section
 
 /-! # Monadic lazy lists.
@@ -73,6 +75,7 @@ private opaque spec (m) : MLList.Spec m
 end MLList
 
 /-- A monadic lazy list, controlled by an arbitrary monad. -/
+@[deprecated "It is recommended to use `Std.IterM` instead." (since := "2026-07-06")]
 def MLList (m : Type u → Type u) (α : Type u) : Type u := (MLList.spec m).listM α
 
 namespace MLList

--- a/Batteries/Data/MLList/Basic.lean
+++ b/Batteries/Data/MLList/Basic.lean
@@ -7,6 +7,8 @@ module
 
 public import Batteries.Control.AlternativeMonad
 
+set_option linter.deprecated false
+
 deprecated_module "It is recommended to use `Std.IterM` instead." (since := "2026-07-06")
 
 public section
@@ -79,8 +81,6 @@ end MLList
 def MLList (m : Type u → Type u) (α : Type u) : Type u := (MLList.spec m).listM α
 
 namespace MLList
-
-set_option linter.deprecated false
 
 /-- The empty `MLList`. -/
 @[inline] def nil : MLList m α := (MLList.spec m).nil

--- a/Batteries/Data/MLList/Basic.lean
+++ b/Batteries/Data/MLList/Basic.lean
@@ -80,6 +80,8 @@ def MLList (m : Type u → Type u) (α : Type u) : Type u := (MLList.spec m).lis
 
 namespace MLList
 
+set_option linter.deprecated false
+
 /-- The empty `MLList`. -/
 @[inline] def nil : MLList m α := (MLList.spec m).nil
 

--- a/Batteries/Data/MLList/Heartbeats.lean
+++ b/Batteries/Data/MLList/Heartbeats.lean
@@ -3,10 +3,12 @@ Copyright (c) 2023 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-module
+module -- deprecated_module: ignore
 
 public import Batteries.Data.MLList.Basic
 public import Lean.Util.Heartbeats
+
+set_option linter.deprecated false
 
 deprecated_module "It is recommended to use `Std.IterM` instead." (since := "2026-07-06")
 

--- a/Batteries/Data/MLList/Heartbeats.lean
+++ b/Batteries/Data/MLList/Heartbeats.lean
@@ -8,6 +8,8 @@ module
 public import Batteries.Data.MLList.Basic
 public import Lean.Util.Heartbeats
 
+deprecated_module "It is recommended to use `Std.IterM` instead." (since := "2026-07-06")
+
 @[expose] public section
 
 /-!

--- a/Batteries/Data/MLList/IO.lean
+++ b/Batteries/Data/MLList/IO.lean
@@ -3,10 +3,12 @@ Copyright (c) 2023 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-module
+module -- deprecated_module: ignore
 
 public import Batteries.Lean.System.IO
 public import Batteries.Data.MLList.Basic
+
+set_option linter.deprecated false
 
 deprecated_module "It is recommended to use `Std.IterM` instead." (since := "2026-07-06")
 

--- a/Batteries/Data/MLList/IO.lean
+++ b/Batteries/Data/MLList/IO.lean
@@ -8,6 +8,8 @@ module
 public import Batteries.Lean.System.IO
 public import Batteries.Data.MLList.Basic
 
+deprecated_module "It is recommended to use `Std.IterM` instead." (since := "2026-07-06")
+
 @[expose] public section
 
 /-!


### PR DESCRIPTION
This PR deprecates the `Batteries.Data.MLList` modules and the `MLList` type in favour of `Std.IterM`.

The deprecation is added at the module level for `Basic`, `Heartbeats`, and `IO`, and directly on the `MLList` type so existing users get a clear migration hint. 

see Zulip: [#mathlib4 > MLList vs IterM](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/MLList.20vs.20IterM/with/608303631)