### PR TITLE
docs: fix missing 'to' in lake update README sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ scope = "leanprover-community"
 rev = "main"
 ```
 
-Additionally, please make sure that you're using the version of Lean that the current version of `batteries` expects. The easiest way to do this is to copy the [`lean-toolchain`](./lean-toolchain) file from this repository to your project. Once you've added the dependency declaration, the command `lake update` checks out the current version of `batteries` and writes it the Lake manifest file. Don't run this command again unless you're prepared to potentially also update your Lean compiler version, as it will retrieve the latest version of dependencies and add them to the manifest.
+Additionally, please make sure that you're using the version of Lean that the current version of `batteries` expects. The easiest way to do this is to copy the [`lean-toolchain`](./lean-toolchain) file from this repository to your project. Once you've added the dependency declaration, the command `lake update` checks out the current version of `batteries` and writes it to the Lake manifest file. Don't run this command again unless you're prepared to potentially also update your Lean compiler version, as it will retrieve the latest version of dependencies and add them to the manifest.
 
 # Build instructions
 


### PR DESCRIPTION
## Summary
- "writes it the Lake manifest" → "writes it to the Lake manifest"

awaiting-review

Made with [Cursor](https://cursor.com)