### PR TITLE
chore: remove `dupNamespace` linter

### DIFF
--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -26,18 +26,6 @@ namespace Batteries.Tactic.Lint
 This file defines several small linters.
 -/
 
-/-- A linter for checking whether a declaration has a namespace twice consecutively in its name. -/
-@[env_linter] def dupNamespace : Linter where
-  noErrorsFound := "No declarations have a duplicate namespace."
-  errorsFound := "DUPLICATED NAMESPACES IN NAME:"
-  test declName := do
-    if ← isAutoDecl declName then return none
-    if ← isImplicitReducible declName then return none
-    let nm := declName.components
-    let some (dup, _) := nm.zip nm.tail! |>.find? fun (x, y) => x == y
-      | return none
-    return m!"The namespace {dup} is duplicated in the name"
-
 /-- A linter for checking for unused arguments. We skip all declarations that contain `sorry` in
 their value, and allow arguments starting with `_` to be unused. -/
 @[env_linter] def unusedArguments : Linter where

--- a/BatteriesTest/lint_dupNamespace.lean
+++ b/BatteriesTest/lint_dupNamespace.lean
@@ -1,6 +1,0 @@
-import Batteries.Tactic.Lint
-
--- internal names should be ignored
-theorem Foo.Foo._bar : True := trivial
-
-#lint- only dupNamespace

--- a/BatteriesTest/lint_lean.lean
+++ b/BatteriesTest/lint_lean.lean
@@ -37,7 +37,7 @@ but it is useful to run locally to see what the linters would catch.
 
 /-! Lints that have succeeded in the past, and hopefully still do! -/
 
-#lint only explicitVarsOfIff in all -- Found 1 errors, `Iff.refl`, which could be nolinted.
+-- #lint only explicitVarsOfIff in all -- Found 1 errors, `Iff.refl`, which could be nolinted.
 -- #lint only impossibleInstance  in all -- Found 0 errors
 -- #lint only simpVarHead in all -- Found 0 error
 -- #lint only unusedHavesSuffices in all  -- Found 0 errors

--- a/BatteriesTest/lint_lean.lean
+++ b/BatteriesTest/lint_lean.lean
@@ -12,9 +12,6 @@ but it is useful to run locally to see what the linters would catch.
 -- but if we move the environment linters up to Lean,
 -- these nolints should be installed there.
 -- (And in the meantime you can "manually" ignore them!)
--- attribute [nolint dupNamespace] Lean.Elab.Tactic.Tactic
--- attribute [nolint dupNamespace] Lean.Parser.Parser Lean.Parser.Parser.rec Lean.Parser.Parser.mk
---   Lean.Parser.Parser.info Lean.Parser.Parser.fn
 -- attribute [nolint explicitVarsOfIff] Iff.refl
 
 /-! Failing lints that need work. -/
@@ -40,7 +37,7 @@ but it is useful to run locally to see what the linters would catch.
 
 /-! Lints that have succeeded in the past, and hopefully still do! -/
 
--- #lint only explicitVarsOfIff in all -- Found 1 errors, `Iff.refl`, which could be nolinted.
+#lint only explicitVarsOfIff in all -- Found 1 errors, `Iff.refl`, which could be nolinted.
 -- #lint only impossibleInstance  in all -- Found 0 errors
 -- #lint only simpVarHead in all -- Found 0 error
 -- #lint only unusedHavesSuffices in all  -- Found 0 errors


### PR DESCRIPTION
The `dupNamespace` `env_linter` is now superseded by the `dupNamespace` syntax linter upstreamed to `linter.extra` in core and the equivalent `dupNamespace` syntax linter in mathlib.

---

Requested on #1892 and needed for #1831.