### PR TITLE
fix: Float32.toRatParts' takes Float32, not Float

### DIFF
--- a/Batteries/Data/Float/Basic.lean
+++ b/Batteries/Data/Float/Basic.lean
@@ -118,20 +118,20 @@ def toRatParts (f : Float32) : Option (Int × Int) :=
 
 /-- Returns `v, exp` integers such that `f = v * 2^exp`.
 Like `toRatParts`, but `e` is guaranteed to be minimal (`v` is always odd), unless `v = 0`.
-`v.abs` will be at most `2^24 - 1` because `Float` has 24 bits of precision.
+`v.abs` will be at most `2^24 - 1` because `Float32` has 24 bits of precision.
 Returns `none` when `f` is not finite (i.e. `inf`, `-inf` or a `nan`). -/
-partial def toRatParts' (f : Float) : Option (Int × Int) :=
+partial def toRatParts' (f : Float32) : Option (Int × Int) :=
   f.toRatParts.map fun (n, e) =>
     if n == 0 then (0, 0) else
       let neg : Bool := n < 0
-      let v := n.natAbs.toUInt64
+      let v := n.natAbs.toUInt32
       let c := trailingZeros v 0
-      let v := (v >>> c.toUInt64).toNat
+      let v := (v >>> c.toUInt32).toNat
       (if neg then -v else v, e + c.toNat)
 where
-  /-- Calculates the number of trailing bits in a `UInt64`. Requires `v ≠ 0`. -/
+  /-- Calculates the number of trailing bits in a `UInt32`. Requires `v ≠ 0`. -/
   -- TODO: optimize and make total
-  trailingZeros (v : UInt64) (c : UInt8) :=
+  trailingZeros (v : UInt32) (c : UInt8) :=
     if v &&& 1 == 0 then trailingZeros (v >>> 1) (c + 1) else c
 
 /-- Converts `f` to a string, including all decimal digits. -/

--- a/BatteriesTest/float.lean
+++ b/BatteriesTest/float.lean
@@ -66,3 +66,23 @@ import Batteries.Data.Float.Basic
 #guard (Int.divFloat 0 0).isNaN
 #guard (Int.divFloat 0 1).toString == "0.000000"
 #guard (Int.divFloat 0 (-1)).toString == "-0.000000"
+
+-- Float32: toRatParts / toRatParts' (24-bit mantissa)
+#guard (0.0 : Float32).toRatParts == some (0, -24)
+#guard ((2^(-100) : Float32)).toRatParts == some (8388608, -123)
+#guard ((2^(-10) : Float32)).toRatParts == some (8388608, -33)
+#guard ((0.5 : Float32)).toRatParts == some (8388608, -24)
+#guard ((5.0 : Float32)).toRatParts == some (10485760, -21)
+#guard ((-5.0 : Float32)).toRatParts == some (-10485760, -21)
+#guard ((1e40 : Float32)).toRatParts == none
+#guard ((-0/0 : Float32)).toRatParts == none
+
+#guard (0.0 : Float32).toRatParts' == some (0, 0)
+#guard ((2^(-100) : Float32)).toRatParts' == some (1, -100)
+#guard ((2^(-10) : Float32)).toRatParts' == some (1, -10)
+#guard ((0.5 : Float32)).toRatParts' == some (1, -1)
+#guard ((5.0 : Float32)).toRatParts' == some (5, 0)
+#guard ((-5.0 : Float32)).toRatParts' == some (-5, 0)
+#guard ((5.5 : Float32)).toRatParts' == some (11, -1)
+#guard ((1e40 : Float32)).toRatParts' == none
+#guard ((-0/0 : Float32)).toRatParts' == none


### PR DESCRIPTION
## Summary
- `Float32.toRatParts'` was copy-pasted from the `Float` API with argument type `Float` (and docs saying `Float` has 24-bit precision), so it was not a usable `Float32` helper.
- Type it on `Float32`, use `UInt32` for the trailing-zero strip (mantissa fits in 24 bits), and add `Float32` `#guard`s for `toRatParts` / `toRatParts'`.

## Test plan
- [x] `lake build Batteries.Data.Float.Basic BatteriesTest.float`

Made with [Cursor](https://cursor.com)