### PR TITLE
fix: ignore synthetic match terms in matchExpand code action

### DIFF
--- a/Batteries/CodeAction/Match.lean
+++ b/Batteries/CodeAction/Match.lean
@@ -17,7 +17,10 @@ open Lean Meta Elab Server RequestM CodeAction
 
 /-- Filter for the info-nodes to find the match-nodes. -/
 def isMatchTerm : Info → Bool
-  | .ofTermInfo i => i.stx.isOfKind ``Lean.Parser.Term.match
+  | .ofTermInfo i =>
+    i.stx.isOfKind ``Lean.Parser.Term.match
+      && i.stx.getArgs.any fun s =>
+        s.isAtom && s.getAtomVal == "match" && (s.getHeadInfo matches .original ..)
   | _ => false
 
 /-- Returns the String.range that encompasses `match e (with)`. -/


### PR DESCRIPTION
## Summary
- Skip macro-generated `match` nodes (e.g. `@fun`) that lack original source info in `isMatchTerm`
- Prevents LSP panic when `textDocument/codeAction` hits synthetic match terms

Fixes #1502

## Test plan
- [x] `lake build Batteries.CodeAction.Match`
- [ ] Reproduce with mik-jozef's LSP script — code action no longer offered on `@fun` match arms

Made with [Cursor](https://cursor.com)