### PR TITLE
feat(runLinter): --profile to report the slowest checks per linter

### DIFF
--- a/Batteries/Tactic/Lint/Frontend.lean
+++ b/Batteries/Tactic/Lint/Frontend.lean
@@ -117,29 +117,45 @@ def traceLint (msg : String) (inIO : Bool) (currentModule linterName : Option Na
       {if let some l := linterName then s!"- {l}: " else ""}\
       {msg}"
 
+/-- Reports the slowest checks for a single linter. Used by the `--profile` option. -/
+def reportSlowest (currentModule : Option Name) (linterName : Name)
+    (times : Array (Name × Nat)) (inIO : Bool) : CoreM Unit := do
+  let slowest := times.qsort (fun a b => a.2 > b.2) |>.filterMap fun (declName, ns) =>
+    let ms := ns / 1_000_000
+    if ms == 0 then none else some s!"  {ms}ms  {declName}"
+  let msg := if slowest.isEmpty then "all checks under 1ms"
+    else s!"slowest checks:\n{"\n".intercalate (slowest.take 10).toList}"
+  let line := s!"{if let some m := currentModule then s!"[{m}] " else ""}- {linterName}: {msg}"
+  if inIO then IO.println line else trace[Batteries.Lint] line
+
 /--
 Runs all the specified linters on all the specified declarations in parallel,
 producing a list of results.
 -/
 def lintCore (decls : Array Name) (linters : Array NamedLinter)
     -- For tracing:
-    (currentModule : Option Name := none) (inIO : Bool := false) :
+    (currentModule : Option Name := none) (inIO : Bool := false)
+    -- Report the slowest checks per linter.
+    (profile : Bool := false) :
     CoreM (Array (NamedLinter × Std.HashMap Name MessageData)) := do
   traceLint
       s!"Running linters:\n  {"\n  ".intercalate <| linters.map (s!"{·.name}") |>.toList}"
       inIO currentModule
 
-  let tasks : Array (NamedLinter × Array (Name × Task (Except Exception <| Option MessageData))) ←
+  let tasks : Array (NamedLinter ×
+      Array (Name × Task (Except Exception <| Option MessageData × Nat))) ←
     linters.mapM fun linter => do
       traceLint "(0/2) Starting..." inIO currentModule linter.name
       let decls ← decls.filterM (shouldBeLinted linter.name)
       (linter, ·) <$> decls.mapM fun decl => (decl, ·) <$> do
-        let act : MetaM (Option MessageData) := do
+        let act : MetaM (Option MessageData × Nat) := do
+          let start ← IO.monoNanosNow
           let result ← linter.test decl
           if inIO then
             -- Ensure any trace messages are propagated to stdout
             printTraces
-          return result
+          -- Return the elapsed time alongside the result, for the profile report.
+          return (result, (← IO.monoNanosNow) - start)
         EIO.asTask <| (← Core.wrapAsync (fun _ =>
           act |>.run' mkMetaContext -- We use the context used by `Command.liftTermElabM`
         ) (cancelTk? := none)) ()
@@ -147,9 +163,12 @@ def lintCore (decls : Array Name) (linters : Array NamedLinter)
   let result ← tasks.mapM fun (linter, decls) => do
     traceLint "(1/2) Getting..." inIO currentModule linter.name
     let mut msgs : Std.HashMap Name MessageData := {}
+    let mut times : Array (Name × Nat) := #[]
     for (declName, msgTask) in decls do
       let msg? ← match msgTask.get with
-      | Except.ok msg? => pure msg?
+      | Except.ok (msg?, elapsed) =>
+        if profile then times := times.push (declName, elapsed)
+        pure msg?
       | Except.error err => pure m!"LINTER FAILED:\n{err.toMessageData}"
 
       if let .some msg := msg? then
@@ -159,6 +178,8 @@ def lintCore (decls : Array Name) (linters : Array NamedLinter)
         s!"Failed with {msgs.size} messages\
         {if inIO then ", but these may include declarations in `nolints.json`" else ""}."}"
       inIO currentModule linter.name
