### PR TITLE
fix: correct Vector.scanrM fast path

### DIFF
--- a/Batteries/Data/Vector/Basic.lean
+++ b/Batteries/Data/Vector/Basic.lean
@@ -100,7 +100,7 @@ where
       let pred := i - 1
       have h_pred : pred.toNat = i.toNat - 1 := USize.pred_toNat h_gt
       let next ← f (as.uget pred (by omega)) cur
-      loop next pred n_usize h_n (by omega) (acc.uset pred cur (by omega))
+      loop next pred n_usize h_n (by omega) (acc.uset pred next (by omega))
     else
       return acc
   termination_by i.toNat

--- a/BatteriesTest/vector.lean
+++ b/BatteriesTest/vector.lean
@@ -1,5 +1,9 @@
 import Batteries.Data.Vector
 
+/-! ### Testing scans over `Vector`. -/
+
+#guard (Vector.scanr (· + ·) 0 (#v[1, 2, 3] : Vector Nat 3)).toList == [6, 5, 3, 0]
+
 /-! ### Testing decidable quantifiers for `Vector`. -/
 
 example : ∃ v : Vector Bool 6, v.toList.count true = 3 := by decide


### PR DESCRIPTION
Fixes #1924.

`scanrMFast.loop` computed the next accumulator value but stored the previous value in the current output slot. Store `next` instead of `cur` so the compiled `@[implemented_by]` path agrees with the reference definition.

Add a compiled `#guard` for the reported suffix-sum example. This specifically exercises the fast path and would fail before the fix.

Checks run:
- `lake build --wfail`
- `lake test`
- `lake lint`
- `lake env lean scripts/check_imports.lean`
- `scripts/lintWhitespace.sh`
- remaining CI policy scans from `.github/workflows/build.yml`

No Mathlib adaptation is expected: this only corrects erroneous runtime behavior and adds a regression test.