### PR TITLE
feat: expand `Float` API

### DIFF
--- a/Batteries.lean
+++ b/Batteries.lean
@@ -30,6 +30,7 @@ public import Batteries.Data.ByteSlice
 public import Batteries.Data.Char
 public import Batteries.Data.DList
 public import Batteries.Data.Fin
+public import Batteries.Data.Float
 public import Batteries.Data.FloatArray
 public import Batteries.Data.HashMap
 public import Batteries.Data.Int
@@ -41,7 +42,6 @@ public import Batteries.Data.PairingHeap
 public import Batteries.Data.RBMap
 public import Batteries.Data.Random
 public import Batteries.Data.Range
-public import Batteries.Data.Rat
 public import Batteries.Data.RunningStats
 public import Batteries.Data.Stream
 public import Batteries.Data.String
@@ -52,7 +52,6 @@ public import Batteries.Lean.AttributeExtra
 public import Batteries.Lean.EStateM
 public import Batteries.Lean.Except
 public import Batteries.Lean.Expr
-public import Batteries.Lean.Float
 public import Batteries.Lean.HashMap
 public import Batteries.Lean.HashSet
 public import Batteries.Lean.IO.Process

--- a/Batteries/Data/Float.lean
+++ b/Batteries/Data/Float.lean
@@ -1,0 +1,4 @@
+module
+
+public import Batteries.Data.Float.Basic
+public import Batteries.Data.Float.Lemmas

--- a/Batteries/Data/Float.lean
+++ b/Batteries/Data/Float.lean
@@ -2,3 +2,4 @@ module
 
 public import Batteries.Data.Float.Basic
 public import Batteries.Data.Float.Lemmas
+public import Batteries.Data.Float.Rat

--- a/Batteries/Data/Float/Basic.lean
+++ b/Batteries/Data/Float/Basic.lean
@@ -42,7 +42,7 @@ def toRatParts (f : Float) : Option (Int × Int) :=
   else none
 
 /-- Returns `v, exp` integers such that `f = v * 2^exp`.
-Like `toRatParts`, but `e` is guaranteed to be minimal (`n` is always odd), unless `n = 0`.
+Like `toRatParts`, but `e` is guaranteed to be minimal (`v` is always odd), unless `v = 0`.
 `n.abs` will be at most `2^53 - 1` because `Float` has 53 bits of precision.
 Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
 partial def toRatParts' (f : Float) : Option (Int × Int) :=
@@ -117,7 +117,7 @@ def toRatParts (f : Float32) : Option (Int × Int) :=
   else none
 
 /-- Returns `v, exp` integers such that `f = v * 2^exp`.
-Like `toRatParts`, but `e` is guaranteed to be minimal (`n` is always odd), unless `n = 0`.
+Like `toRatParts`, but `e` is guaranteed to be minimal (`v` is always odd), unless `v = 0`.
 `n.abs` will be at most `2^53 - 1` because `Float` has 53 bits of precision.
 Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
 partial def toRatParts' (f : Float) : Option (Int × Int) :=

--- a/Batteries/Data/Float/Basic.lean
+++ b/Batteries/Data/Float/Basic.lean
@@ -22,6 +22,11 @@ involving `nan` return `false`, including in particular `nan == nan`.
 -/
 def nan : Float := 0/0
 
+/--
+The floating point value closest to the mathematical constant `π`.
+-/
+def pi : Float := 3.141592653589793
+
 /-- Returns `v, exp` integers such that `f = v * 2^exp`.
 (`e` is not minimal, but `v.abs` will be at most `2^53 - 1`.)
 Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
@@ -76,6 +81,83 @@ def toStringFull (f : Float) : String :=
   else f.toString -- inf, -inf, nan
 
 end Float