+    if profile then
+      reportSlowest currentModule linter.name times inIO
     pure (linter, msgs)
   traceLint "Completed linting!" inIO currentModule
   return result

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -46,6 +46,8 @@ structure LinterConfig where
   noBuild : Bool := false
   /-- Whether to enable tracing. Default is `false`; set to `true` with `--trace` or `-v`. -/
   trace := false
+  /-- Whether to report the slowest checks per linter. Default is `false`; set with `--profile`. -/
+  profile := false
 
 @[always_inline, inline]
 private def Except.consError (e : ε) : Except (List ε) α → Except (List ε) α
@@ -79,6 +81,7 @@ where
     | "--no-build" => some { parsed with noBuild := true }
     | "--trace"
     | "-v"         => some { parsed with trace := true }
+    | "--profile"  => some { parsed with profile := true }
     | _ => none
 
 /--
@@ -99,7 +102,7 @@ def determineModulesToLint (specifiedModules : List Name) : IO (Array Name) := d
 
 /-- Run the Batteries linter on a given module and update the linter if `update` is `true`. -/
 unsafe def runLinterOnModule (cfg : LinterConfig) (module : Name) : IO Unit := do
-  let { updateNoLints, noBuild, trace } := cfg
+  let { updateNoLints, noBuild, trace, profile } := cfg
   initSearchPath (← findSysroot)
   let rec
     /-- Builds `module` if the filepath `olean` does not exist. Throws if olean is not found and
@@ -150,7 +153,7 @@ unsafe def runLinterOnModule (cfg : LinterConfig) (module : Name) : IO Unit := d
     traceLint s!"Starting lint..." (inIO := true) (currentModule := module)
     let decls ← getDeclsInPackage module.getRoot
     let linters ← getChecks (slow := true) (runAlways := none) (runOnly := none)
-    let results ← lintCore decls linters (inIO := true) (currentModule := module)
+    let results ← lintCore decls linters (inIO := true) (currentModule := module) (profile := profile)
     if updateNoLints then
       traceLint s!"Updating nolints file at {nolintsFile}" (inIO := true) (currentModule := module)
       writeJsonFile (α := NoLints) nolintsFile <|
@@ -180,7 +183,7 @@ unsafe def runLinterOnModule (cfg : LinterConfig) (module : Name) : IO Unit := d
       IO.println s!"-- Linting passed for {module}."
 
 /--
-Usage: `runLinter [--update] [--trace | -v] [--no-build] [Batteries.Data.Nat.Basic]...`
+Usage: `runLinter [--update] [--trace | -v] [--no-build] [--profile] [Batteries.Data.Nat.Basic]...`
 
 Runs the linters on all declarations in the given modules
 (or all root modules of Lake `lean_lib` and `lean_exe` default targets if no module is specified).
@@ -192,6 +195,8 @@ If `--trace` (or, synonymously, `-v`) is set, tracing will be enabled and logged
 
 If `--no-build` is set, `runLinter` will throw if either the oleans to be linted or the oleans
 which drive the linting itself are not present.
+
+If `--profile` is set, the slowest checks per linter are reported.
 -/
 unsafe def main (args : List String) : IO Unit := do
   let linterArgs := parseLinterArgs args
@@ -200,7 +205,7 @@ unsafe def main (args : List String) : IO Unit := do
     | Except.error msgs => do
       IO.eprintln s!"Error parsing args:\n  {"\n  ".intercalate msgs}"
       IO.eprintln "Usage: \
-        runLinter [--update] [--trace | -v] [--no-build] [Batteries.Data.Nat.Basic]..."
+        runLinter [--update] [--trace | -v] [--no-build] [--profile] [Batteries.Data.Nat.Basic]..."
       IO.Process.exit 1
 
   let modulesToLint ← determineModulesToLint mods


### PR DESCRIPTION
Adds a `--profile` flag to `runLinter`. With it, `lintCore` times each check and prints the slowest checks per linter (top 10, in ms):

```
[MyModule] - simpNF: slowest checks:
  6ms  Foo.bar
  5ms  Baz.qux
[MyModule] - dupNamespace: all checks under 1ms
```

Useful for spotting expensive linter/declaration pairs. No effect without the flag.
