### PR TITLE
chore: bump toolchain to v4.32.1

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.32.0
+leanprover/lean4:v4.32.1


### PR DESCRIPTION
## Summary

Update the maintenance line to use the Lean `v4.32.1` point-release toolchain.

This provides a Batteries tag whose checked-in toolchain matches Lean `v4.32.1`, before advancing the same maintenance line to `v4.32.2`.

## Validation

- `lake build`
- `lake test`
