### PR TITLE
chore: pin doc-gen4 for v4.32.2

### DIFF
--- a/docs/lakefile.toml
+++ b/docs/lakefile.toml
@@ -6,7 +6,7 @@ buildDir = "."
 [[require]]
 scope = "leanprover"
 name = "doc-gen4"
-rev = "main"
+rev = "v4.32.1"
 
 [[require]]
 name = "batteries"

--- a/docs/lakefile.toml
+++ b/docs/lakefile.toml
@@ -6,7 +6,7 @@ buildDir = "."
 [[require]]
 scope = "leanprover"
 name = "doc-gen4"
-rev = "v4.32.1"
+rev = "v4.32.2"
 
 [[require]]
 name = "batteries"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.32.1
+leanprover/lean4:v4.32.2


### PR DESCRIPTION
## Summary

Pin `doc-gen4` to the matching `v4.32.2` compatibility tag for the Batteries `v4.32` maintenance line.

The release docs workflow currently follows `doc-gen4`'s moving `main`, which now uses Lean APIs unavailable in Lean 4.32.x. This caused both point-release tag workflows to fail before creating their GitHub Releases.

This branch also retains the corrected `v4.32.1` snapshot in its ancestry, pinned to `doc-gen4 v4.32.1`, so both Batteries tags can be republished with matching toolchain and documentation dependencies.

Please merge this PR with a merge commit rather than squash-merging so the corrected `v4.32.1` release commit remains an ancestor of `v4.32.2`.

## Validation

- From the corrected `v4.32.1` commit: `cd docs && lake build --keep-toolchain -q Batteries:docs`
- From this `v4.32.2` branch: `cd docs && lake build --keep-toolchain -q Batteries:docs`
