### PR TITLE
chore: bump toolchain to v4.32.2

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.32.1
+leanprover/lean4:v4.32.2


### PR DESCRIPTION
## Summary

Update the `v4.32` maintenance line from the Lean `v4.32.1` toolchain to the latest point release, `v4.32.2`.

This enables publishing a Batteries `v4.32.2` tag whose checked-in toolchain matches the corresponding Lean release.

## Validation

- `lake build`
- `lake test`