+
+namespace Float32
+
+/--
+The floating point value "positive infinity", also used to represent numerical computations
+which produce finite values outside of the representable range of `Float32`.
+-/
+def inf : Float32 := 1/0
+
+/--
+The floating point value "not a number", used to represent erroneous numerical computations
+such as `0 / 0`. Using `nan` in any float operation will return `nan`, and all comparisons
+involving `nan` return `false`, including in particular `nan == nan`.
+-/
+def nan : Float32 := 0/0
+
+/--
+The floating point value closest to the mathematical constant `π`.
+-/
+def pi : Float32 := 3.141592653589793
+
+/-- Returns `v, exp` integers such that `f = v * 2^exp`.
+(`e` is not minimal, but `v.abs` will be at most `2^53 - 1`.)
+Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
+def toRatParts (f : Float32) : Option (Int × Int) :=
+  if f.isFinite then
+    let (f', exp) := f.frExp
+    let x := (2^24:Nat).toFloat32 * f'
+    let v := if x < 0 then
+      (-(-x).floor.toUInt32.toNat : Int)
+    else
+      (x.floor.toUInt32.toNat : Int)
+    some (v, exp - 24)
+  else none
+
+/-- Returns `v, exp` integers such that `f = v * 2^exp`.
+Like `toRatParts`, but `e` is guaranteed to be minimal (`n` is always odd), unless `n = 0`.
+`n.abs` will be at most `2^53 - 1` because `Float` has 53 bits of precision.
+Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
+partial def toRatParts' (f : Float) : Option (Int × Int) :=
+  f.toRatParts.map fun (n, e) =>
+    if n == 0 then (0, 0) else
+      let neg : Bool := n < 0
+      let v := n.natAbs.toUInt64
+      let c := trailingZeros v 0
+      let v := (v >>> c.toUInt64).toNat
+      (if neg then -v else v, e + c.toNat)
+where
+  /-- Calculates the number of trailing bits in a `UInt64`. Requires `v ≠ 0`. -/
+  -- Note: it's a bit dumb to be using a loop here, but it is hopefully written
+  -- such that LLVM can tell we are computing trailing bits and do good things to it
+  -- TODO: prove termination under suitable assumptions (only relevant if `Float` is not opaque)
+  trailingZeros (v : UInt64) (c : UInt8) :=
+    if v &&& 1 == 0 then trailingZeros (v >>> 1) (c + 1) else c
+
+/-- Converts `f` to a string, including all decimal digits. -/
+def toStringFull (f : Float32) : String :=
+  if let some (v, exp) := toRatParts f then
+    let v' := v.natAbs
+    let s := if exp ≥ 0 then
+      Nat.repr (v' * (2^exp.toNat:Nat))
+    else
+      let e := (-exp).toNat
+      let intPart := v' / 2^e
+      let rem := v' % 2^e
+      if rem == 0 then
+        Nat.repr intPart
+      else
+        let rem := Nat.repr ((2^e + v' % 2^e) * 5^e)
+        let rem := rem.dropEndWhile (· == '0')
+        s!"{intPart}.{rem.drop 1}"
+    if v < 0 then s!"-{s}" else s
+  else f.toString -- inf, -inf, nan
+
+end Float32
+
+-- TODO: the following definitions don't produce correctly rounded results for subnormals
 
 /--
 Divide two natural numbers, to produce a correctly rounded (nearest-ties-to-even) `Float` result.

--- a/Batteries/Data/Float/Basic.lean
+++ b/Batteries/Data/Float/Basic.lean
@@ -130,9 +130,7 @@ partial def toRatParts' (f : Float) : Option (Int × Int) :=
       (if neg then -v else v, e + c.toNat)
 where
   /-- Calculates the number of trailing bits in a `UInt64`. Requires `v ≠ 0`. -/
-  -- Note: it's a bit dumb to be using a loop here, but it is hopefully written
-  -- such that LLVM can tell we are computing trailing bits and do good things to it
-  -- TODO: prove termination under suitable assumptions (only relevant if `Float` is not opaque)
+  -- TODO: optimize and make total
   trailingZeros (v : UInt64) (c : UInt8) :=
     if v &&& 1 == 0 then trailingZeros (v >>> 1) (c + 1) else c
 

--- a/Batteries/Data/Float/Basic.lean
+++ b/Batteries/Data/Float/Basic.lean
@@ -43,7 +43,7 @@ def toRatParts (f : Float) : Option (Int × Int) :=
 
 /-- Returns `v, exp` integers such that `f = v * 2^exp`.
 Like `toRatParts`, but `e` is guaranteed to be minimal (`v` is always odd), unless `v = 0`.
-`n.abs` will be at most `2^53 - 1` because `Float` has 53 bits of precision.
+`v.abs` will be at most `2^53 - 1` because `Float` has 53 bits of precision.
 Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
 partial def toRatParts' (f : Float) : Option (Int × Int) :=
   f.toRatParts.map fun (n, e) =>
@@ -103,7 +103,7 @@ The floating point value closest to the mathematical constant `π`.
 def pi : Float32 := 3.141592653589793
 
 /-- Returns `v, exp` integers such that `f = v * 2^exp`.
-(`e` is not minimal, but `v.abs` will be at most `2^53 - 1`.)
+(`e` is not minimal, but `v.abs` will be at most `2^24 - 1`.)
 Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
 def toRatParts (f : Float32) : Option (Int × Int) :=
   if f.isFinite then
@@ -118,7 +118,7 @@ def toRatParts (f : Float32) : Option (Int × Int) :=
 
 /-- Returns `v, exp` integers such that `f = v * 2^exp`.
 Like `toRatParts`, but `e` is guaranteed to be minimal (`v` is always odd), unless `v = 0`.
-`n.abs` will be at most `2^53 - 1` because `Float` has 53 bits of precision.
+`v.abs` will be at most `2^24 - 1` because `Float` has 24 bits of precision.
 Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
 partial def toRatParts' (f : Float) : Option (Int × Int) :=
   f.toRatParts.map fun (n, e) =>

--- a/Batteries/Data/Float/Lemmas.lean
+++ b/Batteries/Data/Float/Lemmas.lean
@@ -1,0 +1,303 @@
+/-
+Copyright (c) 2026 Robin Arnez. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Arnez
+-/
+module
+public import Batteries.Data.Float.Basic
+import all Init.Data.OfScientific
+
+@[expose] public section
+
+namespace Float.Model.UnpackedFloat
+
+/-- Returns true if the bits represent an NaN value -/
+def isNaNBits {spec : Format} (b : BitVec spec.numBits) : Bool :=
+  unpackExponent b = -1#_ ∧ unpackMantissa b ≠ 0#_
+
+namespace Sign
+
+@[simp]
+theorem ofBitVec_toBitVec (s : Sign) :
+    Sign.ofBitVec s.toBitVec = s := by
+  cases s <;> rfl
+
+@[simp]
+theorem toBitVec_ofBitVec (b : BitVec 1) :
+    (Sign.ofBitVec b).toBitVec = b := by
+  decide +revert
+
+protected theorem forall_iff {p : Sign → Prop} :
+    (∀ s : Sign, p s) ↔ p .positive ∧ p .negative := by
+  constructor
+  · intro h; simp [h]
+  · rintro ⟨h, h'⟩ (_ | _) <;> assumption
+
+instance {p : Sign → Prop} [∀ s, Decidable (p s)] : Decidable (∀ s : Sign, p s) :=
+  decidable_of_decidable_of_iff Sign.forall_iff.symm
+
+deriving instance DecidableEq for Sign
+
+instance : Std.LawfulEqOrd Sign where
+  compare_self := by decide
+  eq_of_compare := by decide
+
+instance : Std.TransOrd Sign where
+  eq_swap := by decide
+  isLE_trans := by decide
+
+end Sign
+
+theorem unpackMantissa_def {spec : Format} (b : BitVec spec.numBits) :
+    unpackMantissa b = b.extractLsb' 0 spec.mantissaBitsWithoutImplicit := by
+  ext; simp [unpackMantissa, BitVec.extractLsb]
+
+theorem unpackExponent_def {spec : Format} (b : BitVec spec.numBits) :
+    unpackExponent b = b.extractLsb' spec.mantissaBitsWithoutImplicit spec.exponentBits := by
+  ext; simp [unpackExponent, BitVec.extractLsb]
+
+theorem unpackSign_def {spec : Format} (b : BitVec spec.numBits) :
+    unpackSign b = b.extractLsb' (spec.mantissaBitsWithoutImplicit + spec.exponentBits) 1 := by
+  ext; simp [unpackSign, BitVec.extractLsb]
+
+@[simp]
+theorem unpackSign_packComponents {spec : Format} (s e m) :
+    unpackSign (packComponents spec s e m) = s.toBitVec := by
+  ext i (_ | ⟨⟨⟩⟩)
+  simp +arith [unpackSign_def, packComponents, BitVec.getElem_append]
+
+theorem packComponents_unpackSign_unpackExponent_unpackMantissa
+    {spec : Format} (b : BitVec spec.numBits) :
+    packComponents spec (Sign.ofBitVec (unpackSign b)) (unpackExponent b) (unpackMantissa b) = b := by
+  simp [packComponents]
+  rw [unpackSign_def, unpackExponent_def, unpackMantissa_def]
+  rw [BitVec.extractLsb'_append_extractLsb'_eq_extractLsb',
+    BitVec.extractLsb'_append_extractLsb'_eq_extractLsb']
+  · exact BitVec.extractLsb'_eq_self
+  · simp
+  · simp
+
+theorem pack_unpack {spec : Format} (b : BitVec spec.numBits)
+    (hspec : 2 ≤ spec.exponentBits := by decide) :
+    (unpack spec b).pack spec = if isNaNBits b then packedNaN spec else b := by
+  conv => rhs; rw [← packComponents_unpackSign_unpackExponent_unpackMantissa b]
+  unfold isNaNBits
+  fun_cases unpack with
+  | case1 mvec evec svec s hevec hmvec =>
+    -- infinity
+    simp +zetaDelta [pack, packedInfinity, hmvec, hevec]
+  | case2 mvec evec hevec hmvec =>
+    -- nan
+    simp +zetaDelta [pack, packedNaN, hevec, hmvec]
+  | case3 mvec evec svec s _ hevec hmvec =>
+    -- zero
+    simp +zetaDelta [pack, packedZero, hevec, hmvec]
+  | case4 mvec evec e svec s _ hevec hmvec =>
+    -- subnormal
+    simp only [hevec, unpackExponent_packComponents, BitVec.zero_eq_neg_one_iff,
+      Nat.ne_of_gt spec.he, unpackMantissa_packComponents, ne_eq, false_and, decide_false,
+      Bool.false_eq_true, ↓reduceIte, evec]
+    unfold pack
+    extract_lets mantbits biasedexp
+    simp only [BitVec.ofNat_toNat, BitVec.setWidth_eq, mvec]
+    rw [if_neg, if_neg]
+    · rw [Format.mantissaBits, Nat.add_comm, Nat.add_left_cancel_iff]
+      apply Nat.ne_of_lt
+      have := mt BitVec.toNat_inj.mp hmvec
+      simp only [BitVec.toNat_ofNat, Nat.zero_mod] at this
+      simp only [ne_eq, this, not_false_eq_true, Nat.log2_lt, gt_iff_lt, mantbits]
+      exact BitVec.isLt _
+    · simp +arith [biasedexp, e, hevec]
+      have := Nat.pow_le_pow_right (n := 2) (by decide) hspec
+      lia
+  | case5 mvec evec e svec s hevec hevec' =>
+    -- normal
+    simp only [unpackExponent_packComponents, hevec, unpackMantissa_packComponents, ne_eq,
+      false_and, decide_false, Bool.false_eq_true, ↓reduceIte, evec]
+    unfold pack
+    extract_lets mantbits biasedexp
+    rw [if_neg, if_pos]
+    · congr
+      · simp +arith [biasedexp, e, evec]
+      · rw [BitVec.ofNat_toNat, BitVec.setWidth_append]
+        simp [mvec]
+    · subst mantbits
+      have := Nat.two_pow_add_eq_or_of_lt mvec.isLt (a := 1)
+      rw [Nat.mul_one] at this
+      simp only [BitVec.toNat_append, BitVec.toNat_ofNat, Nat.pow_one, Nat.mod_succ,
+        Format.mantissaBits, Nat.add_comm 1, Nat.add_right_cancel_iff,
+        Nat.one_shiftLeft, ← this]
+      rw [Nat.log2_eq_iff (by simp)]
+      simp [Nat.two_pow_succ, mvec.isLt]
+    · simp +arith [biasedexp, e]
+      simp only [BitVec.neg_one_eq_allOnes, ← BitVec.lt_allOnes_iff, BitVec.lt_def,
+        BitVec.toNat_allOnes] at hevec
+      lia
+
+theorem pack_unpack_of_valid {spec : Format} {b : BitVec spec.numBits}
+    (hvalid : spec.Valid b) (hspec : 2 ≤ spec.exponentBits := by decide) :
+    (unpack spec b).pack spec = b := by
+  rw [pack_unpack b hspec]
+  simp +contextual [isNaNBits, ← hvalid.eq_packedNaN]
+
+theorem unpack_inj_of_valid {spec : Format} {b b' : BitVec spec.numBits}
+    (hb : spec.Valid b) (hb' : spec.Valid b') (hspec : 2 ≤ spec.exponentBits := by decide) :
+    unpack spec b = unpack spec b' ↔ b = b' := by
+  constructor
+  · intro h
+    replace h := congrArg (pack spec) h
+    rwa [pack_unpack_of_valid hb hspec, pack_unpack_of_valid hb' hspec] at h
+  · rintro rfl; rfl
+
+theorem isNaNBits_packedNaN {spec : Format} : isNaNBits (packedNaN spec) := by
+  simp only [isNaNBits, packedNaN, unpackExponent_packComponents, unpackMantissa_packComponents,
+    ne_eq, true_and, decide_not, Bool.not_eq_eq_eq_not, Bool.not_true, decide_eq_false_iff_not]
+  intro h
+  replace h := congrArg (·.getLsbD (spec.mantissaBitsWithoutImplicit - 1)) h
+  simp [Nat.sub_one_lt (Nat.ne_of_gt spec.hm)] at h
+
+@[simp]
+theorem unpack_packedNaN {spec : Format} : unpack spec (packedNaN spec) = notANumber := by
+  have := @isNaNBits_packedNaN spec
+  simp only [isNaNBits, decide_eq_true_eq] at this
+  simp [unpack, this]
+
+@[simp]
+theorem unpack_packedZero {spec : Format} {sign : Sign} : unpack spec (packedZero spec sign) = .zero sign := by
+  simp [unpack, packedZero, Nat.ne_of_gt spec.he]
+
+@[simp]
+theorem isNaN_iff : isNaN x ↔ x = notANumber := by
+  cases x <;> simp [isNaN]
+
+theorem unpack_eq_notANumber_iff_of_valid {spec : Format} {b : BitVec spec.numBits}
+    (hvalid : spec.Valid b) (hspec : 2 ≤ spec.exponentBits := by decide) :
+    unpack spec b = notANumber ↔ b = packedNaN spec := by
+  rw [← @unpack_packedNaN spec, unpack_inj_of_valid hvalid ⟨fun _ _ => rfl⟩ hspec]
+
+theorem unpack_eq_zero_iff_of_valid {spec : Format} {sign : Sign} {b : BitVec spec.numBits}
+    (hvalid : spec.Valid b) (hspec : 2 ≤ spec.exponentBits := by decide) :
+    unpack spec b = zero sign ↔ b = packedZero spec sign := by
+  rw [← @unpack_packedZero spec, unpack_inj_of_valid hvalid ⟨by simp [packedZero]⟩ hspec]
+
+theorem isNaN_unpack_iff_of_valid {spec : Format} {b : BitVec spec.numBits}
+    (hvalid : spec.Valid b) (hspec : 2 ≤ spec.exponentBits := by decide) :
+    (unpack spec b).isNaN ↔ b = packedNaN spec := by
+  rw [isNaN_iff, unpack_eq_notANumber_iff_of_valid hvalid hspec]
+
+theorem beq_iff_ne_notANumber_and_eq (a b : UnpackedFloat) :
+    a.beq b ↔ a ≠ notANumber ∧ b ≠ notANumber ∧
+      (a = b ∨ (a = .zero .positive ∧ b = .zero .negative) ∨
+        (a = .zero .negative ∧ b = .zero .positive)) := by
+  simp only [UnpackedFloat.beq, beq_iff_eq, ne_eq]
+  fun_cases UnpackedFloat.compare a b <;> simp_all [eq_comm (α := UnpackedFloat), and_comm]
+  decide +revert -- inf/inf
+
+theorem unpack_beq_unpack_iff {spec : Format} {b b' : BitVec spec.numBits}
+    (hb : spec.Valid b) (hb' : spec.Valid b') (hspec : 2 ≤ spec.exponentBits := by decide) :
+    (unpack spec b).beq (unpack spec b') ↔ b ≠ packedNaN spec ∧ b' ≠ packedNaN spec ∧
+        (b = b' ∨ (b = packedZero spec .positive ∧ b' = packedZero spec .negative) ∨
+          (b = packedZero spec .negative ∧ b' = packedZero spec .positive)) := by
+  rw [beq_iff_ne_notANumber_and_eq]
+  simp [unpack_eq_notANumber_iff_of_valid, unpack_eq_zero_iff_of_valid, unpack_inj_of_valid, *]
+
+end Float.Model.UnpackedFloat
+
+theorem Float.toBits_inj {f f' : Float} : f.toBits = f'.toBits ↔ f = f' := by
+  rcases f with ⟨⟨⟩⟩; rcases f' with ⟨⟨⟩⟩; simp [toBits]
+
+theorem Float32.toBits_inj {f f' : Float32} : f.toBits = f'.toBits ↔ f = f' := by
+  rcases f with ⟨⟨⟩⟩; rcases f' with ⟨⟨⟩⟩; simp [toBits]
+
+@[simp]
+theorem Float.ofBits_toBits (f : Float) : ofBits f.toBits = f :=
+  toBits_inj.mp <| UInt64.toBitVec_inj.mp <|
+    Float.Model.UnpackedFloat.pack_unpack_of_valid f.toModel.valid
+
+@[simp]
+theorem Float32.ofBits_toBits (f : Float32) : ofBits f.toBits = f :=
+  toBits_inj.mp <| UInt32.toBitVec_inj.mp <|
+    Float.Model.UnpackedFloat.pack_unpack_of_valid f.toModel.valid
+
+@[simp]
+theorem Float.isNaN_eq_decide_eq_nan {f : Float} : isNaN f = decide (f = nan) := by
+  rw [Bool.eq_iff_iff, decide_eq_true_eq, ← toBits_inj, ← UInt64.toBitVec_inj]
+  exact Float.Model.UnpackedFloat.isNaN_unpack_iff_of_valid f.toModel.valid
+
+@[simp]
+theorem Float32.isNaN_eq_decide_eq_nan {f : Float32} : isNaN f = decide (f = nan) := by
+  rw [Bool.eq_iff_iff, decide_eq_true_eq, ← toBits_inj, ← UInt32.toBitVec_inj]
+  exact Float.Model.UnpackedFloat.isNaN_unpack_iff_of_valid f.toModel.valid
+
+theorem Float.beq_iff_ne_nan_and_eq {f f' : Float} :
+    f == f' ↔ f ≠ nan ∧ f' ≠ nan ∧ (f = f' ∨ (f = 0 ∧ f' = -0) ∨ (f = -0 ∧ f' = 0)) := by
+  simp only [ne_eq, ← toBits_inj, ← UInt64.toBitVec_inj]
+  exact Float.Model.UnpackedFloat.unpack_beq_unpack_iff f.toModel.valid f'.toModel.valid
+
+theorem Float32.beq_iff_ne_nan_and_eq {f f' : Float32} :
+    f == f' ↔ f ≠ nan ∧ f' ≠ nan ∧ (f = f' ∨ (f = 0 ∧ f' = -0) ∨ (f = -0 ∧ f' = 0)) := by
+  simp only [ne_eq, ← toBits_inj, ← UInt32.toBitVec_inj]
+  exact Float.Model.UnpackedFloat.unpack_beq_unpack_iff f.toModel.valid f'.toModel.valid
+
+@[simp]
+theorem Float.nan_beq_eq_false (f : Float) : (nan == f) = false := by
+  simp [← Bool.not_eq_true, beq_iff_ne_nan_and_eq]
+
+@[simp]
+theorem Float32.nan_beq_eq_false (f : Float32) : (nan == f) = false := by
+  simp [← Bool.not_eq_true, beq_iff_ne_nan_and_eq]
+
+@[simp]
+theorem Float.beq_nan_eq_false (f : Float) : (f == nan) = false := by
+  simp [← Bool.not_eq_true, beq_iff_ne_nan_and_eq]
+
+@[simp]
+theorem Float32.beq_nan_eq_false (f : Float32) : (f == nan) = false := by
+  simp [← Bool.not_eq_true, beq_iff_ne_nan_and_eq]
+
+@[simp]
+theorem Float.beq_self_iff {f : Float} : f == f ↔ f ≠ nan := by
+  grind [beq_iff_ne_nan_and_eq]
+
+@[simp]
+theorem Float32.beq_self_iff {f : Float32} : f == f ↔ f ≠ nan := by
+  grind [beq_iff_ne_nan_and_eq]
+
+@[simp]
+theorem Float.beq_self_eq_false_iff {f : Float} : (f == f) = false ↔ f = nan := by
+  grind [beq_self_iff]
+
+@[simp]
+theorem Float32.beq_self_eq_false_iff {f : Float32} : (f == f) = false ↔ f = nan := by
+  grind [beq_self_iff]
+
+/--
+This theorem is true in general but most other types have `LawfulBEq` where
+`bne_self_eq_false` or `bne_iff_ne` apply.
+-/
+@[simp] theorem Float.bne_eq {f : Float} : (f != f) = (!f == f) := (rfl)
+
+/--
+This theorem is true in general but most other types have `LawfulBEq` where
+`bne_self_eq_false` or `bne_iff_ne` apply.
+-/
+@[simp] theorem Float32.bne_eq {f : Float32} : (f != f) = (!f == f) := (rfl)
+
+instance : PartialEquivBEq Float where
+  symm := by grind [Float.beq_iff_ne_nan_and_eq]
+  trans := by grind [Float.beq_iff_ne_nan_and_eq]
+
+instance : PartialEquivBEq Float32 where
+  symm := by grind [Float32.beq_iff_ne_nan_and_eq]
+  trans := by grind [Float32.beq_iff_ne_nan_and_eq]
+
+-- but!
+example : ¬ EquivBEq Float := by
+  intro h
+  have : Float.nan == Float.nan := BEq.rfl
+  contradiction
+
+example : ¬ EquivBEq Float32 := by
+  intro h
+  have : Float32.nan == Float32.nan := BEq.rfl
+  contradiction

--- a/Batteries/Data/Float/Lemmas.lean
+++ b/Batteries/Data/Float/Lemmas.lean
@@ -69,7 +69,8 @@ theorem unpackSign_packComponents {spec : Format} (s e m) :
 
 theorem packComponents_unpackSign_unpackExponent_unpackMantissa
     {spec : Format} (b : BitVec spec.numBits) :
-    packComponents spec (Sign.ofBitVec (unpackSign b)) (unpackExponent b) (unpackMantissa b) = b := by
+    packComponents spec
+      (Sign.ofBitVec (unpackSign b)) (unpackExponent b) (unpackMantissa b) = b := by
   simp [packComponents]
   rw [unpackSign_def, unpackExponent_def, unpackMantissa_def]
   rw [BitVec.extractLsb'_append_extractLsb'_eq_extractLsb',
@@ -164,7 +165,8 @@ theorem unpack_packedNaN {spec : Format} : unpack spec (packedNaN spec) = notANu
   simp [unpack, this]
 
 @[simp]
-theorem unpack_packedZero {spec : Format} {sign : Sign} : unpack spec (packedZero spec sign) = .zero sign := by
+theorem unpack_packedZero {spec : Format} {sign : Sign} :
+    unpack spec (packedZero spec sign) = .zero sign := by
   simp [unpack, packedZero, Nat.ne_of_gt spec.he]
 
 @[simp]

--- a/Batteries/Data/Float/Lemmas.lean
+++ b/Batteries/Data/Float/Lemmas.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robin Arnez
 -/
 module
+
 public import Batteries.Data.Float.Basic
-import all Init.Data.OfScientific
+import all Init.Data.OfScientific -- remove when Float.ofNat is exposed
 
 @[expose] public section
 

--- a/Batteries/Data/Float/Lemmas.lean
+++ b/Batteries/Data/Float/Lemmas.lean
@@ -37,15 +37,7 @@ protected theorem forall_iff {p : Sign → Prop} :
 instance {p : Sign → Prop} [∀ s, Decidable (p s)] : Decidable (∀ s : Sign, p s) :=
   decidable_of_decidable_of_iff Sign.forall_iff.symm
 
-deriving instance DecidableEq for Sign
-
-instance : Std.LawfulEqOrd Sign where
-  compare_self := by decide
-  eq_of_compare := by decide
-
-instance : Std.TransOrd Sign where
-  eq_swap := by decide
-  isLE_trans := by decide
+deriving instance ReflBEq, LawfulBEq for Sign
 
 end Sign
 
@@ -193,8 +185,9 @@ theorem beq_iff_ne_notANumber_and_eq (a b : UnpackedFloat) :
       (a = b ∨ (a = .zero .positive ∧ b = .zero .negative) ∨
         (a = .zero .negative ∧ b = .zero .positive)) := by
   simp only [UnpackedFloat.beq, beq_iff_eq, ne_eq]
-  fun_cases UnpackedFloat.compare a b <;> simp_all [eq_comm (α := UnpackedFloat), and_comm]
-  decide +revert -- inf/inf
+  let := instDecidableEqOfLawfulBEq (α := Sign)
+  fun_cases UnpackedFloat.compare a b <;> simp_all [eq_comm (α := UnpackedFloat), and_comm] <;>
+    rename_i s₁ s₂ <;> revert s₁ s₂ <;> decide
 
 theorem unpack_beq_unpack_iff {spec : Format} {b b' : BitVec spec.numBits}
     (hb : spec.Valid b) (hb' : spec.Valid b') (hspec : 2 ≤ spec.exponentBits := by decide) :
@@ -275,32 +268,29 @@ theorem Float32.beq_self_eq_false_iff {f : Float32} : (f == f) = false ↔ f = n
   grind [beq_self_iff]
 
 /--
-This theorem is true in general but most other types have `LawfulBEq` where
+This theorem is true for all types but most other types have `LawfulBEq` where
 `bne_self_eq_false` or `bne_iff_ne` apply.
 -/
 @[simp] theorem Float.bne_eq {f : Float} : (f != f) = (!f == f) := (rfl)
 
 /--
-This theorem is true in general but most other types have `LawfulBEq` where
+This theorem is true for all types but most other types have `LawfulBEq` where
 `bne_self_eq_false` or `bne_iff_ne` apply.
 -/
 @[simp] theorem Float32.bne_eq {f : Float32} : (f != f) = (!f == f) := (rfl)
 
+/--
+Boolean equality on `Float`s is symmetric and transitive, but not reflexive, as demonstrated
+by `nan != nan`.
+-/
 instance : PartialEquivBEq Float where
   symm := by grind [Float.beq_iff_ne_nan_and_eq]
   trans := by grind [Float.beq_iff_ne_nan_and_eq]
 
+/--
+Boolean equality on `Float32`s is symmetric and transitive, but not reflexive, as demonstrated
+by `nan != nan`.
+-/
 instance : PartialEquivBEq Float32 where
   symm := by grind [Float32.beq_iff_ne_nan_and_eq]
   trans := by grind [Float32.beq_iff_ne_nan_and_eq]
-
--- but!
-example : ¬ EquivBEq Float := by
-  intro h
-  have : Float.nan == Float.nan := BEq.rfl
-  contradiction
-
-example : ¬ EquivBEq Float32 := by
-  intro h
-  have : Float32.nan == Float32.nan := BEq.rfl
-  contradiction

--- a/Batteries/Data/Float/Rat.lean
+++ b/Batteries/Data/Float/Rat.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro
 -/
 module
 
-public import Batteries.Lean.Float
+public import Batteries.Data.Float.Basic
 
 @[expose] public section
 

--- a/Batteries/Data/Rat.lean
+++ b/Batteries/Data/Rat.lean
@@ -1,3 +1,0 @@
-module
-
-public import Batteries.Data.Rat.Float

--- a/Batteries/Lean/Json.lean
+++ b/Batteries/Lean/Json.lean
@@ -5,22 +5,12 @@
 -/
 module
 
-public import Batteries.Lean.Float
+public import Batteries.Data.Float.Basic
 public import Lean.Data.Json.FromToJson.Basic
 
 @[expose] public section
 
 open Lean
-
-instance : OfScientific JsonNumber where
-  ofScientific mantissa exponentSign decimalExponent :=
-    if exponentSign then
-      { mantissa := mantissa, exponent := decimalExponent }
-    else
-      { mantissa := (mantissa * 10 ^ decimalExponent : Nat), exponent := 0 }
-
-instance : Neg JsonNumber where
-  neg jn := ⟨-jn.mantissa, jn.exponent⟩
 
 instance : ToJson Float where
   toJson x :=

--- a/BatteriesTest/float.lean
+++ b/BatteriesTest/float.lean
@@ -1,4 +1,4 @@
-import Batteries.Lean.Float
+import Batteries.Data.Float.Basic
 
 #guard 0.0.toRatParts == some (0, -53)
 #guard (2^(-1000):Float).toRatParts == some (4503599627370496, -1052)


### PR DESCRIPTION
This PR expands the `Float` API in several ways. Specifically, it adds:
- `Float32` versions of various `Float` definitions (e.g. `Float32.nan`)
- `Float.pi` and `Float32.pi` for the mathematical constant pi
- Basic lemmas about `Float` and `Float32`, in particular `Float.ofBits_toBits` and `PartialEquivBEq` instances

Furthermore, some modules were renamed, namely `Batteries.Lean.Float` to `Batteries.Data.Float.Basic` and `Batteries.Data.Rat.Float` to `Batteries.Data.Float.Rat`. The corresponding `deprecated_module`s will be added in a follow-up PR. In addition to that, two instances about `JsonNumber` already present in core were removed.

Closes leanprover/lean4#13369