### PR TITLE
fix: where command test

### DIFF
--- a/BatteriesTest/where.lean
+++ b/BatteriesTest/where.lean
@@ -67,7 +67,7 @@ open Lean.Elab hiding TermElabM
 #guard_msgs in #where
 
 open Command Batteries
-open Array renaming map -> listMap
+open _root_.Array renaming map -> listMap
 
 /--
 info: open Lean Lean.Meta


### PR DESCRIPTION
Preemptively fix a name ambiguity introduced by [lean4#14307](https://github.com/leanprover/lean4/pull/14307)