### PR TITLE
fix: preserve reducibility when aliasing definitions

### DIFF
--- a/Batteries/Tactic/Alias.lean
+++ b/Batteries/Tactic/Alias.lean
@@ -159,14 +159,21 @@ elab (name := alias) mods:declModifiers "alias " alias:ident " := " nameStx:iden
         value := mkConst name (cinfo.toConstantVal.levelParams.map mkLevelParam)
       }
     else
+      -- Preserve reducibility (e.g. `abbrev` targets) instead of forcing `.regular 0`.
+      let hints := match cinfo with
+        | .defnInfo info => info.hints
+        | _ => .regular 0
       .defnDecl { cinfo.toConstantVal with
         name := declName
         value := mkConst name (cinfo.levelParams.map mkLevelParam)
-        hints := .regular 0 -- FIXME
+        hints := hints
         safety := if declMods.isUnsafe then .unsafe else .safe
       }
     checkNotAlreadyDeclared declName
     addDecl decl
+    -- `abbrev` (and `@[reducible]` / `@[irreducible]`) store status separately from
+    -- `ReducibilityHints`; copy it so aliases of abbrevs stay reducible.
+    setReducibilityStatus declName (← getReducibilityStatus name)
     if !declMods.isNoncomputable then
       if declMods.isMeta then
         modifyEnv (markMeta · declName)

--- a/BatteriesTest/alias.lean
+++ b/BatteriesTest/alias.lean
@@ -71,6 +71,13 @@ noncomputable alias foobaz3 := id
 /-- error: Failed to find LCNF signature for A.foobaz3 -/
 #guard_msgs in def foobaz4 (n : Nat) := foobaz3 n
 
+/- Test that aliasing an `abbrev` preserves reducibility hints -/
+
+abbrev reducibleAdd (n : Nat) : Nat := n + 1
+alias reducibleAddAlias := reducibleAdd
+-- Fails if the alias is registered as `.regular` instead of `.abbrev`.
+example : reducibleAddAlias 0 = 1 := by with_reducible rfl
+
 /- Test unsafe -/
 
 /-- doc string for barbaz -/


### PR DESCRIPTION
## Summary
- `alias` of an `abbrev` dropped hints/status, so the alias was not reducible.
- Copy `ReducibilityHints` and status from the target; add a regression test.

## Test plan
- [x] `lake build BatteriesTest.alias`


Made with [Cursor](https://cursor.com)