### PR TITLE
chore(Tactic/SeqFocus): rewrite `map_tacs` and `<;> [...]` tactic docstring

### DIFF
--- a/Batteries/Tactic/SeqFocus.lean
+++ b/Batteries/Tactic/SeqFocus.lean
@@ -14,7 +14,8 @@ open Lean Elab Meta Tactic
 namespace Batteries.Tactic
 
 /-- Assuming there are `n` goals, `map_tacs [t1; t2; ...; tn]` applies each `ti` to the respective
-goal and leaves the resulting subgoals. -/
+goal and leaves the resulting subgoals. It raises an error if the number of subgoals does not match
+-/
 elab "map_tacs " "[" ts:sepBy(tactic, "; ") "]" : tactic => do
   let goals ← getUnsolvedGoals
   let tacs := ts.getElems
@@ -40,6 +41,10 @@ elab "map_tacs " "[" ts:sepBy(tactic, "; ") "]" : tactic => do
 
 /-- `t <;> [t1; t2; ...; tn]` focuses on the first goal and applies `t`, which should result in `n`
 subgoals. It then applies each `ti` to the corresponding goal and collects the resulting
-subgoals. -/
+subgoals. It raises an error if the number of subgoals does not match.
+-/
+tactic_extension Lean.Parser.Tactic.«tactic_<;>_»
+
+@[tactic_alt Lean.Parser.Tactic.«tactic_<;>_»]
 macro:1 (name := seq_focus) t:tactic " <;> " "[" ts:sepBy(tactic, "; ") "]" : tactic =>
   `(tactic| focus ( $t:tactic; map_tacs [$ts;*]) )

--- a/Batteries/Tactic/SeqFocus.lean
+++ b/Batteries/Tactic/SeqFocus.lean
@@ -14,7 +14,7 @@ open Lean Elab Meta Tactic
 namespace Batteries.Tactic
 
 /-- Assuming there are `n` goals, `map_tacs [t1; t2; ...; tn]` applies each `ti` to the respective
-goal and leaves the resulting subgoals. It raises an error if the number of subgoals does not match
+goal and leaves the resulting subgoals. It raises an error if the number of subgoals does not match.
 -/
 elab "map_tacs " "[" ts:sepBy(tactic, "; ") "]" : tactic => do
   let goals ← getUnsolvedGoals


### PR DESCRIPTION
This PR rewrites the docstrings for the `map_tacs` and `<;> [...]` tactics, to consistently match the [official style guide](https://github.com/leanprover/lean4/blob/master/doc/style.md#tactics), to make sure they are complete while not getting too long.

In particular, add a remark about what happens if the number of goals mismatches, and make the `<;> [...]` an alternative to the plain `<;>` notation, so we don't get a duplicate entry in the doc-gen tactic overview.