### PR TITLE
chore: ignore deprecated declarations in some linters

### DIFF
--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -33,7 +33,6 @@ This file defines several small linters.
   test declName := do
     if ← isAutoDecl declName then return none
     if ← isImplicitReducible declName then return none
-    if Linter.isDeprecated (← getEnv) declName then return none
     let nm := declName.components
     let some (dup, _) := nm.zip nm.tail! |>.find? fun (x, y) => x == y
       | return none

--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -10,6 +10,7 @@ public meta import Lean.Util.ForEachExpr
 public meta import Lean.Meta.Check
 public meta import Lean.Meta.Instances
 public meta import Lean.Util.Recognizers
+public meta import Lean.Linter.Deprecated
 public meta import Lean.DocString
 public meta import Batteries.Tactic.Lint.Basic
 
@@ -32,6 +33,7 @@ This file defines several small linters.
   test declName := do
     if ← isAutoDecl declName then return none
     if ← isImplicitReducible declName then return none
+    if Linter.isDeprecated (← getEnv) declName then return none
     let nm := declName.components
     let some (dup, _) := nm.zip nm.tail! |>.find? fun (x, y) => x == y
       | return none
@@ -45,6 +47,7 @@ their value, and allow arguments starting with `_` to be unused. -/
   test declName := do
     if ← isAutoDecl declName then return none
     if ← isProjectionFn declName then return none
+    if Linter.isDeprecated (← getEnv) declName then return none
     let info ← getConstInfo declName
     let ty := info.type
     -- Don't use `value? (allowOpaque := true)`, which would include `opaque` definition values.
@@ -162,6 +165,7 @@ with rfl when elaboration results in a different term than the user intended. -/
   isFast := true
   test declName := do
     if ← isAutoDecl declName then return none
+    if Linter.isDeprecated (← getEnv) declName then return none
     forallTelescope (← getConstInfo declName).type fun _ ty => do
       let some (lhs, rhs) := ty.eq?.map (fun (_, l, r) => (l, r)) <|> ty.iff?
         | return none
@@ -224,6 +228,7 @@ variables should be implicit instead.
   errorsFound := "EXPLICIT VARIABLES ON BOTH SIDES OF IFF"
   test declName := do
     if ← isAutoDecl declName then return none
+    if Linter.isDeprecated (← getEnv) declName then return none
     forallTelescope (← getConstInfo declName).type fun args ty => do
       let some (lhs, rhs) := ty.iff? | return none
       let explicit ← args.filterM fun arg =>

--- a/BatteriesTest/lint_dupNamespace.lean
+++ b/BatteriesTest/lint_dupNamespace.lean
@@ -3,4 +3,7 @@ import Batteries.Tactic.Lint
 -- internal names should be ignored
 theorem Foo.Foo._bar : True := trivial
 
+-- deprecated names are ignored
+@[deprecated Foo.Foo._bar (since := "today")] theorem Foo.Foo.bar : True := trivial
+
 #lint- only dupNamespace

--- a/BatteriesTest/lint_dupNamespace.lean
+++ b/BatteriesTest/lint_dupNamespace.lean
@@ -3,7 +3,4 @@ import Batteries.Tactic.Lint
 -- internal names should be ignored
 theorem Foo.Foo._bar : True := trivial
 
--- deprecated names are ignored
-@[deprecated Foo.Foo._bar (since := "today")] theorem Foo.Foo.bar : True := trivial
-
 #lint- only dupNamespace

--- a/BatteriesTest/lintunused.lean
+++ b/BatteriesTest/lintunused.lean
@@ -29,6 +29,10 @@ theorem foo6_ok (_ : Nat) : True := trivial
 set_option linter.unusedVariables false in
 theorem foo7_bad [Mul Nat] [inst : Add Nat] {h : 1 = 1} ⦃h' : 0 = 0⦄ : True := trivial
 
+-- deprecated names are ignored
+set_option linter.unusedVariables false in
+@[deprecated foo6_ok (since := "today")] theorem foo6_ok' (h : Nat) : True := trivial
+
 /--
 error: /- The `unusedArguments` linter reports:
 UNUSED ARGUMENTS.


### PR DESCRIPTION
This PR ensures we ignore deprecated declarations in certain linters. 

The rule followed here for choosing linters to adjust is: "could modifying my declaration's code to satisfy the linter result in deprecating that declaration?" If so, we ignore deprecated declarations in that linter.

This PR also adds a test for the `unusedArguments` linter, but does not add tests for modified linters that do not already have tests.

---

Necessary for linting private declarations in #1831.