### PR TITLE
fix: sampleVariance definition for n=2

### DIFF
--- a/Batteries/Data/RunningStats.lean
+++ b/Batteries/Data/RunningStats.lean
@@ -62,7 +62,7 @@ public def variance (s : RunningStats) : Float :=
 /-- Unbiased variance of running data stream. -/
 @[inline]
 public def sampleVariance (s : RunningStats) : Float :=
-  if s.count ≤ 2 then 0.0 else s.var / (s.count - 1).toFloat
+  if s.count ≤ 1 then 0.0 else s.var / (s.count - 1).toFloat
 
 /-- Standard deviation of running data stream. -/
 @[inline]

--- a/Batteries/Data/RunningStats.lean
+++ b/Batteries/Data/RunningStats.lean
@@ -57,7 +57,7 @@ public def push (data : Float) (s : RunningStats) : RunningStats :=
 /-- Variance of running data stream. -/
 @[inline]
 public def variance (s : RunningStats) : Float :=
-  if s.count ≤ 1 then 0.0 else s.var / s.count.toFloat
+  if s.count = 0 then 0.0 else s.var / s.count.toFloat
 
 /-- Unbiased variance of running data stream. -/
 @[inline]


### PR DESCRIPTION
## Summary
- Guard was `count ≤ 2`, so two samples always returned variance 0.
- Unbiased `S/(n-1)` needs `n ≥ 2` → guard `≤ 1`.

## Test plan
- [ ] `lake build Batteries.Data.RunningStats`

Made with [Cursor](https://cursor.com)